### PR TITLE
Add security hardening and enforce pnpm as package manager

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -12,8 +12,6 @@ runs:
   steps:
     - name: Setup pnpm
       uses: pnpm/action-setup@v4
-      with:
-        version: latest
 
     - name: Setup Node.js
       uses: actions/setup-node@v4

--- a/.npmrc
+++ b/.npmrc
@@ -1,10 +1,6 @@
 # Security hardening for pnpm/npm
 # See: https://pnpm.io/npmrc
 
-# Disable automatic script execution to prevent supply chain attacks
-# Run `pnpm install --ignore-scripts=false` when you trust a package's scripts
-ignore-scripts=true
-
 # Enable automatic security auditing during install
 audit=true
 
@@ -13,10 +9,6 @@ audit-level=high
 
 # Enforce strict peer dependencies resolution
 strict-peer-dependencies=true
-
-# Prevent untrusted packages from running arbitrary code
-# Only allow trusted packages to run lifecycle scripts
-enable-pre-post-scripts=false
 
 # Use exact versions for reproducible builds
 save-exact=true
@@ -29,6 +21,3 @@ use-lockfile-v6=true
 
 # Disable package modifications in node_modules
 shamefully-hoist=false
-
-# Disable shell execution during resolution
-shell-emulator=false

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,34 @@
+# Security hardening for pnpm/npm
+# See: https://pnpm.io/npmrc
+
+# Disable automatic script execution to prevent supply chain attacks
+# Run `pnpm install --ignore-scripts=false` when you trust a package's scripts
+ignore-scripts=true
+
+# Enable automatic security auditing during install
+audit=true
+
+# Fail on high severity vulnerabilities during audit
+audit-level=high
+
+# Enforce strict peer dependencies resolution
+strict-peer-dependencies=true
+
+# Prevent untrusted packages from running arbitrary code
+# Only allow trusted packages to run lifecycle scripts
+enable-pre-post-scripts=false
+
+# Use exact versions for reproducible builds
+save-exact=true
+
+# Prefer offline packages to reduce exposure to registry attacks
+prefer-offline=true
+
+# Verify package integrity using lockfile checksums
+use-lockfile-v6=true
+
+# Disable package modifications in node_modules
+shamefully-hoist=false
+
+# Disable shell execution during resolution
+shell-emulator=false

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "build": "tsc",
     "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js",
     "lint": "eslint src",
-    "prepublishOnly": "npm run build && npm run test",
+    "prepublishOnly": "pnpm run build && pnpm run test",
     "postinstall": "bash scripts/install-hooks.sh || true",
     "install-hooks": "bash scripts/install-hooks.sh"
   },
@@ -45,6 +45,7 @@
   "engines": {
     "node": ">=18.0.0"
   },
+  "packageManager": "pnpm@10.28.1",
   "devDependencies": {
     "@eslint/js": "^9.39.2",
     "@types/jest": "^29.5.12",


### PR DESCRIPTION
## Summary
This PR enhances the project's security posture and standardizes the package manager by introducing a comprehensive `.npmrc` configuration file and updating package.json to enforce pnpm usage.

## Key Changes
- **Added `.npmrc` configuration** with security-focused settings:
  - Enable automatic security auditing during install with high severity threshold
  - Enforce strict peer dependency resolution to catch compatibility issues early
  - Use exact versions for reproducible builds
  - Prefer offline packages to reduce exposure to registry attacks
  - Verify package integrity using lockfile checksums (v6)
  - Disable shameful hoisting to maintain proper module isolation

- **Updated `package.json`**:
  - Changed `prepublishOnly` script to use `pnpm` instead of `npm` for consistency
  - Added `packageManager` field specifying `pnpm@10.28.1` to enforce the package manager version across all environments

## Implementation Details
These changes ensure that:
1. All developers and CI/CD pipelines use the same package manager version
2. Security vulnerabilities are caught early in the development workflow
3. Dependencies are resolved consistently and reproducibly
4. The project follows npm/pnpm best practices for security and reliability

https://claude.ai/code/session_01Deekr2PAWLo96FFcr8iJsE