### PR TITLE
Fix fraction regex to avoid matching fractions in paths and decimals

### DIFF
--- a/src/symbols.ts
+++ b/src/symbols.ts
@@ -285,11 +285,13 @@ export function fractions(text: string, options: SymbolOptions = {}): string {
     : ESCAPED_DEFAULT_SEPARATOR
 
   for (const [ascii, unicode] of Object.entries(FRACTION_MAP)) {
-    // Negative lookbehind/lookahead: ensures fraction is not part of a larger number
+    // Negative lookbehind/lookahead: ensures fraction is not part of a larger number or path
+    // - (?<![/.\d]) prevents matching after slashes, dots, or digits
+    // - (?![/\d]|\.\d) prevents matching before slashes, digits, or decimal points
     // Named captures preserve separators before and after the slash
     const [numerator, denominator] = ascii.split("/")
     const pattern = new RegExp(
-      `(?<!\\d)${numerator}(?<sepBefore>${chr}?)/(?<sepAfter>${chr}?)${denominator}(?!\\d)`,
+      `(?<![/\\.\\d])${numerator}(?<sepBefore>${chr}?)/(?<sepAfter>${chr}?)${denominator}(?![/\\d]|\\.\\d)`,
       "g"
     )
     // Preserve separators around the fraction Unicode character

--- a/src/tests/symbols.test.ts
+++ b/src/tests/symbols.test.ts
@@ -201,6 +201,13 @@ describe("fractions", () => {
     ["page 1/25", "page 1/25"],
     ["1/7", "1/7"],
     ["5/9", "5/9"],
+    // Edge cases: fractions in paths/URLs should not match
+    ["a/1/4", "a/1/4"],
+    ["1/4/b", "1/4/b"],
+    ["x/1/2", "x/1/2"],
+    // Edge cases: fractions adjacent to decimals
+    ["3.1/4", "3.1/4"],
+    ["1/4.5", "1/4.5"],
   ])('converts "%s" to "%s"', (input, expected) => {
     expect(fractions(input)).toBe(expected)
   })


### PR DESCRIPTION
## Summary
Updated the fraction conversion regex pattern to prevent false matches when fractions appear in file paths, URLs, or adjacent to decimal numbers.

## Changes
- **Updated negative lookbehind pattern** from `(?<!\d)` to `(?<![/\.\d])` to prevent matching fractions that follow slashes, dots, or digits
- **Updated negative lookahead pattern** from `(?!\d)` to `(?![/\d]|\.\d)` to prevent matching fractions that precede slashes, digits, or decimal points
- **Enhanced documentation** with inline comments explaining the purpose of each lookahead/lookbehind assertion
- **Added test cases** covering edge cases:
  - Fractions within paths (e.g., `a/1/4`, `1/4/b`, `x/1/2`)
  - Fractions adjacent to decimals (e.g., `3.1/4`, `1/4.5`)

## Implementation Details
The regex now correctly distinguishes between:
- Valid fractions to convert (e.g., `1/4` in "I ate 1/4 of the pie")
- Invalid matches to skip (e.g., `1/4` in file paths like `src/1/4` or URLs)
- Fractions adjacent to decimal notation (e.g., `3.1/4` should not convert the `1/4` part)

This prevents unintended conversions in technical contexts while maintaining the intended fraction-to-Unicode conversion for natural language text.

https://claude.ai/code/session_01QmBmYka1EvBLmXu7fmmMBG