### PR TITLE
Prevent duplicate version bumps in version-bump script

### DIFF
--- a/scripts/version-bump.sh
+++ b/scripts/version-bump.sh
@@ -15,6 +15,13 @@ fi
 CURRENT_VERSION=$(node -p "require('./package.json').version")
 echo "Current version: $CURRENT_VERSION"
 
+# Check if package.json version was already changed in this commit
+PREV_VERSION=$(git show HEAD~1:package.json 2>/dev/null | node -p "JSON.parse(require('fs').readFileSync(0, 'utf8')).version" 2>/dev/null || echo "")
+if [ -n "$PREV_VERSION" ] && [ "$PREV_VERSION" != "$CURRENT_VERSION" ]; then
+  echo "package.json version already changed in this commit ($PREV_VERSION -> $CURRENT_VERSION). Skipping."
+  exit 0
+fi
+
 # Get commits since last version bump
 LAST_BUMP_COMMIT=$(git log --oneline --grep="^chore: bump version" -1 --format="%H" 2>/dev/null || echo "")
 


### PR DESCRIPTION
## Summary
Added a check to the version-bump script to detect and skip version bumping if the package.json version has already been modified in the current commit. This prevents duplicate version increments and ensures idempotent behavior.

## Key Changes
- Added logic to retrieve the previous commit's package.json version using `git show HEAD~1:package.json`
- Compare the previous version with the current version to detect if a change has already occurred
- Exit early with status 0 if a version change is detected, allowing the script to be safely re-run without side effects
- Gracefully handles cases where the previous commit doesn't exist or package.json wasn't present

## Implementation Details
- Uses `git show` to access the previous commit's file content without checking it out
- Leverages Node.js to parse JSON inline for consistency with existing version retrieval logic
- Suppresses errors with `2>/dev/null` to handle edge cases (new repository, missing file, etc.)
- Returns exit code 0 on early exit to indicate successful completion rather than failure

https://claude.ai/code/session_01Kjgzx7ZijGk3t9AtByR2uw