### PR TITLE
Enhance enDashDateRange to support year ranges and dashStyle option

### DIFF
--- a/src/dashes.ts
+++ b/src/dashes.ts
@@ -66,21 +66,38 @@ export function enDashNumberRange(text: string, options: DashOptions = {}): stri
  * Spacing around the en-dash is controlled by dashStyle:
  * - "american" (default): No spaces (October 2012–December 2014)
  * - "british": Spaced (October 2012 – December 2014)
+ * - "none": Preserve original spacing
  */
 export function enDashDateRange(text: string, options: DashOptions = {}): string {
   const chr = options.separator ?? DEFAULT_SEPARATOR
   const dashStyle = options.dashStyle ?? "american"
-  const spaced = dashStyle === "british"
 
-  return text.replace(
-    new RegExp(
-      `\\b(?<startMonth>${months})(?<startYear>${chr}? \\d{4})?(?<preSep>${chr}?) ?- ?(?<postSep>${chr}?)(?<endMonth>${months})(?<endYear> \\d{4})?\\b`,
-      "g"
-    ),
-    spaced
-      ? `$<startMonth>$<startYear>$<preSep> ${EN_DASH} $<postSep>$<endMonth>$<endYear>`
-      : `$<startMonth>$<startYear>$<preSep>${EN_DASH}$<postSep>$<endMonth>$<endYear>`
+  const startPattern = `(?<startMonth>${months})(?<startYear>${chr}? \\d{4})?(?<preSep>${chr}?)`
+  const endPattern = `(?<postSep>${chr}?)(?<endMonth>${months})(?<endYear> \\d{4})?`
+  const dateRangeRegex = new RegExp(
+    `\\b${startPattern}(?<preSpace> ?)-(?<postSpace> ?)${endPattern}\\b`,
+    "g"
   )
+
+  return text.replace(dateRangeRegex, (...args) => {
+    const groups = args.at(-1) as Record<string, string>
+    const { startMonth, startYear = "", preSep, postSep, endMonth, endYear = "", preSpace, postSpace } = groups
+
+    let pre: string, post: string
+    if (dashStyle === "british") {
+      pre = " "
+      post = " "
+    } else if (dashStyle === "none") {
+      pre = preSpace
+      post = postSpace
+    } else {
+      // american (default)
+      pre = ""
+      post = ""
+    }
+
+    return `${startMonth}${startYear}${preSep}${pre}${EN_DASH}${post}${postSep}${endMonth}${endYear}`
+  })
 }
 
 /**

--- a/src/dashes.ts
+++ b/src/dashes.ts
@@ -62,15 +62,24 @@ export function enDashNumberRange(text: string, options: DashOptions = {}): stri
  * Replaces hyphens with en-dashes in month/date ranges.
  * Supports formats like "January-March", "Jan-Mar", "February-April 2024",
  * and "October 2012 - December 2014".
+ *
+ * Spacing around the en-dash is controlled by dashStyle:
+ * - "american" (default): No spaces (October 2012–December 2014)
+ * - "british": Spaced (October 2012 – December 2014)
  */
 export function enDashDateRange(text: string, options: DashOptions = {}): string {
   const chr = options.separator ?? DEFAULT_SEPARATOR
+  const dashStyle = options.dashStyle ?? "american"
+  const spaced = dashStyle === "british"
+
   return text.replace(
     new RegExp(
-      `\\b(?<startMonth>${months})(?<startYear>${chr}? \\d{4})?(?<preDash>${chr}? ?)-(?<postDash> ?${chr}?)(?<endMonth>${months})(?<endYear> \\d{4})?\\b`,
+      `\\b(?<startMonth>${months})(?<startYear>${chr}? \\d{4})?(?<preSep>${chr}?) ?- ?(?<postSep>${chr}?)(?<endMonth>${months})(?<endYear> \\d{4})?\\b`,
       "g"
     ),
-    `$<startMonth>$<startYear>$<preDash>${EN_DASH}$<postDash>$<endMonth>$<endYear>`
+    spaced
+      ? `$<startMonth>$<startYear>$<preSep> ${EN_DASH} $<postSep>$<endMonth>$<endYear>`
+      : `$<startMonth>$<startYear>$<preSep>${EN_DASH}$<postSep>$<endMonth>$<endYear>`
   )
 }
 

--- a/src/dashes.ts
+++ b/src/dashes.ts
@@ -60,12 +60,17 @@ export function enDashNumberRange(text: string, options: DashOptions = {}): stri
 
 /**
  * Replaces hyphens with en-dashes in month/date ranges.
+ * Supports formats like "January-March", "Jan-Mar", "February-April 2024",
+ * and "October 2012 - December 2014".
  */
 export function enDashDateRange(text: string, options: DashOptions = {}): string {
   const chr = options.separator ?? DEFAULT_SEPARATOR
   return text.replace(
-    new RegExp(`\\b(?<startMonth>${months}${chr}?)-(?<endMonth>${chr}?(?:${months}))\\b`, "g"),
-    `$<startMonth>${EN_DASH}$<endMonth>`
+    new RegExp(
+      `\\b(?<startMonth>${months})(?<startYear>${chr}? \\d{4})?(?<preDash>${chr}? ?)-(?<postDash> ?${chr}?)(?<endMonth>${months})(?<endYear> \\d{4})?\\b`,
+      "g"
+    ),
+    `$<startMonth>$<startYear>$<preDash>${EN_DASH}$<postDash>$<endMonth>$<endYear>`
   )
 }
 

--- a/src/tests/dashes.test.ts
+++ b/src/tests/dashes.test.ts
@@ -157,6 +157,17 @@ describe("enDashDateRange", () => {
     })
   })
 
+  describe("none style (preserve spacing)", () => {
+    it.each([
+      ["January-March", "January–March"],
+      ["January - March", "January – March"],
+      ["October 2012 - December 2014", "October 2012 – December 2014"],
+      ["Oct 2012-Dec 2014", "Oct 2012–Dec 2014"],
+    ])('should convert "%s" to "%s"', (input, expected) => {
+      expect(enDashDateRange(input, { dashStyle: "none" })).toBe(expected)
+    })
+  })
+
   it("should not convert non-month words", () => {
     expect(enDashDateRange("hello-world")).toBe("hello-world")
     expect(enDashDateRange("Mon-Fri")).toBe("Mon-Fri") // Days, not months

--- a/src/tests/dashes.test.ts
+++ b/src/tests/dashes.test.ts
@@ -133,6 +133,12 @@ describe("enDashDateRange", () => {
     ["May-June", "May–June"],
     ["Sep-Nov", "Sep–Nov"],
     ["December-January", "December–January"],
+    ["October 2012 - December 2014", "October 2012 – December 2014"],
+    ["Oct 2012 - Dec 2014", "Oct 2012 – Dec 2014"],
+    ["January 2020 - March 2020", "January 2020 – March 2020"],
+    ["May 2019-June 2020", "May 2019–June 2020"],
+    ["Jan 2000 - Feb", "Jan 2000 – Feb"],
+    ["March - April 2025", "March – April 2025"],
   ])('should convert "%s" to "%s"', (input, expected) => {
     expect(enDashDateRange(input)).toBe(expected)
   })

--- a/src/tests/dashes.test.ts
+++ b/src/tests/dashes.test.ts
@@ -126,21 +126,35 @@ describe("enDashNumberRange", () => {
 })
 
 describe("enDashDateRange", () => {
-  it.each([
-    ["January-March", "January–March"],
-    ["Jan-Mar", "Jan–Mar"],
-    ["February-April 2024", "February–April 2024"],
-    ["May-June", "May–June"],
-    ["Sep-Nov", "Sep–Nov"],
-    ["December-January", "December–January"],
-    ["October 2012 - December 2014", "October 2012 – December 2014"],
-    ["Oct 2012 - Dec 2014", "Oct 2012 – Dec 2014"],
-    ["January 2020 - March 2020", "January 2020 – March 2020"],
-    ["May 2019-June 2020", "May 2019–June 2020"],
-    ["Jan 2000 - Feb", "Jan 2000 – Feb"],
-    ["March - April 2025", "March – April 2025"],
-  ])('should convert "%s" to "%s"', (input, expected) => {
-    expect(enDashDateRange(input)).toBe(expected)
+  describe("american style (default, unspaced)", () => {
+    it.each([
+      ["January-March", "January–March"],
+      ["Jan-Mar", "Jan–Mar"],
+      ["February-April 2024", "February–April 2024"],
+      ["May-June", "May–June"],
+      ["Sep-Nov", "Sep–Nov"],
+      ["December-January", "December–January"],
+      ["October 2012 - December 2014", "October 2012–December 2014"],
+      ["Oct 2012 - Dec 2014", "Oct 2012–Dec 2014"],
+      ["January 2020 - March 2020", "January 2020–March 2020"],
+      ["May 2019-June 2020", "May 2019–June 2020"],
+      ["Jan 2000 - Feb", "Jan 2000–Feb"],
+      ["March - April 2025", "March–April 2025"],
+    ])('should convert "%s" to "%s"', (input, expected) => {
+      expect(enDashDateRange(input)).toBe(expected)
+    })
+  })
+
+  describe("british style (spaced)", () => {
+    it.each([
+      ["January-March", "January – March"],
+      ["Jan-Mar", "Jan – Mar"],
+      ["October 2012 - December 2014", "October 2012 – December 2014"],
+      ["Oct 2012 - Dec 2014", "Oct 2012 – Dec 2014"],
+      ["May 2019-June 2020", "May 2019 – June 2020"],
+    ])('should convert "%s" to "%s"', (input, expected) => {
+      expect(enDashDateRange(input, { dashStyle: "british" })).toBe(expected)
+    })
   })
 
   it("should not convert non-month words", () => {


### PR DESCRIPTION
## Summary
Enhanced the `enDashDateRange` function to support date ranges with years (e.g., "October 2012 - December 2014") and added a `dashStyle` option to control spacing around the en-dash, matching the behavior of other dash functions in the library.

## Key Changes
- **Extended regex pattern** to capture optional years in both start and end dates, supporting formats like "Month Year - Month Year"
- **Added `dashStyle` option** with three modes:
  - `"american"` (default): No spaces around en-dash (e.g., "October 2012–December 2014")
  - `"british"`: Spaces around en-dash (e.g., "October 2012 – December 2014")
  - `"none"`: Preserves original spacing from input
- **Improved documentation** with examples of supported formats and explanation of spacing behavior
- **Expanded test coverage** with 20+ test cases covering:
  - All three `dashStyle` modes
  - Various date range formats (month-only, month-year, mixed)
  - Different spacing patterns in input

## Implementation Details
- Refactored from simple regex replacement to a callback-based approach to handle complex spacing logic
- Captures spacing around the original hyphen to support the `"none"` style
- Maintains backward compatibility—existing code without the `dashStyle` option uses American style by default

https://claude.ai/code/session_018C8m75MxeWPMdmXin8iuFc