### PR TITLE
Refactor publish workflow to trigger on version bump completion

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,12 +1,13 @@
 name: Publish to npm
 
 on:
-  push:
-    branches: [main]
+  workflow_run:
+    workflows: ["Auto Version Bump"]
+    types: [completed]
 
 jobs:
   publish:
-    if: "${{ startsWith(github.event.head_commit.message, 'chore: bump version') }}"
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary
Changed the npm publish workflow to be triggered by the completion of the "Auto Version Bump" workflow instead of directly on pushes to main, improving the CI/CD pipeline reliability and decoupling version management from publishing.

## Key Changes
- **Trigger mechanism**: Replaced `push` event on main branch with `workflow_run` event that listens for successful completion of the "Auto Version Bump" workflow
- **Condition logic**: Updated the job condition from checking commit message (`startsWith(github.event.head_commit.message, 'chore: bump version')`) to verifying workflow success (`github.event.workflow_run.conclusion == 'success'`)

## Benefits
- More reliable publishing: Only publishes when version bump workflow completes successfully
- Better separation of concerns: Version bumping and publishing are now explicitly linked through workflow orchestration
- Eliminates race conditions: Ensures version is bumped before publishing occurs
- Cleaner commit message dependency: No longer relies on commit message conventions for triggering publishes

https://claude.ai/code/session_01GSS8akPWjriTk2AwtNC9yi