### PR TITLE
Fix GitHub Actions workflow condition syntax

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   publish:
-    if: startsWith(github.event.head_commit.message, 'chore: bump version')
+    if: ${{ startsWith(github.event.head_commit.message, 'chore: bump version') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary
Fixed incorrect GitHub Actions workflow condition syntax in the publish workflow by properly wrapping the conditional expression with `${{ }}` delimiters.

## Changes
- Updated the `if` condition in the publish job to use correct GitHub Actions expression syntax
- Changed from `if: startsWith(github.event.head_commit.message, 'chore: bump version')` to `if: ${{ startsWith(github.event.head_commit.message, 'chore: bump version') }}`

## Details
GitHub Actions requires expressions to be wrapped in `${{ }}` delimiters. Without this wrapper, the condition may not be evaluated correctly, potentially causing the publish job to always run or fail to evaluate the commit message properly. This fix ensures the workflow only triggers when a commit message starts with "chore: bump version" as intended.

https://claude.ai/code/session_01Qcz9g2nNyjqDhYbZ9YN5Zt