### PR TITLE
fix: use npm publish for OIDC support, add lint/test deps

### DIFF
--- a/.github/workflows/auto-version.yml
+++ b/.github/workflows/auto-version.yml
@@ -5,7 +5,22 @@ on:
     branches: [main]
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup
+      - run: pnpm lint
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup
+      - run: pnpm test
+
   version-and-publish:
+    needs: [lint, test]
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -28,6 +43,6 @@ jobs:
         run: |
           git pull origin main
           npm install -g npm@latest
-          pnpm publish --access public --provenance
+          npm publish --access public
         env:
           NODE_AUTH_TOKEN: ""


### PR DESCRIPTION
- pnpm doesn't support OIDC trusted publishing (pnpm/pnpm#9812)
- Add lint/test jobs that version-and-publish depends on

https://claude.ai/code/session_01WHVhPbXznbzmR2Bx9pHUpb