### PR TITLE
Document separation boundaries feature for DOM transformation

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,18 +67,18 @@ As far as I can tell, `punctilio`’s only missing feature is non-English quote 
 
 ## Scalable DOM transformation via separation boundaries
 
-Real-world HTML has text spanning multiple elements. If you transform each element separately, cross-element patterns break—an ellipsis split across `<em>.</em>..` won't be recognized.
+Other typography libraries only transform plain strings. But real HTML has text spanning multiple elements—if you concatenate text from `<em>Wait</em>...`, transform it, then try to split it back, you've lost track of where `</em>` belonged.
 
-`punctilio` solves this with **separation boundaries**: insert a private-use Unicode character (`DEFAULT_SEPARATOR`, U+E000) where elements meet. All transforms treat this character as transparent and preserve it in output.
+`punctilio` solves this with **separation boundaries**, a novel approach: insert `DEFAULT_SEPARATOR` (U+E000) at each element boundary before transforming. Every regex is written to allow this character mid-pattern without breaking matches—`.[SEP]..` still becomes `.[SEP]…`. The separator count is validated to ensure none are lost.
 
 ```typescript
 import { transform, DEFAULT_SEPARATOR } from 'punctilio'
 
 const SEP = DEFAULT_SEPARATOR
-transform(`Hello${SEP}...`)  // → "Hello" + SEP + "…"
+transform(`Wait${SEP}...`)  // → "Wait" + SEP + "…"
 ```
 
-Your DOM code inserts separators, calls `transform()`, then uses separator positions to map the result back to elements. Use the `separator` option if U+E000 conflicts with your content.
+Your DOM walker tracks which text node each segment came from, inserts separators between them, transforms the combined string, then splits on separators to update each node. Use the `separator` option if U+E000 conflicts with your content.
 
 ## Options
 

--- a/README.md
+++ b/README.md
@@ -67,33 +67,18 @@ As far as I can tell, `punctilio`’s only missing feature is non-English quote 
 
 ## Scalable DOM transformation via separation boundaries
 
-Most typography libraries can only transform plain strings. But real-world HTML has text spanning multiple elements:
+Real-world HTML has text spanning multiple elements. If you transform each element separately, cross-element patterns break—an ellipsis split across `<em>.</em>..` won't be recognized.
 
-```html
-<p><em>Hello</em>, world...</p>
-```
-
-If you extract just the text (`Hello, world...`) and transform it, you lose element boundaries. If you transform each element separately (`Hello` and `, world...`), cross-element patterns break.
-
-`punctilio` solves this with **separation boundaries**: a private-use Unicode character (U+E000) that marks where elements meet. All regex patterns treat this character as transparent—it can appear anywhere without breaking matches, and it's always preserved in output.
+`punctilio` solves this with **separation boundaries**: insert a private-use Unicode character (`DEFAULT_SEPARATOR`, U+E000) where elements meet. All transforms treat this character as transparent and preserve it in output.
 
 ```typescript
 import { transform, DEFAULT_SEPARATOR } from 'punctilio'
 
-// Your DOM walker inserts separators at element boundaries
-const text = `"Hello${DEFAULT_SEPARATOR}, world..."`
-const result = transform(text)
-// → "Hello\uE000, world…"  (separator preserved between curly quotes)
+const SEP = DEFAULT_SEPARATOR
+transform(`Hello${SEP}...`)  // → "Hello" + SEP + "…"
 ```
 
-The workflow:
-1. Walk your DOM tree, concatenating text with `DEFAULT_SEPARATOR` at element boundaries
-2. Call `transform()` on the combined string
-3. Split on separators to reconstruct elements with transformed text
-
-This lets `punctilio` handle patterns that span elements—like quotes wrapping styled text, or ellipses split across nodes—while your code maintains full control over DOM structure.
-
-A custom separator can be specified via the `separator` option if U+E000 conflicts with your content.
+Your DOM code inserts separators, calls `transform()`, then uses separator positions to map the result back to elements. Use the `separator` option if U+E000 conflicts with your content.
 
 ## Options
 

--- a/README.md
+++ b/README.md
@@ -62,20 +62,21 @@ By running [`benchmark.mjs`](./benchmark.mjs), I basically graded all libraries 
 
 As far as I can tell, `punctilio`’s only missing feature is non-English quote support. I don’t have a personal reason to use non-English localization, but feel free to make a pull request!
 
-## Scalable DOM transformation via separation boundaries
+## Works with HTML DOMs via separation boundaries
 
-Other typography libraries either transform plain strings or operate on AST nodes individually (`retext-smartypants` [can't map changes back to HTML](https://github.com/rehypejs/rehype-retext)). But real HTML has text spanning multiple elements—if you concatenate text from `<em>Wait</em>...`, transform it, then try to split it back, you've lost track of where `</em>` belonged.
+Other typography libraries either transform plain strings or operate on AST nodes individually (`retext-smartypants` [can't map changes back to HTML](https://github.com/rehypejs/rehype-retext)). But real HTML has text spanning multiple elements—if you concatenate text from `<em>Wait</em>...`, transform it, then try to split it back, you've lost track of where `</em>` belonged. 
 
 `punctilio` introduces _separation boundaries_. First, insert a “separator” character (default: `U+E000`) at each element boundary before transforming (like at the start and end of an `<em>`). Every regex allows this character mid-pattern without breaking matches. For example, `.[SEP]..` still becomes `…[SEP]`. `punctilio` validates the output by ensuring the separator count remains the same. 
 
 ```typescript
 import { transform, DEFAULT_SEPARATOR } from 'punctilio'
 
-const SEP = DEFAULT_SEPARATOR
-transform(`Wait${SEP}...`)  // → "Wait" + SEP + "…"
+transform(`"Wait${DEFAULT_SEPARATOR}"`)
+// → `“Wait”${DEFAULT_SEPARATOR}`
+// The separator doesn't block the information that this should be an end-quote!
 ```
 
-Your DOM walker tracks which text node each segment came from, inserts separators between them, transforms the combined string, then splits on separators to update each node. Use the `separator` option if `U+E000` conflicts with your content.
+Your DOM walker tracks which text node each segment came from, inserts separators between them, transforms the combined string, then splits on separators to update each node. Use the `separator` option if `U+E000` conflicts with your content. For an example of how to integrate this functionality, see [my website’s code](https://github.com/alexander-turner/TurnTrout.com/blob/main/quartz/plugins/transformers/formatting_improvement_html.ts). 
 
 ## Options
 

--- a/README.md
+++ b/README.md
@@ -13,9 +13,6 @@ transform('"It\'s a beautiful thing, the destruction of words..." -- 1984')
 [![Lint](https://github.com/alexander-turner/punctilio/actions/workflows/lint.yml/badge.svg)](https://github.com/alexander-turner/punctilio/actions/workflows/lint.yml)
 [![Coverage](https://img.shields.io/badge/coverage-100%25-brightgreen)](https://github.com/alexander-turner/punctilio)
  
-
-## Install
-
 ```bash
 npm install punctilio
 ```
@@ -69,7 +66,7 @@ As far as I can tell, `punctilio`’s only missing feature is non-English quote 
 
 Other typography libraries either transform plain strings or operate on AST nodes individually (`retext-smartypants` [can't map changes back to HTML](https://github.com/rehypejs/rehype-retext)). But real HTML has text spanning multiple elements—if you concatenate text from `<em>Wait</em>...`, transform it, then try to split it back, you've lost track of where `</em>` belonged.
 
-`punctilio` solves this with **separation boundaries**, a novel approach: insert `DEFAULT_SEPARATOR` (U+E000) at each element boundary before transforming. Every regex is written to allow this character mid-pattern without breaking matches—`.[SEP]..` still becomes `.[SEP]…`. The separator count is validated to ensure none are lost.
+`punctilio` introduces _separation boundaries_. First, insert a “separator” character (default: `U+E000`) at each element boundary before transforming (like at the start and end of an `<em>`). Every regex allows this character mid-pattern without breaking matches. For example, `.[SEP]..` still becomes `…[SEP]`. `punctilio` validates the output by ensuring the separator count remains the same. 
 
 ```typescript
 import { transform, DEFAULT_SEPARATOR } from 'punctilio'
@@ -78,7 +75,7 @@ const SEP = DEFAULT_SEPARATOR
 transform(`Wait${SEP}...`)  // → "Wait" + SEP + "…"
 ```
 
-Your DOM walker tracks which text node each segment came from, inserts separators between them, transforms the combined string, then splits on separators to update each node. Use the `separator` option if U+E000 conflicts with your content.
+Your DOM walker tracks which text node each segment came from, inserts separators between them, transforms the combined string, then splits on separators to update each node. Use the `separator` option if `U+E000` conflicts with your content.
 
 ## Options
 

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ As far as I can tell, `punctilio`’s only missing feature is non-English quote 
 
 ## Scalable DOM transformation via separation boundaries
 
-Other typography libraries only transform plain strings. But real HTML has text spanning multiple elements—if you concatenate text from `<em>Wait</em>...`, transform it, then try to split it back, you've lost track of where `</em>` belonged.
+Other typography libraries either transform plain strings or operate on AST nodes individually (`retext-smartypants` [can't map changes back to HTML](https://github.com/rehypejs/rehype-retext)). But real HTML has text spanning multiple elements—if you concatenate text from `<em>Wait</em>...`, transform it, then try to split it back, you've lost track of where `</em>` belonged.
 
 `punctilio` solves this with **separation boundaries**, a novel approach: insert `DEFAULT_SEPARATOR` (U+E000) at each element boundary before transforming. Every regex is written to allow this character mid-pattern without breaking matches—`.[SEP]..` still becomes `.[SEP]…`. The separator count is validated to ensure none are lost.
 

--- a/README.md
+++ b/README.md
@@ -65,9 +65,39 @@ By running [`benchmark.mjs`](./benchmark.mjs), I basically graded all libraries 
 
 As far as I can tell, `punctilio`’s only missing feature is non-English quote support. I don’t have a personal reason to use non-English localization, but feel free to make a pull request!
 
+## Scalable DOM transformation via separation boundaries
+
+Most typography libraries can only transform plain strings. But real-world HTML has text spanning multiple elements:
+
+```html
+<p><em>Hello</em>, world...</p>
+```
+
+If you extract just the text (`Hello, world...`) and transform it, you lose element boundaries. If you transform each element separately (`Hello` and `, world...`), cross-element patterns break.
+
+`punctilio` solves this with **separation boundaries**: a private-use Unicode character (U+E000) that marks where elements meet. All regex patterns treat this character as transparent—it can appear anywhere without breaking matches, and it's always preserved in output.
+
+```typescript
+import { transform, DEFAULT_SEPARATOR } from 'punctilio'
+
+// Your DOM walker inserts separators at element boundaries
+const text = `"Hello${DEFAULT_SEPARATOR}, world..."`
+const result = transform(text)
+// → "Hello\uE000, world…"  (separator preserved between curly quotes)
+```
+
+The workflow:
+1. Walk your DOM tree, concatenating text with `DEFAULT_SEPARATOR` at element boundaries
+2. Call `transform()` on the combined string
+3. Split on separators to reconstruct elements with transformed text
+
+This lets `punctilio` handle patterns that span elements—like quotes wrapping styled text, or ellipses split across nodes—while your code maintains full control over DOM structure.
+
+A custom separator can be specified via the `separator` option if U+E000 conflicts with your content.
+
 ## Options
 
-`punctilio` doesn’t enable all transformations by default. Fractions and degrees tend to match too aggressively (perfectly applying the degree transformation requires semantic meaning). Superscript letters and punctuation ligatures have spotty font support—this README’s font doesn’t even support the example superscript! Furthermore, `ligatures = true` can change the meaning of text by collapsing question and exclamation marks.
+`punctilio` doesn't enable all transformations by default. Fractions and degrees tend to match too aggressively (perfectly applying the degree transformation requires semantic meaning). Superscript letters and punctuation ligatures have spotty font support—this README’s font doesn’t even support the example superscript! Furthermore, `ligatures = true` can change the meaning of text by collapsing question and exclamation marks.
 
 ```typescript
 transform(text, {

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Your DOM walker tracks which text node each segment came from, inserts separator
 
 ## Options
 
-`punctilio` doesn't enable all transformations by default. Fractions and degrees tend to match too aggressively (perfectly applying the degree transformation requires semantic meaning). Superscript letters and punctuation ligatures have spotty font support—this README’s font doesn’t even support the example superscript! Furthermore, `ligatures = true` can change the meaning of text by collapsing question and exclamation marks.
+`punctilio` doesn’t enable all transformations by default. Fractions and degrees tend to match too aggressively (perfectly applying the degree transformation requires semantic meaning). Superscript letters and punctuation ligatures have spotty font support—this README’s font doesn’t even support the example superscript! Furthermore, `ligatures = true` can change the meaning of text by collapsing question and exclamation marks.
 
 ```typescript
 transform(text, {


### PR DESCRIPTION
## Summary
This PR adds comprehensive documentation for `punctilio`'s separation boundaries feature, which enables scalable DOM transformation by handling text that spans multiple HTML elements.

## Changes
- Added new "Scalable DOM transformation via separation boundaries" section to README.md
- Explained the problem: standard typography libraries can't handle patterns that cross element boundaries
- Documented the solution: using private-use Unicode character (U+E000) as transparent separation markers
- Provided practical example showing the workflow: insert separators → transform → split results
- Clarified that custom separators can be specified via the `separator` option if needed
- Minor formatting adjustment to the Options section

## Key Details
The documentation explains how `punctilio` solves a real-world problem where:
- Extracting text loses element boundaries
- Transforming elements separately breaks cross-element patterns
- Separation boundaries allow regex patterns to work transparently across element boundaries while preserving DOM structure

This feature enables handling complex cases like quotes wrapping styled text or ellipses split across nodes.

https://claude.ai/code/session_01Mma14hWgZsFhq8ASoVjbdH