### PR TITLE
Enable provenance attestation for npm package publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,4 +25,4 @@ jobs:
         run: pnpm build
 
       - name: Publish to npm
-        run: pnpm publish --access public
+        run: pnpm publish --access public --provenance


### PR DESCRIPTION
## Summary
This change enables npm provenance attestation when publishing packages to the npm registry. Provenance attestation provides cryptographic proof of where and how a package was built, enhancing supply chain security.

## Changes
- Added `--provenance` flag to the `pnpm publish` command in the publish workflow

## Details
The `--provenance` flag generates a signed provenance statement that is published alongside the package. This allows consumers to verify that the package was built by the expected CI/CD pipeline and hasn't been tampered with. This is part of npm's supply chain security initiative and aligns with best practices for open source package distribution.

**Note:** This requires npm v9.5.0 or later and Node.js v18.17.0 or later to be available in the CI environment.

https://claude.ai/code/session_01C2P3dGa3XxsuR4s7Q5dNgH