### PR TITLE
Add rehype plugin for HTML typography transformations

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,31 @@ transform(`"Wait${DEFAULT_SEPARATOR}"`)
 // The separator doesn’t block the information that this should be an end-quote!
 ```
 
-Use via a DOM walker tracks which text node each segment came from, inserts separators between them, transforms the combined string, then splits on separators to update each node. Use the `separator` option if `U+E000` conflicts with your content. For an example of how to integrate this functionality, see [my website’s code](https://github.com/alexander-turner/TurnTrout.com/blob/main/quartz/plugins/transformers/formatting_improvement_html.ts). 
+Use via a DOM walker tracks which text node each segment came from, inserts separators between them, transforms the combined string, then splits on separators to update each node. Use the `separator` option if `U+E000` conflicts with your content. For an example of how to integrate this functionality, see [my website's code](https://github.com/alexander-turner/TurnTrout.com/blob/main/quartz/plugins/transformers/formatting_improvement_html.ts).
+
+### Rehype plugin
+
+For unified/rehype pipelines, use the built-in plugin:
+
+```typescript
+import rehypePunctilio from 'punctilio/rehype'
+
+const file = await unified()
+  .use(rehypeParse)
+  .use(rehypePunctilio, { fractions: true })
+  .use(rehypeStringify)
+  .process('<p>"Hello..." -- world</p>')
+
+// → <p>"Hello…"—world</p>
+```
+
+The plugin handles the DOM walking and separator logic automatically. For custom transforms, import the utilities directly:
+
+```typescript
+import { transformElement, DEFAULT_SEPARATOR } from 'punctilio/rehype'
+
+transformElement(element, myTransform, shouldSkip, DEFAULT_SEPARATOR)
+```
 
 ### Not for raw Markdown
 

--- a/README.md
+++ b/README.md
@@ -64,8 +64,6 @@ My [`benchmark.mjs`](https://github.com/alexander-turner/punctilio/blob/main/ben
 | Non-English quotes | „Hallo” (German) | ✗ | ✗ | ✓ | ✗ | ~ |
 | Non-breaking spaces | Chapter 1 | ✗ | ✗ | ✗ | ✗ | ✓ |
 
-_~ = partial success (handles main example but misses edge cases)_
-
 `typograf` uniquely inserts non-breaking spaces to prevent bad line breaks (e.g. before numbers, after colons). I might add this to `punctilio` in the future. `punctilio`’s other missing feature is non-English quote support—feel free to make a pull request!
 
 ### Known limitations of `punctilio`

--- a/README.md
+++ b/README.md
@@ -100,35 +100,20 @@ transform(`"Wait${DEFAULT_SEPARATOR}"`)
 // The separator doesn’t block the information that this should be an end-quote!
 ```
 
-Use via a DOM walker tracks which text node each segment came from, inserts separators between them, transforms the combined string, then splits on separators to update each node. Use the `separator` option if `U+E000` conflicts with your content. For an example of how to integrate this functionality, see [my website's code](https://github.com/alexander-turner/TurnTrout.com/blob/main/quartz/plugins/transformers/formatting_improvement_html.ts).
-
-### Rehype plugin
-
-For unified/rehype pipelines, use the built-in plugin:
+For rehype/unified pipelines, use the built-in plugin (handles the separator logic automatically):
 
 ```typescript
 import rehypePunctilio from 'punctilio/rehype'
 
-const file = await unified()
+unified()
   .use(rehypeParse)
   .use(rehypePunctilio, { fractions: true })
   .use(rehypeStringify)
   .process('<p>"Hello..." -- world</p>')
-
 // → <p>"Hello…"—world</p>
 ```
 
-The plugin handles the DOM walking and separator logic automatically. For custom transforms, import the utilities directly:
-
-```typescript
-import { transformElement, DEFAULT_SEPARATOR } from 'punctilio/rehype'
-
-transformElement(element, myTransform, shouldSkip, DEFAULT_SEPARATOR)
-```
-
-### Not for raw Markdown
-
-`punctilio` transforms plain text or separator-flattened HTML—not raw Markdown. 
+For manual DOM walking or custom transforms, use `transformElement` from `punctilio/rehype`. Note: `punctilio` transforms plain text or HTML—not raw Markdown. 
 
 ## Options
 

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ import rehypePunctilio from 'punctilio/rehype'
 
 unified()
   .use(rehypeParse)
-  .use(rehypePunctilio, { fractions: true })
+  .use(rehypePunctilio, { dashStyle: 'american' })
   .use(rehypeStringify)
   .process('<p>"Hello..." -- world</p>')
 // → <p>"Hello…"—world</p>

--- a/package.json
+++ b/package.json
@@ -9,6 +9,10 @@
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
+    },
+    "./rehype": {
+      "types": "./dist/rehype.d.ts",
+      "import": "./dist/rehype.js"
     }
   },
   "files": [
@@ -30,7 +34,12 @@
     "en-dash",
     "typesetting",
     "punctuation",
-    "text-formatting"
+    "text-formatting",
+    "rehype",
+    "rehype-plugin",
+    "unified",
+    "markdown",
+    "html"
   ],
   "author": "Alexander Turner",
   "license": "MIT",
@@ -53,6 +62,8 @@
     "eslint": "^9.39.2",
     "eslint-plugin-regexp": "^3.0.0",
     "jest": "^29.7.0",
+    "rehype-parse": "9.0.1",
+    "rehype-stringify": "10.0.1",
     "retext": "9.0.0",
     "retext-smartypants": "6.2.0",
     "smartquotes": "2.3.2",
@@ -65,6 +76,9 @@
     "unified": "11.0.5"
   },
   "dependencies": {
-    "escape-string-regexp": "5.0.0"
+    "@types/hast": "^3.0.4",
+    "escape-string-regexp": "5.0.0",
+    "unified": "^11.0.5",
+    "unist-util-visit-parents": "^6.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "@types/node": "^20.11.0",
     "eslint": "^9.39.2",
     "eslint-plugin-regexp": "^3.0.0",
+    "hastscript": "9.0.1",
     "jest": "^29.7.0",
     "rehype-parse": "9.0.1",
     "rehype-stringify": "10.0.1",

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
   "packageManager": "pnpm@10.28.1",
   "devDependencies": {
     "@eslint/js": "^9.39.2",
+    "@types/hast": "^3.0.4",
     "@types/jest": "^29.5.12",
     "@types/node": "^20.11.0",
     "eslint": "^9.39.2",
@@ -75,10 +76,16 @@
     "typograf": "7.6.0",
     "unified": "11.0.5"
   },
+  "peerDependencies": {
+    "unified": "^11.0.0"
+  },
+  "peerDependenciesMeta": {
+    "unified": {
+      "optional": true
+    }
+  },
   "dependencies": {
-    "@types/hast": "^3.0.4",
     "escape-string-regexp": "5.0.0",
-    "unified": "^11.0.5",
     "unist-util-visit-parents": "^6.0.1"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,6 +33,9 @@ importers:
       eslint-plugin-regexp:
         specifier: ^3.0.0
         version: 3.0.0(eslint@9.39.2)
+      hastscript:
+        specifier: 9.0.1
+        version: 9.0.1
       jest:
         specifier: ^29.7.0
         version: 29.7.0(@types/node@20.19.30)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,18 @@ importers:
 
   .:
     dependencies:
+      '@types/hast':
+        specifier: ^3.0.4
+        version: 3.0.4
       escape-string-regexp:
         specifier: 5.0.0
         version: 5.0.0
+      unified:
+        specifier: ^11.0.5
+        version: 11.0.5
+      unist-util-visit-parents:
+        specifier: ^6.0.1
+        version: 6.0.2
     devDependencies:
       '@eslint/js':
         specifier: ^9.39.2
@@ -30,6 +39,12 @@ importers:
       jest:
         specifier: ^29.7.0
         version: 29.7.0(@types/node@20.19.30)
+      rehype-parse:
+        specifier: 9.0.1
+        version: 9.0.1
+      rehype-stringify:
+        specifier: 10.0.1
+        version: 10.0.1
       retext:
         specifier: 9.0.0
         version: 9.0.0
@@ -57,9 +72,6 @@ importers:
       typograf:
         specifier: 7.6.0
         version: 7.6.0
-      unified:
-        specifier: 11.0.5
-        version: 11.0.5
 
 packages:
 
@@ -399,6 +411,9 @@ packages:
   '@types/graceful-fs@4.1.9':
     resolution: {integrity: sha512-olP3sd1qOEe5dXTSaFvQG+02VdRXcdytWLAZsAq1PecU8uqQAhkrnbli7DagjtXKW/Bl7YJbUsa8MPcuc8LHEQ==}
 
+  '@types/hast@3.0.4':
+    resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
+
   '@types/istanbul-lib-coverage@2.0.6':
     resolution: {integrity: sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==}
 
@@ -413,6 +428,9 @@ packages:
 
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
+
+  '@types/mdast@4.0.4':
+    resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
 
   '@types/nlcst@2.0.3':
     resolution: {integrity: sha512-vSYNSDe6Ix3q+6Z7ri9lyWqgGhJTmzRjZRqyq15N0Z/1/UnVsno9G/N40NBijoYx2seFDIl0+B2mgAb9mezUCA==}
@@ -490,6 +508,9 @@ packages:
   '@typescript-eslint/visitor-keys@8.54.0':
     resolution: {integrity: sha512-VFlhGSl4opC0bprJiItPQ1RfUhGDIBokcPwaFH4yiBCaNPeld/9VeXbiPO1cLyorQi1G1vL+ecBk1x8o1axORA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@ungap/structured-clone@1.3.0':
+    resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
 
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
@@ -608,6 +629,9 @@ packages:
   caniuse-lite@1.0.30001766:
     resolution: {integrity: sha512-4C0lfJ0/YPjJQHagaE9x2Elb69CIqEPZeG0anQt9SIvIoOH4a4uaRl73IavyO+0qZh6MDLH//DrXThEYKHkmYA==}
 
+  ccount@2.0.1:
+    resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
+
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
@@ -615,6 +639,12 @@ packages:
   char-regex@1.0.2:
     resolution: {integrity: sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==}
     engines: {node: '>=10'}
+
+  character-entities-html4@2.1.0:
+    resolution: {integrity: sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==}
+
+  character-entities-legacy@3.0.0:
+    resolution: {integrity: sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==}
 
   ci-info@3.9.0:
     resolution: {integrity: sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==}
@@ -643,6 +673,9 @@ packages:
 
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
+  comma-separated-tokens@2.0.3:
+    resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
 
   comment-parser@1.4.5:
     resolution: {integrity: sha512-aRDkn3uyIlCFfk5NUA+VdwMmMsh8JGhc4hapfV4yxymHGQ3BVskMQfoXGpCo5IoBuQ9tS5iiVKhCpTcB4pW4qw==}
@@ -715,6 +748,10 @@ packages:
 
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+
+  entities@6.0.1:
+    resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
+    engines: {node: '>=0.12'}
 
   error-ex@1.3.4:
     resolution: {integrity: sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==}
@@ -902,8 +939,29 @@ packages:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
 
+  hast-util-from-html@2.0.3:
+    resolution: {integrity: sha512-CUSRHXyKjzHov8yKsQjGOElXy/3EKpyX56ELnkHH34vDVw1N1XSQ1ZcAvTyAPtGqLTuKP/uxM+aLkSPqF/EtMw==}
+
+  hast-util-from-parse5@8.0.3:
+    resolution: {integrity: sha512-3kxEVkEKt0zvcZ3hCRYI8rqrgwtlIOFMWkbclACvjlDw8Li9S2hk/d51OI0nr/gIpdMHNepwgOKqZ/sy0Clpyg==}
+
+  hast-util-parse-selector@4.0.0:
+    resolution: {integrity: sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==}
+
+  hast-util-to-html@9.0.5:
+    resolution: {integrity: sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==}
+
+  hast-util-whitespace@3.0.0:
+    resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
+
+  hastscript@9.0.1:
+    resolution: {integrity: sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==}
+
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
+
+  html-void-elements@3.0.0:
+    resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
 
   human-signals@2.1.0:
     resolution: {integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==}
@@ -1210,8 +1268,26 @@ packages:
   makeerror@1.0.12:
     resolution: {integrity: sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==}
 
+  mdast-util-to-hast@13.2.1:
+    resolution: {integrity: sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==}
+
   merge-stream@2.0.0:
     resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
+
+  micromark-util-character@2.1.1:
+    resolution: {integrity: sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==}
+
+  micromark-util-encode@2.0.1:
+    resolution: {integrity: sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==}
+
+  micromark-util-sanitize-uri@2.0.1:
+    resolution: {integrity: sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==}
+
+  micromark-util-symbol@2.0.1:
+    resolution: {integrity: sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==}
+
+  micromark-util-types@2.0.2:
+    resolution: {integrity: sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==}
 
   micromatch@4.0.8:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
@@ -1299,6 +1375,9 @@ packages:
   parse-latin@7.0.0:
     resolution: {integrity: sha512-mhHgobPPua5kZ98EF4HWiH167JWBfl4pvAIXXdbaVohtK7a6YBOy56kvhCqduqyo/f3yrHFWmqmiMg/BkBkYYQ==}
 
+  parse5@7.3.0:
+    resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
+
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
@@ -1345,6 +1424,9 @@ packages:
     resolution: {integrity: sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==}
     engines: {node: '>= 6'}
 
+  property-information@7.1.0:
+    resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
+
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
@@ -1362,6 +1444,12 @@ packages:
   regexp-ast-analysis@0.7.1:
     resolution: {integrity: sha512-sZuz1dYW/ZsfG17WSAG7eS85r5a0dDsvg+7BiiYR5o6lKCAtUrEwdmRmaGF6rwVj3LcmAeYkOWKEPlbPzN3Y3A==}
     engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
+
+  rehype-parse@9.0.1:
+    resolution: {integrity: sha512-ksCzCD0Fgfh7trPDxr2rSylbwq9iYDkSn8TCDmEJ49ljEUBxDVCzCHv7QNzZOfODanX4+bWQ4WZqLCRWYLfhag==}
+
+  rehype-stringify@10.0.1:
+    resolution: {integrity: sha512-k9ecfXHmIPuFVI61B9DeLPN0qFHfawM6RsuX48hoqlaKSF61RskNjSm1lI8PhBEM0MRdLxVVm4WmTqJQccH9mA==}
 
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
@@ -1452,6 +1540,9 @@ packages:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
 
+  space-separated-tokens@2.0.2:
+    resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
+
   sprintf-js@1.0.3:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
 
@@ -1466,6 +1557,9 @@ packages:
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
     engines: {node: '>=8'}
+
+  stringify-entities@4.0.4:
+    resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
 
   strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
@@ -1513,6 +1607,9 @@ packages:
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
+
+  trim-lines@3.0.1:
+    resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
 
   trough@2.2.0:
     resolution: {integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==}
@@ -1599,6 +1696,9 @@ packages:
   unist-util-modify-children@4.0.0:
     resolution: {integrity: sha512-+tdN5fGNddvsQdIzUF3Xx82CU9sMM+fA0dLgR9vOmT0oPT2jH+P1nd5lSqfCfXAw+93NhcXNY2qqvTUtE4cQkw==}
 
+  unist-util-position@5.0.0:
+    resolution: {integrity: sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==}
+
   unist-util-stringify-position@4.0.0:
     resolution: {integrity: sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==}
 
@@ -1624,6 +1724,9 @@ packages:
     resolution: {integrity: sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==}
     engines: {node: '>=10.12.0'}
 
+  vfile-location@5.0.3:
+    resolution: {integrity: sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==}
+
   vfile-message@4.0.3:
     resolution: {integrity: sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==}
 
@@ -1632,6 +1735,9 @@ packages:
 
   walker@1.0.8:
     resolution: {integrity: sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==}
+
+  web-namespaces@2.0.1:
+    resolution: {integrity: sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==}
 
   which-module@2.0.1:
     resolution: {integrity: sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==}
@@ -1692,6 +1798,9 @@ packages:
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+
+  zwitch@2.0.4:
+    resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
 snapshots:
 
@@ -2169,6 +2278,10 @@ snapshots:
     dependencies:
       '@types/node': 20.19.30
 
+  '@types/hast@3.0.4':
+    dependencies:
+      '@types/unist': 3.0.3
+
   '@types/istanbul-lib-coverage@2.0.6': {}
 
   '@types/istanbul-lib-report@3.0.3':
@@ -2185,6 +2298,10 @@ snapshots:
       pretty-format: 29.7.0
 
   '@types/json-schema@7.0.15': {}
+
+  '@types/mdast@4.0.4':
+    dependencies:
+      '@types/unist': 3.0.3
 
   '@types/nlcst@2.0.3':
     dependencies:
@@ -2294,6 +2411,8 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 8.54.0
       eslint-visitor-keys: 4.2.1
+
+  '@ungap/structured-clone@1.3.0': {}
 
   acorn-jsx@5.3.2(acorn@8.15.0):
     dependencies:
@@ -2433,12 +2552,18 @@ snapshots:
 
   caniuse-lite@1.0.30001766: {}
 
+  ccount@2.0.1: {}
+
   chalk@4.1.2:
     dependencies:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
 
   char-regex@1.0.2: {}
+
+  character-entities-html4@2.1.0: {}
+
+  character-entities-legacy@3.0.0: {}
 
   ci-info@3.9.0: {}
 
@@ -2465,6 +2590,8 @@ snapshots:
       color-name: 1.1.4
 
   color-name@1.1.4: {}
+
+  comma-separated-tokens@2.0.3: {}
 
   comment-parser@1.4.5: {}
 
@@ -2520,6 +2647,8 @@ snapshots:
   emittery@0.13.1: {}
 
   emoji-regex@8.0.0: {}
+
+  entities@6.0.1: {}
 
   error-ex@1.3.4:
     dependencies:
@@ -2722,7 +2851,59 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
+  hast-util-from-html@2.0.3:
+    dependencies:
+      '@types/hast': 3.0.4
+      devlop: 1.1.0
+      hast-util-from-parse5: 8.0.3
+      parse5: 7.3.0
+      vfile: 6.0.3
+      vfile-message: 4.0.3
+
+  hast-util-from-parse5@8.0.3:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/unist': 3.0.3
+      devlop: 1.1.0
+      hastscript: 9.0.1
+      property-information: 7.1.0
+      vfile: 6.0.3
+      vfile-location: 5.0.3
+      web-namespaces: 2.0.1
+
+  hast-util-parse-selector@4.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+
+  hast-util-to-html@9.0.5:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/unist': 3.0.3
+      ccount: 2.0.1
+      comma-separated-tokens: 2.0.3
+      hast-util-whitespace: 3.0.0
+      html-void-elements: 3.0.0
+      mdast-util-to-hast: 13.2.1
+      property-information: 7.1.0
+      space-separated-tokens: 2.0.2
+      stringify-entities: 4.0.4
+      zwitch: 2.0.4
+
+  hast-util-whitespace@3.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+
+  hastscript@9.0.1:
+    dependencies:
+      '@types/hast': 3.0.4
+      comma-separated-tokens: 2.0.3
+      hast-util-parse-selector: 4.0.0
+      property-information: 7.1.0
+      space-separated-tokens: 2.0.2
+
   html-escaper@2.0.2: {}
+
+  html-void-elements@3.0.0: {}
 
   human-signals@2.1.0: {}
 
@@ -3188,7 +3369,36 @@ snapshots:
     dependencies:
       tmpl: 1.0.5
 
+  mdast-util-to-hast@13.2.1:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      '@ungap/structured-clone': 1.3.0
+      devlop: 1.1.0
+      micromark-util-sanitize-uri: 2.0.1
+      trim-lines: 3.0.1
+      unist-util-position: 5.0.0
+      unist-util-visit: 5.1.0
+      vfile: 6.0.3
+
   merge-stream@2.0.0: {}
+
+  micromark-util-character@2.1.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-encode@2.0.1: {}
+
+  micromark-util-sanitize-uri@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-encode: 2.0.1
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-symbol@2.0.1: {}
+
+  micromark-util-types@2.0.2: {}
 
   micromatch@4.0.8:
     dependencies:
@@ -3282,6 +3492,10 @@ snapshots:
       unist-util-visit-children: 3.0.0
       vfile: 6.0.3
 
+  parse5@7.3.0:
+    dependencies:
+      entities: 6.0.1
+
   path-exists@4.0.0: {}
 
   path-is-absolute@1.0.1: {}
@@ -3315,6 +3529,8 @@ snapshots:
       kleur: 3.0.3
       sisteransi: 1.0.5
 
+  property-information@7.1.0: {}
+
   punycode@2.3.1: {}
 
   pure-rand@6.1.0: {}
@@ -3329,6 +3545,18 @@ snapshots:
     dependencies:
       '@eslint-community/regexpp': 4.12.2
       refa: 0.12.1
+
+  rehype-parse@9.0.1:
+    dependencies:
+      '@types/hast': 3.0.4
+      hast-util-from-html: 2.0.3
+      unified: 11.0.5
+
+  rehype-stringify@10.0.1:
+    dependencies:
+      '@types/hast': 3.0.4
+      hast-util-to-html: 9.0.5
+      unified: 11.0.5
 
   require-directory@2.1.1: {}
 
@@ -3410,6 +3638,8 @@ snapshots:
 
   source-map@0.6.1: {}
 
+  space-separated-tokens@2.0.2: {}
+
   sprintf-js@1.0.3: {}
 
   stack-utils@2.0.6:
@@ -3426,6 +3656,11 @@ snapshots:
       emoji-regex: 8.0.0
       is-fullwidth-code-point: 3.0.0
       strip-ansi: 6.0.1
+
+  stringify-entities@4.0.4:
+    dependencies:
+      character-entities-html4: 2.1.0
+      character-entities-legacy: 3.0.0
 
   strip-ansi@6.0.1:
     dependencies:
@@ -3467,6 +3702,8 @@ snapshots:
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
+
+  trim-lines@3.0.1: {}
 
   trough@2.2.0: {}
 
@@ -3543,6 +3780,10 @@ snapshots:
       '@types/unist': 3.0.3
       array-iterate: 2.0.1
 
+  unist-util-position@5.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+
   unist-util-stringify-position@4.0.0:
     dependencies:
       '@types/unist': 3.0.3
@@ -3578,6 +3819,11 @@ snapshots:
       '@types/istanbul-lib-coverage': 2.0.6
       convert-source-map: 2.0.0
 
+  vfile-location@5.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      vfile: 6.0.3
+
   vfile-message@4.0.3:
     dependencies:
       '@types/unist': 3.0.3
@@ -3591,6 +3837,8 @@ snapshots:
   walker@1.0.8:
     dependencies:
       makeerror: 1.0.12
+
+  web-namespaces@2.0.1: {}
 
   which-module@2.0.1: {}
 
@@ -3659,3 +3907,5 @@ snapshots:
       yargs-parser: 21.1.1
 
   yocto-queue@0.1.0: {}
+
+  zwitch@2.0.4: {}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,15 +8,9 @@ importers:
 
   .:
     dependencies:
-      '@types/hast':
-        specifier: ^3.0.4
-        version: 3.0.4
       escape-string-regexp:
         specifier: 5.0.0
         version: 5.0.0
-      unified:
-        specifier: ^11.0.5
-        version: 11.0.5
       unist-util-visit-parents:
         specifier: ^6.0.1
         version: 6.0.2
@@ -24,6 +18,9 @@ importers:
       '@eslint/js':
         specifier: ^9.39.2
         version: 9.39.2
+      '@types/hast':
+        specifier: ^3.0.4
+        version: 3.0.4
       '@types/jest':
         specifier: ^29.5.12
         version: 29.5.14
@@ -72,6 +69,9 @@ importers:
       typograf:
         specifier: 7.6.0
         version: 7.6.0
+      unified:
+        specifier: 11.0.5
+        version: 11.0.5
 
 packages:
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -128,7 +128,7 @@ export interface TransformOptions {
 import { niceQuotes } from "./quotes.js"
 import { hyphenReplace } from "./dashes.js"
 import { symbolTransform, fractions as fractionsTransform, degrees as degreesTransform, superscriptOrdinal as superscriptTransform, primeMarks, collapseSpaces as collapseSpacesTransform, punctuationLigatures as ligaturesTransform } from "./symbols.js"
-import { assertSeparatorCountPreserved } from "./utils.js"
+import { assertSeparatorCountPreserved, formatErrorString } from "./utils.js"
 import { DEFAULT_SEPARATOR } from "./constants.js"
 
 export { assertSeparatorCountPreserved, countSeparators } from "./utils.js"
@@ -231,8 +231,8 @@ export function transform(text: string, options: TransformOptions = {}): string 
     if (text !== secondPass) {
       throw new Error(
         `Transform is not idempotent.\n` +
-        `First pass:  ${JSON.stringify(text)}\n` +
-        `Second pass: ${JSON.stringify(secondPass)}\n` +
+        `First pass:  ${formatErrorString(text, "first-pass")}\n` +
+        `Second pass: ${formatErrorString(secondPass, "second-pass")}\n` +
         `This is a bug in punctilio. Please file an issue at https://github.com/alexander-turner/punctilio/issues\n` +
         `Include the input text that caused this error.`
       )

--- a/src/quotes.ts
+++ b/src/quotes.ts
@@ -43,8 +43,9 @@ function convertSingleQuotes(text: string, sep: string): string {
 
   const apostropheWhitelist = `(?=n${RIGHT_SINGLE_QUOTE} )`
   const endQuoteNotContraction = `(?!${contraction})${RIGHT_SINGLE_QUOTE}${afterEndingSingle}`
+  // Limit lookahead scan to 1000 chars to prevent catastrophic backtracking on pathological inputs
   const apostropheRegex = new RegExp(
-    `(?<=^|[^\\w])'(${apostropheWhitelist}|(?![^${LEFT_SINGLE_QUOTE}'\\n]*${endQuoteNotContraction}))`,
+    `(?<=^|[^\\w])'(${apostropheWhitelist}|(?![^${LEFT_SINGLE_QUOTE}'\\n]{0,1000}${endQuoteNotContraction}))`,
     "gm"
   )
   text = text.replace(apostropheRegex, RIGHT_SINGLE_QUOTE)

--- a/src/rehype.ts
+++ b/src/rehype.ts
@@ -159,6 +159,8 @@ const TRANSFORMABLE_ELEMENTS = [
   "strong",
   "i",
   "b",
+  "u",
+  "s",
   "sub",
   "sup",
   "small",
@@ -243,6 +245,20 @@ function collectTransformableElements(
 }
 
 /**
+ * Recursively marks all element descendants as transformed.
+ * Used to prevent redundant processing of nested elements whose text
+ * was already processed as part of a parent element.
+ */
+function markDescendants(node: Element, set: Set<Element>): void {
+  for (const child of node.children) {
+    if (child.type === "element") {
+      set.add(child)
+      markDescendants(child, set)
+    }
+  }
+}
+
+/**
  * Rehype plugin that applies punctilio typography transformations to HTML.
  *
  * @param options - Plugin configuration options
@@ -324,6 +340,8 @@ export function rehypePunctilio(
         if (!transformed.has(elt)) {
           transformElement(elt, transformFn, shouldSkip, separator)
           transformed.add(elt)
+          // Mark all descendants as processed since their text was included
+          markDescendants(elt, transformed)
         }
       }
     })

--- a/src/rehype.ts
+++ b/src/rehype.ts
@@ -14,6 +14,7 @@ import { visitParents } from "unist-util-visit-parents"
 
 import { transform, type TransformOptions } from "./index.js"
 import { DEFAULT_SEPARATOR } from "./constants.js"
+import { formatErrorString } from "./utils.js"
 
 /**
  * Options for the rehype-punctilio plugin.
@@ -38,6 +39,12 @@ export interface RehypePunctilioOptions extends TransformOptions {
 }
 
 const DEFAULT_SKIP_TAGS = ["code", "pre", "script", "style", "kbd", "var", "samp"]
+
+/**
+ * Maximum recursion depth for tree traversal functions.
+ * Prevents stack overflow from maliciously deep HTML nesting.
+ */
+const MAX_RECURSION_DEPTH = 1000
 
 /**
  * Check if an element has a specific CSS class.
@@ -74,6 +81,7 @@ function hasAncestor(
  *
  * @param node - The element or element content to process
  * @param shouldSkip - Function to determine which elements to skip
+ * @param depth - Current recursion depth (internal use)
  * @returns Array of Text nodes
  *
  * @example
@@ -83,8 +91,13 @@ function hasAncestor(
  */
 export function flattenTextNodes(
   node: Element | ElementContent,
-  shouldSkip: (n: Element) => boolean
+  shouldSkip: (n: Element) => boolean,
+  depth: number = 0
 ): Text[] {
+  if (depth > MAX_RECURSION_DEPTH) {
+    return []
+  }
+
   if (node.type === "element" && shouldSkip(node)) {
     return []
   }
@@ -94,7 +107,7 @@ export function flattenTextNodes(
   }
 
   if (node.type === "element" && "children" in node) {
-    return node.children.flatMap((child) => flattenTextNodes(child, shouldSkip))
+    return node.children.flatMap((child) => flattenTextNodes(child, shouldSkip, depth + 1))
   }
 
   return []
@@ -158,7 +171,7 @@ export function transformElement(
     throw new Error(
       `Transformation altered the number of text nodes. ` +
         `Expected ${textNodes.length}, got ${transformedFragments.length}. ` +
-        `Input: ${JSON.stringify(markedContent)}`
+        `Input: ${formatErrorString(markedContent, "input")}`
     )
   }
 
@@ -232,12 +245,19 @@ const TRANSFORMABLE_ELEMENTS = [
  *
  * @param node - The root element to search from
  * @param shouldSkip - Function to determine which elements to skip
+ * @param depth - Current recursion depth (internal use)
  * @returns Array of elements that contain transformable text
  */
 function collectTransformableElements(
   node: Element,
-  shouldSkip: (n: Element) => boolean
+  shouldSkip: (n: Element) => boolean,
+  depth: number = 0
 ): Element[] {
+  /* istanbul ignore if -- defensive: prevents stack overflow from malicious HTML */
+  if (depth > MAX_RECURSION_DEPTH) {
+    return []
+  }
+
   const results: Element[] = []
 
   if (shouldSkip(node)) {
@@ -254,7 +274,7 @@ function collectTransformableElements(
     // Otherwise, recurse into children
     for (const child of node.children) {
       if (child.type === "element") {
-        results.push(...collectTransformableElements(child, shouldSkip))
+        results.push(...collectTransformableElements(child, shouldSkip, depth + 1))
       }
     }
   }
@@ -267,11 +287,16 @@ function collectTransformableElements(
  * Used to prevent redundant processing of nested elements whose text
  * was already processed as part of a parent element.
  */
-function markDescendants(node: Element, set: Set<Element>): void {
+function markDescendants(node: Element, set: Set<Element>, depth: number = 0): void {
+  /* istanbul ignore if -- defensive: prevents stack overflow from malicious HTML */
+  if (depth > MAX_RECURSION_DEPTH) {
+    return
+  }
+
   for (const child of node.children) {
     if (child.type === "element") {
       set.add(child)
-      markDescendants(child, set)
+      markDescendants(child, set, depth + 1)
     }
   }
 }

--- a/src/rehype.ts
+++ b/src/rehype.ts
@@ -86,13 +86,13 @@ function hasAncestor(
  *
  * @example
  * ```ts
- * const textNodes = flattenTextNodes(paragraphElement, (el) => el.tagName === 'code', 0)
+ * const textNodes = flattenTextNodes(paragraphElement, (el) => el.tagName === 'code')
  * ```
  */
 export function flattenTextNodes(
   node: Element | ElementContent,
   shouldSkip: (n: Element) => boolean,
-  depth: number
+  depth: number = 0
 ): Text[] {
   if (depth > MAX_RECURSION_DEPTH) {
     return []
@@ -152,7 +152,7 @@ export function transformElement(
     return
   }
 
-  const textNodes = flattenTextNodes(node, shouldSkip, 0)
+  const textNodes = flattenTextNodes(node, shouldSkip)
   /* istanbul ignore if -- only hit when element has no text descendants */
   if (textNodes.length === 0) {
     return
@@ -251,7 +251,7 @@ const TRANSFORMABLE_ELEMENTS = [
 function collectTransformableElements(
   node: Element,
   shouldSkip: (n: Element) => boolean,
-  depth: number
+  depth: number = 0
 ): Element[] {
   /* istanbul ignore if -- defensive: prevents stack overflow from malicious HTML */
   if (depth > MAX_RECURSION_DEPTH) {
@@ -287,7 +287,7 @@ function collectTransformableElements(
  * Used to prevent redundant processing of nested elements whose text
  * was already processed as part of a parent element.
  */
-function markDescendants(node: Element, set: Set<Element>, depth: number): void {
+function markDescendants(node: Element, set: Set<Element>, depth: number = 0): void {
   /* istanbul ignore if -- defensive: prevents stack overflow from malicious HTML */
   if (depth > MAX_RECURSION_DEPTH) {
     return
@@ -378,13 +378,13 @@ export function rehypePunctilio(
       }
 
       // Collect and transform elements with text content
-      const elementsToTransform = collectTransformableElements(element, shouldSkip, 0)
+      const elementsToTransform = collectTransformableElements(element, shouldSkip)
       for (const elt of elementsToTransform) {
         if (!transformed.has(elt)) {
           transformElement(elt, transformFn, shouldSkip, separator)
           transformed.add(elt)
           // Mark all descendants as processed since their text was included
-          markDescendants(elt, transformed, 0)
+          markDescendants(elt, transformed)
         }
       }
     })

--- a/src/rehype.ts
+++ b/src/rehype.ts
@@ -86,13 +86,13 @@ function hasAncestor(
  *
  * @example
  * ```ts
- * const textNodes = flattenTextNodes(paragraphElement, (el) => el.tagName === 'code')
+ * const textNodes = flattenTextNodes(paragraphElement, (el) => el.tagName === 'code', 0)
  * ```
  */
 export function flattenTextNodes(
   node: Element | ElementContent,
   shouldSkip: (n: Element) => boolean,
-  depth: number = 0
+  depth: number
 ): Text[] {
   if (depth > MAX_RECURSION_DEPTH) {
     return []
@@ -152,7 +152,7 @@ export function transformElement(
     return
   }
 
-  const textNodes = flattenTextNodes(node, shouldSkip)
+  const textNodes = flattenTextNodes(node, shouldSkip, 0)
   /* istanbul ignore if -- only hit when element has no text descendants */
   if (textNodes.length === 0) {
     return
@@ -251,7 +251,7 @@ const TRANSFORMABLE_ELEMENTS = [
 function collectTransformableElements(
   node: Element,
   shouldSkip: (n: Element) => boolean,
-  depth: number = 0
+  depth: number
 ): Element[] {
   /* istanbul ignore if -- defensive: prevents stack overflow from malicious HTML */
   if (depth > MAX_RECURSION_DEPTH) {
@@ -287,7 +287,7 @@ function collectTransformableElements(
  * Used to prevent redundant processing of nested elements whose text
  * was already processed as part of a parent element.
  */
-function markDescendants(node: Element, set: Set<Element>, depth: number = 0): void {
+function markDescendants(node: Element, set: Set<Element>, depth: number): void {
   /* istanbul ignore if -- defensive: prevents stack overflow from malicious HTML */
   if (depth > MAX_RECURSION_DEPTH) {
     return
@@ -378,13 +378,13 @@ export function rehypePunctilio(
       }
 
       // Collect and transform elements with text content
-      const elementsToTransform = collectTransformableElements(element, shouldSkip)
+      const elementsToTransform = collectTransformableElements(element, shouldSkip, 0)
       for (const elt of elementsToTransform) {
         if (!transformed.has(elt)) {
           transformElement(elt, transformFn, shouldSkip, separator)
           transformed.add(elt)
           // Mark all descendants as processed since their text was included
-          markDescendants(elt, transformed)
+          markDescendants(elt, transformed, 0)
         }
       }
     })

--- a/src/rehype.ts
+++ b/src/rehype.ts
@@ -204,7 +204,6 @@ const TRANSFORMABLE_ELEMENTS = [
   "ruby",
   "rt",
   "rp",
-  "wbr",
 ]
 
 /**
@@ -295,6 +294,9 @@ export function rehypePunctilio(
   }
 
   return (tree: Root) => {
+    // Track transformed elements to avoid double-processing
+    const transformed = new Set<Element>()
+
     visitParents(tree, (node, ancestors) => {
       // Only process element nodes
       if (node.type !== "element") {
@@ -302,6 +304,11 @@ export function rehypePunctilio(
       }
 
       const element = node as Element
+
+      // Skip if already transformed
+      if (transformed.has(element)) {
+        return
+      }
 
       // Check if this node or any ancestor should be skipped
       if (shouldSkip(element)) {
@@ -314,7 +321,10 @@ export function rehypePunctilio(
       // Collect and transform elements with text content
       const elementsToTransform = collectTransformableElements(element, shouldSkip)
       for (const elt of elementsToTransform) {
-        transformElement(elt, transformFn, shouldSkip, separator)
+        if (!transformed.has(elt)) {
+          transformElement(elt, transformFn, shouldSkip, separator)
+          transformed.add(elt)
+        }
       }
     })
   }

--- a/src/rehype.ts
+++ b/src/rehype.ts
@@ -1,0 +1,323 @@
+/**
+ * Rehype plugin for applying punctilio typography transformations to HTML.
+ *
+ * This plugin integrates punctilio with the unified/rehype ecosystem,
+ * allowing you to apply smart typography transformations to HTML ASTs.
+ *
+ * @packageDocumentation
+ */
+
+import type { Root, Element, Text, ElementContent, Parent } from "hast"
+import type { Transformer } from "unified"
+
+import { visitParents } from "unist-util-visit-parents"
+
+import { transform, type TransformOptions } from "./index.js"
+import { DEFAULT_SEPARATOR } from "./constants.js"
+
+/**
+ * Options for the rehype-punctilio plugin.
+ */
+export interface RehypePunctilioOptions extends TransformOptions {
+  /**
+   * HTML tag names to skip when applying transformations.
+   * Content inside these elements won't have formatting improvements applied.
+   *
+   * Default: ["code", "pre", "script", "style", "kbd", "var", "samp"]
+   */
+  skipTags?: string[]
+
+  /**
+   * CSS class names that indicate content should skip formatting.
+   * Elements with any of these classes (or descendants of such elements)
+   * will be skipped.
+   *
+   * Default: []
+   */
+  skipClasses?: string[]
+}
+
+const DEFAULT_SKIP_TAGS = ["code", "pre", "script", "style", "kbd", "var", "samp"]
+
+/**
+ * Check if an element has a specific CSS class.
+ */
+function hasClass(node: Element, className: string): boolean {
+  const classNames = node.properties?.className
+  if (Array.isArray(classNames)) {
+    return classNames.includes(className)
+  }
+  /* istanbul ignore next -- rehype-parse always produces arrays, but handle strings defensively */
+  if (typeof classNames === "string") {
+    return classNames.split(/\s+/).includes(className)
+  }
+  return false
+}
+
+/**
+ * Check if any ancestor of a node matches a predicate.
+ */
+function hasAncestor(
+  ancestors: Parent[],
+  predicate: (node: Element) => boolean
+): boolean {
+  return ancestors.some((ancestor) => {
+    if (ancestor.type === "element") {
+      return predicate(ancestor as Element)
+    }
+    return false
+  })
+}
+
+/**
+ * Flattens text nodes from an element tree into a single array.
+ *
+ * @param node - The element or element content to process
+ * @param shouldSkip - Function to determine which elements to skip
+ * @returns Array of Text nodes
+ */
+function flattenTextNodes(
+  node: Element | ElementContent,
+  shouldSkip: (n: Element) => boolean
+): Text[] {
+  if (node.type === "element" && shouldSkip(node)) {
+    return []
+  }
+
+  if (node.type === "text") {
+    return [node]
+  }
+
+  if (node.type === "element" && "children" in node) {
+    return node.children.flatMap((child) => flattenTextNodes(child, shouldSkip))
+  }
+
+  return []
+}
+
+/**
+ * Applies a transformation to element text content while preserving HTML structure.
+ *
+ * This function uses a marker technique to handle text that spans multiple
+ * HTML elements. It:
+ * 1. Appends a private-use Unicode character to each child's text content
+ * 2. Concatenates and transforms the whole paragraph
+ * 3. Splits the result back into the original text nodes
+ *
+ * @param node - The element to transform
+ * @param transformFn - The transformation function to apply
+ * @param shouldSkip - Function to determine which elements to skip
+ * @param separator - The marker character to use
+ * @throws Error if transformation alters the number of text nodes
+ */
+function transformElement(
+  node: Element,
+  transformFn: (input: string) => string,
+  shouldSkip: (input: Element) => boolean,
+  separator: string
+): void {
+  /* istanbul ignore if -- defensive: elements should always have children array */
+  if (!node?.children) {
+    return
+  }
+
+  const textNodes = flattenTextNodes(node, shouldSkip)
+  /* istanbul ignore if -- only hit when element has no text descendants */
+  if (textNodes.length === 0) {
+    return
+  }
+
+  // Append marker and concatenate all text nodes
+  const markedContent = textNodes.map((n) => n.value + separator).join("")
+
+  const transformedContent = transformFn(markedContent)
+
+  // Split and overwrite. Last fragment is always empty because strings end with marker
+  const transformedFragments = transformedContent.split(separator).slice(0, -1)
+
+  /* istanbul ignore if -- defensive: transform should never consume separator chars */
+  if (transformedFragments.length !== textNodes.length) {
+    throw new Error(
+      `Transformation altered the number of text nodes. ` +
+        `Expected ${textNodes.length}, got ${transformedFragments.length}. ` +
+        `Input: ${JSON.stringify(markedContent)}`
+    )
+  }
+
+  textNodes.forEach((n, index) => {
+    n.value = transformedFragments[index]
+  })
+}
+
+/**
+ * HTML elements that can contain transformable text content.
+ * We traverse into these to find text nodes to transform.
+ */
+const TRANSFORMABLE_ELEMENTS = [
+  "p",
+  "em",
+  "strong",
+  "i",
+  "b",
+  "sub",
+  "sup",
+  "small",
+  "del",
+  "ins",
+  "mark",
+  "span",
+  "div",
+  "td",
+  "th",
+  "dt",
+  "dd",
+  "li",
+  "h1",
+  "h2",
+  "h3",
+  "h4",
+  "h5",
+  "h6",
+  "figcaption",
+  "blockquote",
+  "cite",
+  "q",
+  "a",
+  "label",
+  "legend",
+  "caption",
+  "summary",
+  "address",
+  "article",
+  "aside",
+  "footer",
+  "header",
+  "main",
+  "nav",
+  "section",
+  "time",
+  "abbr",
+  "dfn",
+  "data",
+  "bdi",
+  "bdo",
+  "ruby",
+  "rt",
+  "rp",
+  "wbr",
+]
+
+/**
+ * Collects elements that should have text transformations applied.
+ * Only collects elements that directly contain text nodes.
+ *
+ * @param node - The root element to search from
+ * @param shouldSkip - Function to determine which elements to skip
+ * @returns Array of elements that contain transformable text
+ */
+function collectTransformableElements(
+  node: Element,
+  shouldSkip: (n: Element) => boolean
+): Element[] {
+  const results: Element[] = []
+
+  if (shouldSkip(node)) {
+    return []
+  }
+
+  // If this node is a transformable element with direct text children, collect it
+  if (
+    TRANSFORMABLE_ELEMENTS.includes(node.tagName) &&
+    node.children.some((child) => child.type === "text")
+  ) {
+    results.push(node)
+  } else {
+    // Otherwise, recurse into children
+    for (const child of node.children) {
+      if (child.type === "element") {
+        results.push(...collectTransformableElements(child, shouldSkip))
+      }
+    }
+  }
+
+  return results
+}
+
+/**
+ * Rehype plugin that applies punctilio typography transformations to HTML.
+ *
+ * @param options - Plugin configuration options
+ * @returns Unified transformer function
+ *
+ * @example
+ * ```ts
+ * import { unified } from 'unified'
+ * import remarkParse from 'remark-parse'
+ * import remarkRehype from 'remark-rehype'
+ * import rehypeStringify from 'rehype-stringify'
+ * import { rehypePunctilio } from 'punctilio/rehype'
+ *
+ * const result = await unified()
+ *   .use(remarkParse)
+ *   .use(remarkRehype)
+ *   .use(rehypePunctilio, {
+ *     punctuationStyle: 'american',
+ *     dashStyle: 'american',
+ *   })
+ *   .use(rehypeStringify)
+ *   .process('"Hello," she said -- "it\'s nice."')
+ *
+ * // Output HTML will have smart quotes and em-dashes
+ * ```
+ */
+export function rehypePunctilio(
+  options: RehypePunctilioOptions = {}
+): Transformer<Root, Root> {
+  const {
+    skipTags = DEFAULT_SKIP_TAGS,
+    skipClasses = [],
+    separator = DEFAULT_SEPARATOR,
+    ...transformOptions
+  } = options
+
+  const shouldSkip = (node: Element): boolean => {
+    if (skipTags.includes(node.tagName)) {
+      return true
+    }
+    if (skipClasses.some((cls) => hasClass(node, cls))) {
+      return true
+    }
+    return false
+  }
+
+  const transformFn = (text: string): string => {
+    return transform(text, { ...transformOptions, separator })
+  }
+
+  return (tree: Root) => {
+    visitParents(tree, (node, ancestors) => {
+      // Only process element nodes
+      if (node.type !== "element") {
+        return
+      }
+
+      const element = node as Element
+
+      // Check if this node or any ancestor should be skipped
+      if (shouldSkip(element)) {
+        return
+      }
+      if (hasAncestor(ancestors as Parent[], shouldSkip)) {
+        return
+      }
+
+      // Collect and transform elements with text content
+      const elementsToTransform = collectTransformableElements(element, shouldSkip)
+      for (const elt of elementsToTransform) {
+        transformElement(elt, transformFn, shouldSkip, separator)
+      }
+    })
+  }
+}
+
+export default rehypePunctilio

--- a/src/rehype.ts
+++ b/src/rehype.ts
@@ -75,8 +75,13 @@ function hasAncestor(
  * @param node - The element or element content to process
  * @param shouldSkip - Function to determine which elements to skip
  * @returns Array of Text nodes
+ *
+ * @example
+ * ```ts
+ * const textNodes = flattenTextNodes(paragraphElement, (el) => el.tagName === 'code')
+ * ```
  */
-function flattenTextNodes(
+export function flattenTextNodes(
   node: Element | ElementContent,
   shouldSkip: (n: Element) => boolean
 ): Text[] {
@@ -107,10 +112,23 @@ function flattenTextNodes(
  * @param node - The element to transform
  * @param transformFn - The transformation function to apply
  * @param shouldSkip - Function to determine which elements to skip
- * @param separator - The marker character to use
+ * @param separator - The marker character to use (default: DEFAULT_SEPARATOR)
  * @throws Error if transformation alters the number of text nodes
+ *
+ * @example
+ * ```ts
+ * import { transformElement, DEFAULT_SEPARATOR } from 'punctilio/rehype'
+ *
+ * // Apply a custom transform to an element
+ * transformElement(
+ *   paragraphElement,
+ *   (text) => text.replace(/eg\b/g, 'e.g.'),
+ *   (el) => el.tagName === 'code',
+ *   DEFAULT_SEPARATOR
+ * )
+ * ```
  */
-function transformElement(
+export function transformElement(
   node: Element,
   transformFn: (input: string) => string,
   shouldSkip: (input: Element) => boolean,

--- a/src/symbols.ts
+++ b/src/symbols.ts
@@ -190,9 +190,10 @@ export function primeMarks(text: string, options: SymbolOptions = {}): string {
       `(?<digit>\\d)(?<sep>${chr}?)${quote}(?<afterSep>${chr}?)(?![${LATIN_LETTERS}])`,
       "g"
     )
+    const quoteCountPattern = new RegExp(escapeStringRegexp(quote), "g")
     text = text.replace(pattern, (match, digit, sep, afterSep, offset) => {
       const textBefore = text.slice(0, offset)
-      const quoteCount = (textBefore.match(new RegExp(quote, "g")) || []).length
+      const quoteCount = (textBefore.match(quoteCountPattern) || []).length
       if (quoteCount % 2 === 0) {
         return `${digit}${sep}${prime}${afterSep}`
       }

--- a/src/tests/rehype.test.ts
+++ b/src/tests/rehype.test.ts
@@ -1,4 +1,5 @@
 import type { Element, Text, ElementContent } from "hast"
+import { h } from "hastscript"
 import { unified } from "unified"
 import rehypeParse from "rehype-parse"
 import rehypeStringify from "rehype-stringify"
@@ -329,176 +330,91 @@ describe("rehypePunctilio", () => {
   })
 
   describe("exported utilities", () => {
+    const ignoreNone = () => false
+    const ignoreCode = (el: Element) => el.tagName === "code"
+
+    // Test nodes using hastscript for cleaner syntax
+    const testNodes = {
+      empty: h("div", []) as Element,
+      simple: h("p", "Hello, world!") as Element,
+      nested: h("div", ["This is ", h("em", "emphasized"), " text."]) as Element,
+      withCode: h("div", ["This is ", h("code", "ignored"), " text."]) as Element,
+      emptyAndComment: h("div", [
+        h("span"),
+        { type: "comment", value: "This is a comment" } as unknown as ElementContent,
+      ]) as Element,
+      deeplyNested: h("div", [
+        "Level 1 ",
+        h("span", ["Level 2 ", h("em", "Level 3")]),
+        " End",
+      ]) as Element,
+    }
+
     describe("flattenTextNodes", () => {
-      const noSkip = () => false
-      const skipCode = (n: Element) => n.tagName === "code"
+      it("handles various node structures", () => {
+        expect(flattenTextNodes(testNodes.empty, ignoreNone)).toEqual([])
+        expect(flattenTextNodes(testNodes.simple, ignoreNone)).toEqual([
+          { type: "text", value: "Hello, world!" },
+        ])
+        expect(flattenTextNodes(testNodes.nested, ignoreNone)).toEqual([
+          { type: "text", value: "This is " },
+          { type: "text", value: "emphasized" },
+          { type: "text", value: " text." },
+        ])
+        expect(flattenTextNodes(testNodes.withCode, ignoreCode)).toEqual([
+          { type: "text", value: "This is " },
+          { type: "text", value: " text." },
+        ])
+        expect(flattenTextNodes(testNodes.emptyAndComment, ignoreNone)).toEqual([])
+        expect(flattenTextNodes(testNodes.deeplyNested, ignoreNone)).toEqual([
+          { type: "text", value: "Level 1 " },
+          { type: "text", value: "Level 2 " },
+          { type: "text", value: "Level 3" },
+          { type: "text", value: " End" },
+        ])
+      })
 
       it("extracts text from a single text node", () => {
         const textNode: Text = { type: "text", value: "Hello" }
-        const result = flattenTextNodes(textNode, noSkip)
+        const result = flattenTextNodes(textNode, ignoreNone)
         expect(result).toHaveLength(1)
         expect(result[0].value).toBe("Hello")
       })
 
-      it("extracts text from element with text children", () => {
-        const element: Element = {
-          type: "element",
-          tagName: "p",
-          properties: {},
-          children: [
-            { type: "text", value: "Hello " },
-            { type: "text", value: "world" },
-          ],
-        }
-        const result = flattenTextNodes(element, noSkip)
-        expect(result).toHaveLength(2)
-        expect(result.map((n) => n.value)).toEqual(["Hello ", "world"])
-      })
-
-      it("extracts text from nested elements", () => {
-        const element: Element = {
-          type: "element",
-          tagName: "p",
-          properties: {},
-          children: [
-            { type: "text", value: "Start " },
-            {
-              type: "element",
-              tagName: "em",
-              properties: {},
-              children: [{ type: "text", value: "middle" }],
-            },
-            { type: "text", value: " end" },
-          ],
-        }
-        const result = flattenTextNodes(element, noSkip)
-        expect(result).toHaveLength(3)
-        expect(result.map((n) => n.value)).toEqual(["Start ", "middle", " end"])
-      })
-
-      it("skips elements matching the skip predicate", () => {
-        const element: Element = {
-          type: "element",
-          tagName: "p",
-          properties: {},
-          children: [
-            { type: "text", value: "Before " },
-            {
-              type: "element",
-              tagName: "code",
-              properties: {},
-              children: [{ type: "text", value: "skipped" }],
-            },
-            { type: "text", value: " after" },
-          ],
-        }
-        const result = flattenTextNodes(element, skipCode)
-        expect(result).toHaveLength(2)
-        expect(result.map((n) => n.value)).toEqual(["Before ", " after"])
-      })
-
-      it("returns empty array for skipped root element", () => {
-        const element: Element = {
-          type: "element",
-          tagName: "code",
-          properties: {},
-          children: [{ type: "text", value: "content" }],
-        }
-        const result = flattenTextNodes(element, skipCode)
-        expect(result).toHaveLength(0)
-      })
-
-      it("ignores non-text, non-element nodes", () => {
-        const element: Element = {
-          type: "element",
-          tagName: "p",
-          properties: {},
-          children: [
-            { type: "text", value: "text" },
-            { type: "comment", value: "comment" } as unknown as ElementContent,
-          ],
-        }
-        const result = flattenTextNodes(element, noSkip)
-        expect(result).toHaveLength(1)
-        expect(result[0].value).toBe("text")
-      })
-
       it("stops recursion at max depth to prevent stack overflow", () => {
-        // Build a deeply nested structure that exceeds MAX_RECURSION_DEPTH (1000)
-        let deepElement: Element = {
-          type: "element",
-          tagName: "span",
-          properties: {},
-          children: [{ type: "text", value: "deep" }],
-        }
+        let deepElement: Element = h("span", "deep") as Element
         for (let i = 0; i < 1005; i++) {
-          deepElement = {
-            type: "element",
-            tagName: "div",
-            properties: {},
-            children: [deepElement],
-          }
+          deepElement = h("div", [deepElement]) as Element
         }
-        // Should not throw and should return empty (text is beyond depth limit)
-        const result = flattenTextNodes(deepElement, noSkip)
+        const result = flattenTextNodes(deepElement, ignoreNone)
         expect(result).toHaveLength(0)
       })
     })
 
     describe("transformElement", () => {
-      const noSkip = () => false
       const toUpper = (s: string) => s.toUpperCase()
 
       it("transforms text in a simple element", () => {
-        const element: Element = {
-          type: "element",
-          tagName: "p",
-          properties: {},
-          children: [{ type: "text", value: "hello" }],
-        }
-        transformElement(element, toUpper, noSkip, DEFAULT_SEPARATOR)
+        const element = h("p", "hello") as Element
+        transformElement(element, toUpper, ignoreNone, DEFAULT_SEPARATOR)
         expect((element.children[0] as Text).value).toBe("HELLO")
       })
 
       it("transforms text across multiple nodes preserving structure", () => {
-        const element: Element = {
-          type: "element",
-          tagName: "p",
-          properties: {},
-          children: [
-            { type: "text", value: "hello " },
-            {
-              type: "element",
-              tagName: "em",
-              properties: {},
-              children: [{ type: "text", value: "world" }],
-            },
-          ],
-        }
-        transformElement(element, toUpper, noSkip, DEFAULT_SEPARATOR)
+        const element = h("p", ["hello ", h("em", "world")]) as Element
+        transformElement(element, toUpper, ignoreNone, DEFAULT_SEPARATOR)
         expect((element.children[0] as Text).value).toBe("HELLO ")
         const em = element.children[1] as Element
         expect((em.children[0] as Text).value).toBe("WORLD")
       })
 
       it("skips elements matching the skip predicate", () => {
-        const skipCode = (n: Element) => n.tagName === "code"
-        const element: Element = {
-          type: "element",
-          tagName: "p",
-          properties: {},
-          children: [
-            { type: "text", value: "before " },
-            {
-              type: "element",
-              tagName: "code",
-              properties: {},
-              children: [{ type: "text", value: "unchanged" }],
-            },
-            { type: "text", value: " after" },
-          ],
-        }
-        transformElement(element, toUpper, skipCode, DEFAULT_SEPARATOR)
+        const element = h("p", [
+          "before ",
+          h("code", "unchanged"),
+          " after",
+        ]) as Element
+        transformElement(element, toUpper, ignoreCode, DEFAULT_SEPARATOR)
         expect((element.children[0] as Text).value).toBe("BEFORE ")
         const code = element.children[1] as Element
         expect((code.children[0] as Text).value).toBe("unchanged")
@@ -507,26 +423,36 @@ describe("rehypePunctilio", () => {
 
       it("applies custom transform functions", () => {
         const replaceHyphens = (s: string) => s.replace(/-/g, "–")
-        const element: Element = {
-          type: "element",
-          tagName: "p",
-          properties: {},
-          children: [{ type: "text", value: "pages 1-5" }],
-        }
-        transformElement(element, replaceHyphens, noSkip, DEFAULT_SEPARATOR)
+        const element = h("p", "pages 1-5") as Element
+        transformElement(element, replaceHyphens, ignoreNone, DEFAULT_SEPARATOR)
         expect((element.children[0] as Text).value).toBe("pages 1–5")
       })
 
       it("works with custom separator", () => {
-        const customSep = "\uE001"
-        const element: Element = {
-          type: "element",
-          tagName: "p",
-          properties: {},
-          children: [{ type: "text", value: "hello" }],
-        }
-        transformElement(element, toUpper, noSkip, customSep)
+        const element = h("p", "hello") as Element
+        transformElement(element, toUpper, ignoreNone, "\uE001")
         expect((element.children[0] as Text).value).toBe("HELLO")
+      })
+    })
+
+    describe("transformElement error conditions", () => {
+      it("handles node with no children gracefully", () => {
+        const nodeWithoutChildren = h("div") as Element
+        nodeWithoutChildren.children = undefined as unknown as Element["children"]
+        const transform = (text: string) => text.toUpperCase()
+        // Should not throw - returns early for defensive reasons
+        expect(() => {
+          transformElement(nodeWithoutChildren, transform, ignoreNone, DEFAULT_SEPARATOR)
+        }).not.toThrow()
+      })
+
+      it("throws error when transformation alters number of text nodes", () => {
+        const node = h("p", "hello world") as Element
+        const transform = (text: string): string =>
+          text.replace("hello", `hello${DEFAULT_SEPARATOR}extra${DEFAULT_SEPARATOR}`)
+        expect(() => {
+          transformElement(node, transform, ignoreNone, DEFAULT_SEPARATOR)
+        }).toThrow("Transformation altered the number of text nodes")
       })
     })
   })

--- a/src/tests/rehype.test.ts
+++ b/src/tests/rehype.test.ts
@@ -1,8 +1,14 @@
+import type { Element, Text, ElementContent } from "hast"
 import { unified } from "unified"
 import rehypeParse from "rehype-parse"
 import rehypeStringify from "rehype-stringify"
-import { rehypePunctilio, type RehypePunctilioOptions } from "../rehype.js"
-import { UNICODE_SYMBOLS } from "../constants.js"
+import {
+  rehypePunctilio,
+  type RehypePunctilioOptions,
+  transformElement,
+  flattenTextNodes,
+} from "../rehype.js"
+import { UNICODE_SYMBOLS, DEFAULT_SEPARATOR } from "../constants.js"
 
 const {
   LEFT_DOUBLE_QUOTE,
@@ -319,6 +325,188 @@ describe("rehypePunctilio", () => {
     it("exports rehypePunctilio as default", async () => {
       const { default: defaultExport } = await import("../rehype.js")
       expect(defaultExport).toBe(rehypePunctilio)
+    })
+  })
+
+  describe("exported utilities", () => {
+    describe("flattenTextNodes", () => {
+      const noSkip = () => false
+      const skipCode = (n: Element) => n.tagName === "code"
+
+      it("extracts text from a single text node", () => {
+        const textNode: Text = { type: "text", value: "Hello" }
+        const result = flattenTextNodes(textNode, noSkip)
+        expect(result).toHaveLength(1)
+        expect(result[0].value).toBe("Hello")
+      })
+
+      it("extracts text from element with text children", () => {
+        const element: Element = {
+          type: "element",
+          tagName: "p",
+          properties: {},
+          children: [
+            { type: "text", value: "Hello " },
+            { type: "text", value: "world" },
+          ],
+        }
+        const result = flattenTextNodes(element, noSkip)
+        expect(result).toHaveLength(2)
+        expect(result.map((n) => n.value)).toEqual(["Hello ", "world"])
+      })
+
+      it("extracts text from nested elements", () => {
+        const element: Element = {
+          type: "element",
+          tagName: "p",
+          properties: {},
+          children: [
+            { type: "text", value: "Start " },
+            {
+              type: "element",
+              tagName: "em",
+              properties: {},
+              children: [{ type: "text", value: "middle" }],
+            },
+            { type: "text", value: " end" },
+          ],
+        }
+        const result = flattenTextNodes(element, noSkip)
+        expect(result).toHaveLength(3)
+        expect(result.map((n) => n.value)).toEqual(["Start ", "middle", " end"])
+      })
+
+      it("skips elements matching the skip predicate", () => {
+        const element: Element = {
+          type: "element",
+          tagName: "p",
+          properties: {},
+          children: [
+            { type: "text", value: "Before " },
+            {
+              type: "element",
+              tagName: "code",
+              properties: {},
+              children: [{ type: "text", value: "skipped" }],
+            },
+            { type: "text", value: " after" },
+          ],
+        }
+        const result = flattenTextNodes(element, skipCode)
+        expect(result).toHaveLength(2)
+        expect(result.map((n) => n.value)).toEqual(["Before ", " after"])
+      })
+
+      it("returns empty array for skipped root element", () => {
+        const element: Element = {
+          type: "element",
+          tagName: "code",
+          properties: {},
+          children: [{ type: "text", value: "content" }],
+        }
+        const result = flattenTextNodes(element, skipCode)
+        expect(result).toHaveLength(0)
+      })
+
+      it("ignores non-text, non-element nodes", () => {
+        const element: Element = {
+          type: "element",
+          tagName: "p",
+          properties: {},
+          children: [
+            { type: "text", value: "text" },
+            { type: "comment", value: "comment" } as unknown as ElementContent,
+          ],
+        }
+        const result = flattenTextNodes(element, noSkip)
+        expect(result).toHaveLength(1)
+        expect(result[0].value).toBe("text")
+      })
+    })
+
+    describe("transformElement", () => {
+      const noSkip = () => false
+      const toUpper = (s: string) => s.toUpperCase()
+
+      it("transforms text in a simple element", () => {
+        const element: Element = {
+          type: "element",
+          tagName: "p",
+          properties: {},
+          children: [{ type: "text", value: "hello" }],
+        }
+        transformElement(element, toUpper, noSkip, DEFAULT_SEPARATOR)
+        expect((element.children[0] as Text).value).toBe("HELLO")
+      })
+
+      it("transforms text across multiple nodes preserving structure", () => {
+        const element: Element = {
+          type: "element",
+          tagName: "p",
+          properties: {},
+          children: [
+            { type: "text", value: "hello " },
+            {
+              type: "element",
+              tagName: "em",
+              properties: {},
+              children: [{ type: "text", value: "world" }],
+            },
+          ],
+        }
+        transformElement(element, toUpper, noSkip, DEFAULT_SEPARATOR)
+        expect((element.children[0] as Text).value).toBe("HELLO ")
+        const em = element.children[1] as Element
+        expect((em.children[0] as Text).value).toBe("WORLD")
+      })
+
+      it("skips elements matching the skip predicate", () => {
+        const skipCode = (n: Element) => n.tagName === "code"
+        const element: Element = {
+          type: "element",
+          tagName: "p",
+          properties: {},
+          children: [
+            { type: "text", value: "before " },
+            {
+              type: "element",
+              tagName: "code",
+              properties: {},
+              children: [{ type: "text", value: "unchanged" }],
+            },
+            { type: "text", value: " after" },
+          ],
+        }
+        transformElement(element, toUpper, skipCode, DEFAULT_SEPARATOR)
+        expect((element.children[0] as Text).value).toBe("BEFORE ")
+        const code = element.children[1] as Element
+        expect((code.children[0] as Text).value).toBe("unchanged")
+        expect((element.children[2] as Text).value).toBe(" AFTER")
+      })
+
+      it("applies custom transform functions", () => {
+        const replaceHyphens = (s: string) => s.replace(/-/g, "–")
+        const element: Element = {
+          type: "element",
+          tagName: "p",
+          properties: {},
+          children: [{ type: "text", value: "pages 1-5" }],
+        }
+        transformElement(element, replaceHyphens, noSkip, DEFAULT_SEPARATOR)
+        expect((element.children[0] as Text).value).toBe("pages 1–5")
+      })
+
+      it("works with custom separator", () => {
+        const customSep = "\uE001"
+        const element: Element = {
+          type: "element",
+          tagName: "p",
+          properties: {},
+          children: [{ type: "text", value: "hello" }],
+        }
+        transformElement(element, toUpper, noSkip, customSep)
+        expect((element.children[0] as Text).value).toBe("HELLO")
+      })
     })
   })
 

--- a/src/tests/rehype.test.ts
+++ b/src/tests/rehype.test.ts
@@ -269,10 +269,11 @@ describe("rehypePunctilio", () => {
         expect(() => transformElement(node, toUpper, ignoreNone, DEFAULT_SEPARATOR)).not.toThrow()
       })
 
-      it("throws on altered text node count", () => {
-        const node = h("p", "hello") as Element
-        const badTransform = (s: string) => s.replace("hello", `hello${DEFAULT_SEPARATOR}extra${DEFAULT_SEPARATOR}`)
-        expect(() => transformElement(node, badTransform, ignoreNone, DEFAULT_SEPARATOR)).toThrow(
+      it.each([
+        ["injecting separators", h("p", "hello"), (s: string) => s.replace("hello", `hello${DEFAULT_SEPARATOR}injected`)],
+        ["removing separators", h("p", ["hello ", h("em", "world")]), (s: string) => s.replace(DEFAULT_SEPARATOR, "")],
+      ])("throws on %s", (_name, element, transform) => {
+        expect(() => transformElement(element as Element, transform, () => false, DEFAULT_SEPARATOR)).toThrow(
           "Transformation altered the number of text nodes"
         )
       })
@@ -304,25 +305,5 @@ describe("rehypePunctilio", () => {
       expect(result).toMatch(new RegExp(`<p>${LDQ}World${RDQ}</p>`))
       expect(result).toContain('<pre>"Code"</pre>')
     })
-  })
-})
-
-describe("separator injection protection", () => {
-  it("throws when transform injects separators", () => {
-    const element = h("p", "hello world") as Element
-    const maliciousTransform = (text: string): string =>
-      text.replace("hello", `hello${DEFAULT_SEPARATOR}injected`)
-    expect(() => {
-      transformElement(element, maliciousTransform, () => false, DEFAULT_SEPARATOR)
-    }).toThrow("Transformation altered the number of text nodes")
-  })
-
-  it("throws when transform removes separators", () => {
-    const element = h("p", ["hello ", h("em", "world")]) as Element
-    const maliciousTransform = (text: string): string =>
-      text.replace(DEFAULT_SEPARATOR, "")
-    expect(() => {
-      transformElement(element, maliciousTransform, () => false, DEFAULT_SEPARATOR)
-    }).toThrow("Transformation altered the number of text nodes")
   })
 })

--- a/src/tests/rehype.test.ts
+++ b/src/tests/rehype.test.ts
@@ -335,7 +335,7 @@ describe("rehypePunctilio", () => {
 
       it("extracts text from a single text node", () => {
         const textNode: Text = { type: "text", value: "Hello" }
-        const result = flattenTextNodes(textNode, noSkip, 0)
+        const result = flattenTextNodes(textNode, noSkip)
         expect(result).toHaveLength(1)
         expect(result[0].value).toBe("Hello")
       })
@@ -350,7 +350,7 @@ describe("rehypePunctilio", () => {
             { type: "text", value: "world" },
           ],
         }
-        const result = flattenTextNodes(element, noSkip, 0)
+        const result = flattenTextNodes(element, noSkip)
         expect(result).toHaveLength(2)
         expect(result.map((n) => n.value)).toEqual(["Hello ", "world"])
       })
@@ -371,7 +371,7 @@ describe("rehypePunctilio", () => {
             { type: "text", value: " end" },
           ],
         }
-        const result = flattenTextNodes(element, noSkip, 0)
+        const result = flattenTextNodes(element, noSkip)
         expect(result).toHaveLength(3)
         expect(result.map((n) => n.value)).toEqual(["Start ", "middle", " end"])
       })
@@ -392,7 +392,7 @@ describe("rehypePunctilio", () => {
             { type: "text", value: " after" },
           ],
         }
-        const result = flattenTextNodes(element, skipCode, 0)
+        const result = flattenTextNodes(element, skipCode)
         expect(result).toHaveLength(2)
         expect(result.map((n) => n.value)).toEqual(["Before ", " after"])
       })
@@ -404,7 +404,7 @@ describe("rehypePunctilio", () => {
           properties: {},
           children: [{ type: "text", value: "content" }],
         }
-        const result = flattenTextNodes(element, skipCode, 0)
+        const result = flattenTextNodes(element, skipCode)
         expect(result).toHaveLength(0)
       })
 
@@ -418,7 +418,7 @@ describe("rehypePunctilio", () => {
             { type: "comment", value: "comment" } as unknown as ElementContent,
           ],
         }
-        const result = flattenTextNodes(element, noSkip, 0)
+        const result = flattenTextNodes(element, noSkip)
         expect(result).toHaveLength(1)
         expect(result[0].value).toBe("text")
       })
@@ -440,7 +440,7 @@ describe("rehypePunctilio", () => {
           }
         }
         // Should not throw and should return empty (text is beyond depth limit)
-        const result = flattenTextNodes(deepElement, noSkip, 0)
+        const result = flattenTextNodes(deepElement, noSkip)
         expect(result).toHaveLength(0)
       })
     })

--- a/src/tests/rehype.test.ts
+++ b/src/tests/rehype.test.ts
@@ -335,7 +335,7 @@ describe("rehypePunctilio", () => {
 
       it("extracts text from a single text node", () => {
         const textNode: Text = { type: "text", value: "Hello" }
-        const result = flattenTextNodes(textNode, noSkip)
+        const result = flattenTextNodes(textNode, noSkip, 0)
         expect(result).toHaveLength(1)
         expect(result[0].value).toBe("Hello")
       })
@@ -350,7 +350,7 @@ describe("rehypePunctilio", () => {
             { type: "text", value: "world" },
           ],
         }
-        const result = flattenTextNodes(element, noSkip)
+        const result = flattenTextNodes(element, noSkip, 0)
         expect(result).toHaveLength(2)
         expect(result.map((n) => n.value)).toEqual(["Hello ", "world"])
       })
@@ -371,7 +371,7 @@ describe("rehypePunctilio", () => {
             { type: "text", value: " end" },
           ],
         }
-        const result = flattenTextNodes(element, noSkip)
+        const result = flattenTextNodes(element, noSkip, 0)
         expect(result).toHaveLength(3)
         expect(result.map((n) => n.value)).toEqual(["Start ", "middle", " end"])
       })
@@ -392,7 +392,7 @@ describe("rehypePunctilio", () => {
             { type: "text", value: " after" },
           ],
         }
-        const result = flattenTextNodes(element, skipCode)
+        const result = flattenTextNodes(element, skipCode, 0)
         expect(result).toHaveLength(2)
         expect(result.map((n) => n.value)).toEqual(["Before ", " after"])
       })
@@ -404,7 +404,7 @@ describe("rehypePunctilio", () => {
           properties: {},
           children: [{ type: "text", value: "content" }],
         }
-        const result = flattenTextNodes(element, skipCode)
+        const result = flattenTextNodes(element, skipCode, 0)
         expect(result).toHaveLength(0)
       })
 
@@ -418,7 +418,7 @@ describe("rehypePunctilio", () => {
             { type: "comment", value: "comment" } as unknown as ElementContent,
           ],
         }
-        const result = flattenTextNodes(element, noSkip)
+        const result = flattenTextNodes(element, noSkip, 0)
         expect(result).toHaveLength(1)
         expect(result[0].value).toBe("text")
       })
@@ -440,7 +440,7 @@ describe("rehypePunctilio", () => {
           }
         }
         // Should not throw and should return empty (text is beyond depth limit)
-        const result = flattenTextNodes(deepElement, noSkip)
+        const result = flattenTextNodes(deepElement, noSkip, 0)
         expect(result).toHaveLength(0)
       })
     })

--- a/src/tests/rehype.test.ts
+++ b/src/tests/rehype.test.ts
@@ -306,3 +306,23 @@ describe("rehypePunctilio", () => {
     })
   })
 })
+
+describe("separator injection protection", () => {
+  it("throws when transform injects separators", () => {
+    const element = h("p", "hello world") as Element
+    const maliciousTransform = (text: string): string =>
+      text.replace("hello", `hello${DEFAULT_SEPARATOR}injected`)
+    expect(() => {
+      transformElement(element, maliciousTransform, () => false, DEFAULT_SEPARATOR)
+    }).toThrow("Transformation altered the number of text nodes")
+  })
+
+  it("throws when transform removes separators", () => {
+    const element = h("p", ["hello ", h("em", "world")]) as Element
+    const maliciousTransform = (text: string): string =>
+      text.replace(DEFAULT_SEPARATOR, "")
+    expect(() => {
+      transformElement(element, maliciousTransform, () => false, DEFAULT_SEPARATOR)
+    }).toThrow("Transformation altered the number of text nodes")
+  })
+})

--- a/src/tests/rehype.test.ts
+++ b/src/tests/rehype.test.ts
@@ -422,6 +422,27 @@ describe("rehypePunctilio", () => {
         expect(result).toHaveLength(1)
         expect(result[0].value).toBe("text")
       })
+
+      it("stops recursion at max depth to prevent stack overflow", () => {
+        // Build a deeply nested structure that exceeds MAX_RECURSION_DEPTH (1000)
+        let deepElement: Element = {
+          type: "element",
+          tagName: "span",
+          properties: {},
+          children: [{ type: "text", value: "deep" }],
+        }
+        for (let i = 0; i < 1005; i++) {
+          deepElement = {
+            type: "element",
+            tagName: "div",
+            properties: {},
+            children: [deepElement],
+          }
+        }
+        // Should not throw and should return empty (text is beyond depth limit)
+        const result = flattenTextNodes(deepElement, noSkip)
+        expect(result).toHaveLength(0)
+      })
     })
 
     describe("transformElement", () => {

--- a/src/tests/rehype.test.ts
+++ b/src/tests/rehype.test.ts
@@ -1,0 +1,391 @@
+import { unified } from "unified"
+import rehypeParse from "rehype-parse"
+import rehypeStringify from "rehype-stringify"
+import { rehypePunctilio, type RehypePunctilioOptions } from "../rehype.js"
+import { UNICODE_SYMBOLS } from "../constants.js"
+
+const {
+  LEFT_DOUBLE_QUOTE,
+  RIGHT_DOUBLE_QUOTE,
+  RIGHT_SINGLE_QUOTE,
+  EM_DASH,
+  EN_DASH,
+  ELLIPSIS,
+  MULTIPLICATION,
+  NOT_EQUAL,
+  COPYRIGHT,
+} = UNICODE_SYMBOLS
+
+/**
+ * Helper function to process HTML through the rehype-punctilio plugin.
+ */
+async function processHtml(html: string, options?: RehypePunctilioOptions): Promise<string> {
+  const result = await unified()
+    .use(rehypeParse, { fragment: true })
+    .use(rehypePunctilio, options)
+    .use(rehypeStringify)
+    .process(html)
+
+  return String(result)
+}
+
+describe("rehypePunctilio", () => {
+  describe("basic transformations", () => {
+    it("transforms straight quotes to smart quotes", async () => {
+      const html = '<p>"Hello," she said.</p>'
+      const result = await processHtml(html)
+      expect(result).toContain(LEFT_DOUBLE_QUOTE)
+      expect(result).toContain(RIGHT_DOUBLE_QUOTE)
+    })
+
+    it("transforms apostrophes", async () => {
+      const html = "<p>It's a test.</p>"
+      const result = await processHtml(html)
+      expect(result).toContain(RIGHT_SINGLE_QUOTE)
+    })
+
+    it("transforms em dashes", async () => {
+      const html = "<p>Wait -- here it comes.</p>"
+      const result = await processHtml(html)
+      expect(result).toContain(EM_DASH)
+    })
+
+    it("transforms en dashes for number ranges", async () => {
+      const html = "<p>Pages 1-5</p>"
+      const result = await processHtml(html)
+      expect(result).toContain(EN_DASH)
+    })
+
+    it("transforms ellipses", async () => {
+      const html = "<p>Wait...</p>"
+      const result = await processHtml(html)
+      expect(result).toContain(ELLIPSIS)
+    })
+
+    it("transforms multiplication signs", async () => {
+      const html = "<p>5x5</p>"
+      const result = await processHtml(html)
+      expect(result).toContain(MULTIPLICATION)
+    })
+
+    it("transforms math symbols", async () => {
+      const html = "<p>x != y</p>"
+      const result = await processHtml(html)
+      expect(result).toContain(NOT_EQUAL)
+    })
+
+    it("transforms legal symbols", async () => {
+      const html = "<p>(c) 2024</p>"
+      const result = await processHtml(html)
+      expect(result).toContain(COPYRIGHT)
+    })
+  })
+
+  describe("HTML structure preservation", () => {
+    it("preserves nested HTML structure", async () => {
+      const html = '<p><em>"Hello,"</em> she said.</p>'
+      const result = await processHtml(html)
+      expect(result).toContain("<em>")
+      expect(result).toContain("</em>")
+    })
+
+    it("handles text spanning multiple elements", async () => {
+      const html = '<p><em>"Wait</em>..."</p>'
+      const result = await processHtml(html)
+      // Should transform the quotes correctly despite spanning elements
+      expect(result).toContain(LEFT_DOUBLE_QUOTE)
+      expect(result).toContain(RIGHT_DOUBLE_QUOTE)
+      expect(result).toContain(ELLIPSIS)
+    })
+
+    it("handles deeply nested elements", async () => {
+      const html = '<div><p><span><strong>"Hello"</strong></span></p></div>'
+      const result = await processHtml(html)
+      expect(result).toContain(LEFT_DOUBLE_QUOTE)
+      expect(result).toContain(RIGHT_DOUBLE_QUOTE)
+    })
+
+    it("preserves attributes on elements", async () => {
+      const html = '<p class="intro" id="first">"Hello"</p>'
+      const result = await processHtml(html)
+      expect(result).toContain('class="intro"')
+      expect(result).toContain('id="first"')
+    })
+  })
+
+  describe("skipped elements", () => {
+    it.each([
+      ["code", '<code>"Hello"</code>'],
+      ["pre", '<pre>"Hello"</pre>'],
+      ["script", '<script>"Hello"</script>'],
+      ["style", '<style>"Hello"</style>'],
+      ["kbd", '<kbd>"Hello"</kbd>'],
+      ["var", '<var>"Hello"</var>'],
+      ["samp", '<samp>"Hello"</samp>'],
+    ])("skips %s elements", async (_tag, html) => {
+      const result = await processHtml(html)
+      expect(result).toContain('"Hello"')
+      expect(result).not.toContain(LEFT_DOUBLE_QUOTE)
+    })
+
+    it("skips nested content inside code blocks", async () => {
+      const html = '<pre><code>"Hello" -- test...</code></pre>'
+      const result = await processHtml(html)
+      expect(result).toContain('"Hello"')
+      expect(result).toContain("--")
+      expect(result).toContain("...")
+    })
+
+    it("transforms siblings of skipped elements", async () => {
+      const html = '<p><code>code</code> "Hello"</p>'
+      const result = await processHtml(html)
+      expect(result).toContain(LEFT_DOUBLE_QUOTE)
+      expect(result).toContain(RIGHT_DOUBLE_QUOTE)
+    })
+  })
+
+  describe("custom skip options", () => {
+    it("skips custom tags", async () => {
+      const html = '<custom-tag>"Hello"</custom-tag>'
+      const result = await processHtml(html, { skipTags: ["custom-tag"] })
+      expect(result).toContain('"Hello"')
+    })
+
+    it("skips elements with custom classes", async () => {
+      const html = '<p class="no-transform">"Hello"</p>'
+      const result = await processHtml(html, { skipClasses: ["no-transform"] })
+      expect(result).toContain('"Hello"')
+    })
+
+    it("skips descendants of elements with skip classes", async () => {
+      const html = '<div class="raw"><p>"Hello"</p></div>'
+      const result = await processHtml(html, { skipClasses: ["raw"] })
+      expect(result).toContain('"Hello"')
+    })
+  })
+
+  describe("transform options passthrough", () => {
+    it("respects punctuationStyle option", async () => {
+      const html = '<p>"Hello."</p>'
+
+      const americanResult = await processHtml(html, { punctuationStyle: "american" })
+      expect(americanResult).toContain(`${LEFT_DOUBLE_QUOTE}Hello.${RIGHT_DOUBLE_QUOTE}`)
+
+      const britishResult = await processHtml(html, { punctuationStyle: "british" })
+      expect(britishResult).toContain(`${LEFT_DOUBLE_QUOTE}Hello${RIGHT_DOUBLE_QUOTE}.`)
+    })
+
+    it("respects dashStyle option", async () => {
+      const html = "<p>word - word</p>"
+
+      const americanResult = await processHtml(html, { dashStyle: "american" })
+      expect(americanResult).toContain(EM_DASH)
+
+      const britishResult = await processHtml(html, { dashStyle: "british" })
+      expect(britishResult).toContain(EN_DASH)
+    })
+
+    it("respects symbols option", async () => {
+      const html = "<p>5x5</p>"
+
+      const withSymbols = await processHtml(html, { symbols: true })
+      expect(withSymbols).toContain(MULTIPLICATION)
+
+      const withoutSymbols = await processHtml(html, { symbols: false })
+      expect(withoutSymbols).toContain("5x5")
+    })
+
+    it("respects fractions option", async () => {
+      const html = "<p>1/2 cup</p>"
+
+      const withFractions = await processHtml(html, { fractions: true })
+      expect(withFractions).toContain(UNICODE_SYMBOLS.FRACTION_1_2)
+
+      const withoutFractions = await processHtml(html, { fractions: false })
+      expect(withoutFractions).toContain("1/2")
+    })
+  })
+
+  describe("complex real-world scenarios", () => {
+    it("handles article content with multiple paragraph types", async () => {
+      const html = `
+        <article>
+          <h1>"The Article's Title"</h1>
+          <p>First paragraph with "quotes" and dashes -- like this.</p>
+          <blockquote>A quote: "Something meaningful..."</blockquote>
+          <p>Pages 1-5 contain the introduction.</p>
+        </article>
+      `
+      const result = await processHtml(html)
+      expect(result).toContain(LEFT_DOUBLE_QUOTE)
+      expect(result).toContain(RIGHT_DOUBLE_QUOTE)
+      expect(result).toContain(RIGHT_SINGLE_QUOTE)
+      expect(result).toContain(EM_DASH)
+      expect(result).toContain(EN_DASH)
+      expect(result).toContain(ELLIPSIS)
+    })
+
+    it("handles mixed content with code and prose", async () => {
+      const html = `
+        <p>The function <code>getValue()</code> returns "the value" -- which is useful.</p>
+      `
+      const result = await processHtml(html)
+      expect(result).toContain("getValue()")
+      expect(result).toContain(LEFT_DOUBLE_QUOTE)
+      expect(result).toContain(RIGHT_DOUBLE_QUOTE)
+      expect(result).toContain(EM_DASH)
+    })
+
+    it("handles table content", async () => {
+      const html = `
+        <table>
+          <tr>
+            <th>"Header"</th>
+            <td>Pages 1-5</td>
+          </tr>
+        </table>
+      `
+      const result = await processHtml(html)
+      expect(result).toContain(LEFT_DOUBLE_QUOTE)
+      expect(result).toContain(RIGHT_DOUBLE_QUOTE)
+      expect(result).toContain(EN_DASH)
+    })
+
+    it("handles list content", async () => {
+      const html = `
+        <ul>
+          <li>"First item" -- important</li>
+          <li>Pages 1-5</li>
+        </ul>
+      `
+      const result = await processHtml(html)
+      expect(result).toContain(LEFT_DOUBLE_QUOTE)
+      expect(result).toContain(EM_DASH)
+      expect(result).toContain(EN_DASH)
+    })
+  })
+
+  describe("edge cases", () => {
+    it("handles empty paragraphs", async () => {
+      const html = "<p></p>"
+      const result = await processHtml(html)
+      expect(result).toBe("<p></p>")
+    })
+
+    it("handles whitespace-only content", async () => {
+      const html = "<p>   </p>"
+      const result = await processHtml(html)
+      expect(result).toContain("<p>")
+    })
+
+    it("handles special characters", async () => {
+      const html = "<p>Café &amp; résumé</p>"
+      const result = await processHtml(html)
+      expect(result).toContain("Café")
+      expect(result).toContain("résumé")
+    })
+
+    it("handles emoji", async () => {
+      const html = '<p>"Hello 👋 world"</p>'
+      const result = await processHtml(html)
+      expect(result).toContain("👋")
+      expect(result).toContain(LEFT_DOUBLE_QUOTE)
+    })
+
+    it("handles links", async () => {
+      const html = '<p><a href="https://example.com">"Link text"</a></p>'
+      const result = await processHtml(html)
+      expect(result).toContain('href="https://example.com"')
+      expect(result).toContain(LEFT_DOUBLE_QUOTE)
+    })
+
+    it("is idempotent", async () => {
+      const html = '<p>"Hello," she said -- "it\'s nice."</p>'
+      const firstPass = await processHtml(html)
+      const secondPass = await processHtml(firstPass)
+      expect(secondPass).toBe(firstPass)
+    })
+  })
+
+  describe("default export", () => {
+    it("exports rehypePunctilio as default", async () => {
+      const { default: defaultExport } = await import("../rehype.js")
+      expect(defaultExport).toBe(rehypePunctilio)
+    })
+  })
+
+  describe("edge cases for coverage", () => {
+    it("handles class attribute as space-separated string", async () => {
+      // Tests the string className branch in hasClass
+      const html = '<p class="foo bar no-transform baz">"Hello"</p>'
+      const result = await processHtml(html, { skipClasses: ["no-transform"] })
+      expect(result).toContain('"Hello"')
+      expect(result).not.toContain(LEFT_DOUBLE_QUOTE)
+    })
+
+    it("handles HTML comments (non-element, non-text nodes)", async () => {
+      // Tests the return [] branch in flattenTextNodes for comment nodes
+      const html = '<p>"Hello"<!-- comment --></p>'
+      const result = await processHtml(html)
+      expect(result).toContain(LEFT_DOUBLE_QUOTE)
+      expect(result).toContain("<!-- comment -->")
+    })
+
+    it("handles elements with only non-text children", async () => {
+      // Tests the textNodes.length === 0 branch in transformElement
+      const html = '<div><img src="test.jpg" alt="test"></div>'
+      const result = await processHtml(html)
+      expect(result).toContain('<img src="test.jpg"')
+    })
+
+    it("handles skip class at root element level", async () => {
+      // Tests the shouldSkip early return in collectTransformableElements
+      const html = '<p class="skip-this">"Hello"</p>'
+      const result = await processHtml(html, { skipClasses: ["skip-this"] })
+      expect(result).toContain('"Hello"')
+    })
+
+    it("handles elements without children property", async () => {
+      // Tests the !node?.children early return in transformElement
+      // This is mainly defensive code, but can be triggered by raw HTML
+      const html = '<p>"Test"</p>'
+      const result = await processHtml(html)
+      expect(result).toContain(LEFT_DOUBLE_QUOTE)
+    })
+
+    it("handles nested skipped elements correctly", async () => {
+      // Element that should be skipped containing transformable content
+      const html = '<pre><p>"Hello"</p></pre>'
+      const result = await processHtml(html)
+      expect(result).toContain('"Hello"')
+    })
+
+    it("handles multiple skip classes on same element", async () => {
+      const html = '<p class="class-a class-b">"Hello"</p>'
+      const result = await processHtml(html, { skipClasses: ["class-b"] })
+      expect(result).toContain('"Hello"')
+    })
+
+    it("handles skipped child elements within non-skipped parents", async () => {
+      // This tests the shouldSkip early return in collectTransformableElements
+      // The div is not skipped, but its child code element is
+      const html = '<div>"Before" <code>"Inside code"</code> "After"</div>'
+      const result = await processHtml(html)
+      // The quotes outside code should be transformed
+      expect(result).toContain(LEFT_DOUBLE_QUOTE)
+      expect(result).toContain(RIGHT_DOUBLE_QUOTE)
+      // But the content inside code should not
+      expect(result).toContain('"Inside code"')
+    })
+
+    it("handles nested structure with mixed skip and non-skip elements", async () => {
+      const html = '<article><p>"Hello"</p><pre>"Code"</pre><p>"World"</p></article>'
+      const result = await processHtml(html)
+      // p elements should be transformed
+      expect(result).toMatch(new RegExp(`<p>${LEFT_DOUBLE_QUOTE}Hello${RIGHT_DOUBLE_QUOTE}</p>`))
+      expect(result).toMatch(new RegExp(`<p>${LEFT_DOUBLE_QUOTE}World${RIGHT_DOUBLE_QUOTE}</p>`))
+      // pre should not
+      expect(result).toContain('<pre>"Code"</pre>')
+    })
+  })
+})

--- a/src/tests/rehype.test.ts
+++ b/src/tests/rehype.test.ts
@@ -12,306 +12,152 @@ import {
 import { UNICODE_SYMBOLS, DEFAULT_SEPARATOR } from "../constants.js"
 
 const {
-  LEFT_DOUBLE_QUOTE,
-  RIGHT_DOUBLE_QUOTE,
-  RIGHT_SINGLE_QUOTE,
+  LEFT_DOUBLE_QUOTE: LDQ,
+  RIGHT_DOUBLE_QUOTE: RDQ,
+  RIGHT_SINGLE_QUOTE: RSQ,
   EM_DASH,
   EN_DASH,
   ELLIPSIS,
   MULTIPLICATION,
   NOT_EQUAL,
   COPYRIGHT,
+  FRACTION_1_2,
 } = UNICODE_SYMBOLS
 
-/**
- * Helper function to process HTML through the rehype-punctilio plugin.
- */
 async function processHtml(html: string, options?: RehypePunctilioOptions): Promise<string> {
   const result = await unified()
     .use(rehypeParse, { fragment: true })
     .use(rehypePunctilio, options)
     .use(rehypeStringify)
     .process(html)
-
   return String(result)
 }
 
 describe("rehypePunctilio", () => {
   describe("basic transformations", () => {
-    it("transforms straight quotes to smart quotes", async () => {
-      const html = '<p>"Hello," she said.</p>'
+    it.each([
+      ["quotes", '<p>"Hello," she said.</p>', [LDQ, RDQ]],
+      ["apostrophes", "<p>It's a test.</p>", [RSQ]],
+      ["em dashes", "<p>Wait -- here it comes.</p>", [EM_DASH]],
+      ["en dashes", "<p>Pages 1-5</p>", [EN_DASH]],
+      ["ellipses", "<p>Wait...</p>", [ELLIPSIS]],
+      ["multiplication", "<p>5x5</p>", [MULTIPLICATION]],
+      ["math symbols", "<p>x != y</p>", [NOT_EQUAL]],
+      ["legal symbols", "<p>(c) 2024</p>", [COPYRIGHT]],
+    ])("transforms %s", async (_name, html, expected) => {
       const result = await processHtml(html)
-      expect(result).toContain(LEFT_DOUBLE_QUOTE)
-      expect(result).toContain(RIGHT_DOUBLE_QUOTE)
-    })
-
-    it("transforms apostrophes", async () => {
-      const html = "<p>It's a test.</p>"
-      const result = await processHtml(html)
-      expect(result).toContain(RIGHT_SINGLE_QUOTE)
-    })
-
-    it("transforms em dashes", async () => {
-      const html = "<p>Wait -- here it comes.</p>"
-      const result = await processHtml(html)
-      expect(result).toContain(EM_DASH)
-    })
-
-    it("transforms en dashes for number ranges", async () => {
-      const html = "<p>Pages 1-5</p>"
-      const result = await processHtml(html)
-      expect(result).toContain(EN_DASH)
-    })
-
-    it("transforms ellipses", async () => {
-      const html = "<p>Wait...</p>"
-      const result = await processHtml(html)
-      expect(result).toContain(ELLIPSIS)
-    })
-
-    it("transforms multiplication signs", async () => {
-      const html = "<p>5x5</p>"
-      const result = await processHtml(html)
-      expect(result).toContain(MULTIPLICATION)
-    })
-
-    it("transforms math symbols", async () => {
-      const html = "<p>x != y</p>"
-      const result = await processHtml(html)
-      expect(result).toContain(NOT_EQUAL)
-    })
-
-    it("transforms legal symbols", async () => {
-      const html = "<p>(c) 2024</p>"
-      const result = await processHtml(html)
-      expect(result).toContain(COPYRIGHT)
+      expected.forEach((char) => expect(result).toContain(char))
     })
   })
 
   describe("HTML structure preservation", () => {
-    it("preserves nested HTML structure", async () => {
-      const html = '<p><em>"Hello,"</em> she said.</p>'
+    it.each([
+      ["nested elements", '<p><em>"Hello,"</em> she said.</p>', ["<em>", "</em>", LDQ, RDQ]],
+      ["text spanning elements", '<p><em>"Wait</em>..."</p>', [LDQ, RDQ, ELLIPSIS]],
+      ["deeply nested", '<div><p><span><strong>"Hello"</strong></span></p></div>', [LDQ, RDQ]],
+      ["attributes", '<p class="intro" id="first">"Hello"</p>', ['class="intro"', 'id="first"']],
+    ])("preserves %s", async (_name, html, expected) => {
       const result = await processHtml(html)
-      expect(result).toContain("<em>")
-      expect(result).toContain("</em>")
-    })
-
-    it("handles text spanning multiple elements", async () => {
-      const html = '<p><em>"Wait</em>..."</p>'
-      const result = await processHtml(html)
-      // Should transform the quotes correctly despite spanning elements
-      expect(result).toContain(LEFT_DOUBLE_QUOTE)
-      expect(result).toContain(RIGHT_DOUBLE_QUOTE)
-      expect(result).toContain(ELLIPSIS)
-    })
-
-    it("handles deeply nested elements", async () => {
-      const html = '<div><p><span><strong>"Hello"</strong></span></p></div>'
-      const result = await processHtml(html)
-      expect(result).toContain(LEFT_DOUBLE_QUOTE)
-      expect(result).toContain(RIGHT_DOUBLE_QUOTE)
-    })
-
-    it("preserves attributes on elements", async () => {
-      const html = '<p class="intro" id="first">"Hello"</p>'
-      const result = await processHtml(html)
-      expect(result).toContain('class="intro"')
-      expect(result).toContain('id="first"')
+      expected.forEach((str) => expect(result).toContain(str))
     })
   })
 
   describe("skipped elements", () => {
-    it.each([
-      ["code", '<code>"Hello"</code>'],
-      ["pre", '<pre>"Hello"</pre>'],
-      ["script", '<script>"Hello"</script>'],
-      ["style", '<style>"Hello"</style>'],
-      ["kbd", '<kbd>"Hello"</kbd>'],
-      ["var", '<var>"Hello"</var>'],
-      ["samp", '<samp>"Hello"</samp>'],
-    ])("skips %s elements", async (_tag, html) => {
-      const result = await processHtml(html)
-      expect(result).toContain('"Hello"')
-      expect(result).not.toContain(LEFT_DOUBLE_QUOTE)
-    })
+    it.each(["code", "pre", "script", "style", "kbd", "var", "samp"])(
+      "skips %s elements",
+      async (tag) => {
+        const result = await processHtml(`<${tag}>"Hello"</${tag}>`)
+        expect(result).toContain('"Hello"')
+        expect(result).not.toContain(LDQ)
+      }
+    )
 
     it("skips nested content inside code blocks", async () => {
-      const html = '<pre><code>"Hello" -- test...</code></pre>'
-      const result = await processHtml(html)
+      const result = await processHtml('<pre><code>"Hello" -- test...</code></pre>')
       expect(result).toContain('"Hello"')
       expect(result).toContain("--")
       expect(result).toContain("...")
     })
 
     it("transforms siblings of skipped elements", async () => {
-      const html = '<p><code>code</code> "Hello"</p>'
-      const result = await processHtml(html)
-      expect(result).toContain(LEFT_DOUBLE_QUOTE)
-      expect(result).toContain(RIGHT_DOUBLE_QUOTE)
+      const result = await processHtml('<p><code>code</code> "Hello"</p>')
+      expect(result).toContain(LDQ)
+      expect(result).toContain(RDQ)
     })
   })
 
   describe("custom skip options", () => {
-    it("skips custom tags", async () => {
-      const html = '<custom-tag>"Hello"</custom-tag>'
-      const result = await processHtml(html, { skipTags: ["custom-tag"] })
-      expect(result).toContain('"Hello"')
-    })
-
-    it("skips elements with custom classes", async () => {
-      const html = '<p class="no-transform">"Hello"</p>'
-      const result = await processHtml(html, { skipClasses: ["no-transform"] })
-      expect(result).toContain('"Hello"')
-    })
-
-    it("skips descendants of elements with skip classes", async () => {
-      const html = '<div class="raw"><p>"Hello"</p></div>'
-      const result = await processHtml(html, { skipClasses: ["raw"] })
+    it.each([
+      ["custom tags", '<custom-tag>"Hello"</custom-tag>', { skipTags: ["custom-tag"] }],
+      ["custom classes", '<p class="no-transform">"Hello"</p>', { skipClasses: ["no-transform"] }],
+      ["descendants of skip classes", '<div class="raw"><p>"Hello"</p></div>', { skipClasses: ["raw"] }],
+    ])("skips %s", async (_name, html, options) => {
+      const result = await processHtml(html, options)
       expect(result).toContain('"Hello"')
     })
   })
 
   describe("transform options passthrough", () => {
-    it("respects punctuationStyle option", async () => {
-      const html = '<p>"Hello."</p>'
-
-      const americanResult = await processHtml(html, { punctuationStyle: "american" })
-      expect(americanResult).toContain(`${LEFT_DOUBLE_QUOTE}Hello.${RIGHT_DOUBLE_QUOTE}`)
-
-      const britishResult = await processHtml(html, { punctuationStyle: "british" })
-      expect(britishResult).toContain(`${LEFT_DOUBLE_QUOTE}Hello${RIGHT_DOUBLE_QUOTE}.`)
+    it.each([
+      ["punctuationStyle american", '<p>"Hello."</p>', { punctuationStyle: "american" as const }, `${LDQ}Hello.${RDQ}`],
+      ["punctuationStyle british", '<p>"Hello."</p>', { punctuationStyle: "british" as const }, `${LDQ}Hello${RDQ}.`],
+      ["dashStyle american", "<p>word - word</p>", { dashStyle: "american" as const }, EM_DASH],
+      ["dashStyle british", "<p>word - word</p>", { dashStyle: "british" as const }, EN_DASH],
+      ["symbols enabled", "<p>5x5</p>", { symbols: true }, MULTIPLICATION],
+      ["fractions enabled", "<p>1/2 cup</p>", { fractions: true }, FRACTION_1_2],
+      ["custom separator", '<p>"Hello"</p>', { separator: "\uE001" }, LDQ],
+    ])("respects %s", async (_name, html, options, expected) => {
+      const result = await processHtml(html, options)
+      expect(result).toContain(expected)
     })
 
-    it("respects dashStyle option", async () => {
-      const html = "<p>word - word</p>"
-
-      const americanResult = await processHtml(html, { dashStyle: "american" })
-      expect(americanResult).toContain(EM_DASH)
-
-      const britishResult = await processHtml(html, { dashStyle: "british" })
-      expect(britishResult).toContain(EN_DASH)
-    })
-
-    it("respects symbols option", async () => {
-      const html = "<p>5x5</p>"
-
-      const withSymbols = await processHtml(html, { symbols: true })
-      expect(withSymbols).toContain(MULTIPLICATION)
-
-      const withoutSymbols = await processHtml(html, { symbols: false })
-      expect(withoutSymbols).toContain("5x5")
-    })
-
-    it("respects fractions option", async () => {
-      const html = "<p>1/2 cup</p>"
-
-      const withFractions = await processHtml(html, { fractions: true })
-      expect(withFractions).toContain(UNICODE_SYMBOLS.FRACTION_1_2)
-
-      const withoutFractions = await processHtml(html, { fractions: false })
-      expect(withoutFractions).toContain("1/2")
-    })
-
-    it("respects custom separator option", async () => {
-      const customSep = "\uE001"
-      const html = '<p>"Hello"</p>'
-      const result = await processHtml(html, { separator: customSep })
-      expect(result).toContain(LEFT_DOUBLE_QUOTE)
-      expect(result).toContain(RIGHT_DOUBLE_QUOTE)
+    it.each([
+      ["symbols disabled", "<p>5x5</p>", { symbols: false }, "5x5"],
+      ["fractions disabled", "<p>1/2 cup</p>", { fractions: false }, "1/2"],
+    ])("respects %s", async (_name, html, options, expected) => {
+      const result = await processHtml(html, options)
+      expect(result).toContain(expected)
     })
   })
 
-  describe("complex real-world scenarios", () => {
-    it("handles article content with multiple paragraph types", async () => {
-      const html = `
-        <article>
-          <h1>"The Article's Title"</h1>
-          <p>First paragraph with "quotes" and dashes -- like this.</p>
-          <blockquote>A quote: "Something meaningful..."</blockquote>
-          <p>Pages 1-5 contain the introduction.</p>
-        </article>
-      `
+  describe("complex scenarios", () => {
+    it.each([
+      [
+        "article content",
+        `<article><h1>"Title's"</h1><p>"quotes" -- dashes</p><p>Pages 1-5</p></article>`,
+        [LDQ, RDQ, RSQ, EM_DASH, EN_DASH],
+      ],
+      [
+        "mixed code and prose",
+        '<p>The function <code>getValue()</code> returns "the value" -- useful.</p>',
+        ["getValue()", LDQ, RDQ, EM_DASH],
+      ],
+      [
+        "table content",
+        '<table><tr><th>"Header"</th><td>Pages 1-5</td></tr></table>',
+        [LDQ, RDQ, EN_DASH],
+      ],
+      [
+        "list content",
+        '<ul><li>"First" -- important</li><li>Pages 1-5</li></ul>',
+        [LDQ, EM_DASH, EN_DASH],
+      ],
+    ])("handles %s", async (_name, html, expected) => {
       const result = await processHtml(html)
-      expect(result).toContain(LEFT_DOUBLE_QUOTE)
-      expect(result).toContain(RIGHT_DOUBLE_QUOTE)
-      expect(result).toContain(RIGHT_SINGLE_QUOTE)
-      expect(result).toContain(EM_DASH)
-      expect(result).toContain(EN_DASH)
-      expect(result).toContain(ELLIPSIS)
-    })
-
-    it("handles mixed content with code and prose", async () => {
-      const html = `
-        <p>The function <code>getValue()</code> returns "the value" -- which is useful.</p>
-      `
-      const result = await processHtml(html)
-      expect(result).toContain("getValue()")
-      expect(result).toContain(LEFT_DOUBLE_QUOTE)
-      expect(result).toContain(RIGHT_DOUBLE_QUOTE)
-      expect(result).toContain(EM_DASH)
-    })
-
-    it("handles table content", async () => {
-      const html = `
-        <table>
-          <tr>
-            <th>"Header"</th>
-            <td>Pages 1-5</td>
-          </tr>
-        </table>
-      `
-      const result = await processHtml(html)
-      expect(result).toContain(LEFT_DOUBLE_QUOTE)
-      expect(result).toContain(RIGHT_DOUBLE_QUOTE)
-      expect(result).toContain(EN_DASH)
-    })
-
-    it("handles list content", async () => {
-      const html = `
-        <ul>
-          <li>"First item" -- important</li>
-          <li>Pages 1-5</li>
-        </ul>
-      `
-      const result = await processHtml(html)
-      expect(result).toContain(LEFT_DOUBLE_QUOTE)
-      expect(result).toContain(EM_DASH)
-      expect(result).toContain(EN_DASH)
+      expected.forEach((str) => expect(result).toContain(str))
     })
   })
 
   describe("edge cases", () => {
-    it("handles empty paragraphs", async () => {
-      const html = "<p></p>"
+    it.each([
+      ["empty paragraphs", "<p></p>", "<p></p>"],
+      ["whitespace-only", "<p>   </p>", "<p>"],
+      ["special characters", "<p>Café &amp; résumé</p>", "Café"],
+      ["emoji", '<p>"Hello 👋"</p>', "👋"],
+      ["links", '<p><a href="https://example.com">"Link"</a></p>', 'href="https://example.com"'],
+    ])("handles %s", async (_name, html, expected) => {
       const result = await processHtml(html)
-      expect(result).toBe("<p></p>")
-    })
-
-    it("handles whitespace-only content", async () => {
-      const html = "<p>   </p>"
-      const result = await processHtml(html)
-      expect(result).toContain("<p>")
-    })
-
-    it("handles special characters", async () => {
-      const html = "<p>Café &amp; résumé</p>"
-      const result = await processHtml(html)
-      expect(result).toContain("Café")
-      expect(result).toContain("résumé")
-    })
-
-    it("handles emoji", async () => {
-      const html = '<p>"Hello 👋 world"</p>'
-      const result = await processHtml(html)
-      expect(result).toContain("👋")
-      expect(result).toContain(LEFT_DOUBLE_QUOTE)
-    })
-
-    it("handles links", async () => {
-      const html = '<p><a href="https://example.com">"Link text"</a></p>'
-      const result = await processHtml(html)
-      expect(result).toContain('href="https://example.com"')
-      expect(result).toContain(LEFT_DOUBLE_QUOTE)
+      expect(result).toContain(expected)
     })
 
     it("is idempotent", async () => {
@@ -333,15 +179,14 @@ describe("rehypePunctilio", () => {
     const ignoreNone = () => false
     const ignoreCode = (el: Element) => el.tagName === "code"
 
-    // Test nodes using hastscript for cleaner syntax
-    const testNodes = {
+    const fixtures = {
       empty: h("div", []) as Element,
       simple: h("p", "Hello, world!") as Element,
       nested: h("div", ["This is ", h("em", "emphasized"), " text."]) as Element,
       withCode: h("div", ["This is ", h("code", "ignored"), " text."]) as Element,
       emptyAndComment: h("div", [
         h("span"),
-        { type: "comment", value: "This is a comment" } as unknown as ElementContent,
+        { type: "comment", value: "comment" } as unknown as ElementContent,
       ]) as Element,
       deeplyNested: h("div", [
         "Level 1 ",
@@ -351,181 +196,112 @@ describe("rehypePunctilio", () => {
     }
 
     describe("flattenTextNodes", () => {
-      it("handles various node structures", () => {
-        expect(flattenTextNodes(testNodes.empty, ignoreNone)).toEqual([])
-        expect(flattenTextNodes(testNodes.simple, ignoreNone)).toEqual([
-          { type: "text", value: "Hello, world!" },
-        ])
-        expect(flattenTextNodes(testNodes.nested, ignoreNone)).toEqual([
+      it.each([
+        ["empty element", fixtures.empty, ignoreNone, []],
+        ["simple text", fixtures.simple, ignoreNone, [{ type: "text", value: "Hello, world!" }]],
+        ["nested elements", fixtures.nested, ignoreNone, [
           { type: "text", value: "This is " },
           { type: "text", value: "emphasized" },
           { type: "text", value: " text." },
-        ])
-        expect(flattenTextNodes(testNodes.withCode, ignoreCode)).toEqual([
+        ]],
+        ["with ignored code", fixtures.withCode, ignoreCode, [
           { type: "text", value: "This is " },
           { type: "text", value: " text." },
-        ])
-        expect(flattenTextNodes(testNodes.emptyAndComment, ignoreNone)).toEqual([])
-        expect(flattenTextNodes(testNodes.deeplyNested, ignoreNone)).toEqual([
+        ]],
+        ["empty spans and comments", fixtures.emptyAndComment, ignoreNone, []],
+        ["deeply nested", fixtures.deeplyNested, ignoreNone, [
           { type: "text", value: "Level 1 " },
           { type: "text", value: "Level 2 " },
           { type: "text", value: "Level 3" },
           { type: "text", value: " End" },
-        ])
+        ]],
+      ])("handles %s", (_name, node, skip, expected) => {
+        expect(flattenTextNodes(node, skip)).toEqual(expected)
       })
 
-      it("extracts text from a single text node", () => {
+      it("extracts from single text node", () => {
         const textNode: Text = { type: "text", value: "Hello" }
-        const result = flattenTextNodes(textNode, ignoreNone)
-        expect(result).toHaveLength(1)
-        expect(result[0].value).toBe("Hello")
+        expect(flattenTextNodes(textNode, ignoreNone)).toEqual([textNode])
       })
 
-      it("stops recursion at max depth to prevent stack overflow", () => {
-        let deepElement: Element = h("span", "deep") as Element
-        for (let i = 0; i < 1005; i++) {
-          deepElement = h("div", [deepElement]) as Element
-        }
-        const result = flattenTextNodes(deepElement, ignoreNone)
-        expect(result).toHaveLength(0)
+      it("stops at max recursion depth", () => {
+        let deep: Element = h("span", "deep") as Element
+        for (let i = 0; i < 1005; i++) deep = h("div", [deep]) as Element
+        expect(flattenTextNodes(deep, ignoreNone)).toHaveLength(0)
       })
     })
 
     describe("transformElement", () => {
       const toUpper = (s: string) => s.toUpperCase()
 
-      it("transforms text in a simple element", () => {
-        const element = h("p", "hello") as Element
-        transformElement(element, toUpper, ignoreNone, DEFAULT_SEPARATOR)
-        expect((element.children[0] as Text).value).toBe("HELLO")
+      it.each([
+        ["simple element", h("p", "hello"), "HELLO"],
+        ["custom separator", h("p", "hello"), "HELLO", "\uE001"],
+      ])("transforms %s", (_name, element, expected, sep = DEFAULT_SEPARATOR) => {
+        transformElement(element as Element, toUpper, ignoreNone, sep)
+        expect((element.children[0] as Text).value).toBe(expected)
       })
 
-      it("transforms text across multiple nodes preserving structure", () => {
+      it("transforms across multiple nodes", () => {
         const element = h("p", ["hello ", h("em", "world")]) as Element
         transformElement(element, toUpper, ignoreNone, DEFAULT_SEPARATOR)
         expect((element.children[0] as Text).value).toBe("HELLO ")
-        const em = element.children[1] as Element
-        expect((em.children[0] as Text).value).toBe("WORLD")
+        expect(((element.children[1] as Element).children[0] as Text).value).toBe("WORLD")
       })
 
-      it("skips elements matching the skip predicate", () => {
-        const element = h("p", [
-          "before ",
-          h("code", "unchanged"),
-          " after",
-        ]) as Element
+      it("skips matching elements", () => {
+        const element = h("p", ["before ", h("code", "unchanged"), " after"]) as Element
         transformElement(element, toUpper, ignoreCode, DEFAULT_SEPARATOR)
         expect((element.children[0] as Text).value).toBe("BEFORE ")
-        const code = element.children[1] as Element
-        expect((code.children[0] as Text).value).toBe("unchanged")
+        expect(((element.children[1] as Element).children[0] as Text).value).toBe("unchanged")
         expect((element.children[2] as Text).value).toBe(" AFTER")
       })
 
-      it("applies custom transform functions", () => {
-        const replaceHyphens = (s: string) => s.replace(/-/g, "–")
+      it("applies custom transforms", () => {
         const element = h("p", "pages 1-5") as Element
-        transformElement(element, replaceHyphens, ignoreNone, DEFAULT_SEPARATOR)
+        transformElement(element, (s) => s.replace(/-/g, "–"), ignoreNone, DEFAULT_SEPARATOR)
         expect((element.children[0] as Text).value).toBe("pages 1–5")
       })
 
-      it("works with custom separator", () => {
-        const element = h("p", "hello") as Element
-        transformElement(element, toUpper, ignoreNone, "\uE001")
-        expect((element.children[0] as Text).value).toBe("HELLO")
-      })
-    })
-
-    describe("transformElement error conditions", () => {
-      it("handles node with no children gracefully", () => {
-        const nodeWithoutChildren = h("div") as Element
-        nodeWithoutChildren.children = undefined as unknown as Element["children"]
-        const transform = (text: string) => text.toUpperCase()
-        // Should not throw - returns early for defensive reasons
-        expect(() => {
-          transformElement(nodeWithoutChildren, transform, ignoreNone, DEFAULT_SEPARATOR)
-        }).not.toThrow()
+      it("handles missing children gracefully", () => {
+        const node = h("div") as Element
+        node.children = undefined as unknown as Element["children"]
+        expect(() => transformElement(node, toUpper, ignoreNone, DEFAULT_SEPARATOR)).not.toThrow()
       })
 
-      it("throws error when transformation alters number of text nodes", () => {
-        const node = h("p", "hello world") as Element
-        const transform = (text: string): string =>
-          text.replace("hello", `hello${DEFAULT_SEPARATOR}extra${DEFAULT_SEPARATOR}`)
-        expect(() => {
-          transformElement(node, transform, ignoreNone, DEFAULT_SEPARATOR)
-        }).toThrow("Transformation altered the number of text nodes")
+      it("throws on altered text node count", () => {
+        const node = h("p", "hello") as Element
+        const badTransform = (s: string) => s.replace("hello", `hello${DEFAULT_SEPARATOR}extra${DEFAULT_SEPARATOR}`)
+        expect(() => transformElement(node, badTransform, ignoreNone, DEFAULT_SEPARATOR)).toThrow(
+          "Transformation altered the number of text nodes"
+        )
       })
     })
   })
 
-  describe("edge cases for coverage", () => {
-    it("handles class attribute as space-separated string", async () => {
-      // Tests the string className branch in hasClass
-      const html = '<p class="foo bar no-transform baz">"Hello"</p>'
-      const result = await processHtml(html, { skipClasses: ["no-transform"] })
-      expect(result).toContain('"Hello"')
-      expect(result).not.toContain(LEFT_DOUBLE_QUOTE)
+  describe("coverage edge cases", () => {
+    it.each([
+      ["space-separated class string", '<p class="foo bar no-transform">"Hello"</p>', { skipClasses: ["no-transform"] }, '"Hello"'],
+      ["HTML comments", '<p>"Hello"<!-- comment --></p>', {}, "<!-- comment -->"],
+      ["non-text children only", '<div><img src="test.jpg" alt="test"></div>', {}, '<img src="test.jpg"'],
+      ["skip class at root", '<p class="skip">"Hello"</p>', { skipClasses: ["skip"] }, '"Hello"'],
+      ["nested skipped elements", '<pre><p>"Hello"</p></pre>', {}, '"Hello"'],
+      ["multiple skip classes", '<p class="a b">"Hello"</p>', { skipClasses: ["b"] }, '"Hello"'],
+    ])("handles %s", async (_name, html, options, expected) => {
+      const result = await processHtml(html, options)
+      expect(result).toContain(expected)
     })
 
-    it("handles HTML comments (non-element, non-text nodes)", async () => {
-      // Tests the return [] branch in flattenTextNodes for comment nodes
-      const html = '<p>"Hello"<!-- comment --></p>'
-      const result = await processHtml(html)
-      expect(result).toContain(LEFT_DOUBLE_QUOTE)
-      expect(result).toContain("<!-- comment -->")
+    it("handles skipped child within non-skipped parent", async () => {
+      const result = await processHtml('<div>"Before" <code>"Inside"</code> "After"</div>')
+      expect(result).toContain(LDQ)
+      expect(result).toContain('"Inside"')
     })
 
-    it("handles elements with only non-text children", async () => {
-      // Tests the textNodes.length === 0 branch in transformElement
-      const html = '<div><img src="test.jpg" alt="test"></div>'
-      const result = await processHtml(html)
-      expect(result).toContain('<img src="test.jpg"')
-    })
-
-    it("handles skip class at root element level", async () => {
-      // Tests the shouldSkip early return in collectTransformableElements
-      const html = '<p class="skip-this">"Hello"</p>'
-      const result = await processHtml(html, { skipClasses: ["skip-this"] })
-      expect(result).toContain('"Hello"')
-    })
-
-    it("handles basic paragraph transformation", async () => {
-      const html = '<p>"Test"</p>'
-      const result = await processHtml(html)
-      expect(result).toContain(LEFT_DOUBLE_QUOTE)
-    })
-
-    it("handles nested skipped elements correctly", async () => {
-      // Element that should be skipped containing transformable content
-      const html = '<pre><p>"Hello"</p></pre>'
-      const result = await processHtml(html)
-      expect(result).toContain('"Hello"')
-    })
-
-    it("handles multiple skip classes on same element", async () => {
-      const html = '<p class="class-a class-b">"Hello"</p>'
-      const result = await processHtml(html, { skipClasses: ["class-b"] })
-      expect(result).toContain('"Hello"')
-    })
-
-    it("handles skipped child elements within non-skipped parents", async () => {
-      // This tests the shouldSkip early return in collectTransformableElements
-      // The div is not skipped, but its child code element is
-      const html = '<div>"Before" <code>"Inside code"</code> "After"</div>'
-      const result = await processHtml(html)
-      // The quotes outside code should be transformed
-      expect(result).toContain(LEFT_DOUBLE_QUOTE)
-      expect(result).toContain(RIGHT_DOUBLE_QUOTE)
-      // But the content inside code should not
-      expect(result).toContain('"Inside code"')
-    })
-
-    it("handles nested structure with mixed skip and non-skip elements", async () => {
-      const html = '<article><p>"Hello"</p><pre>"Code"</pre><p>"World"</p></article>'
-      const result = await processHtml(html)
-      // p elements should be transformed
-      expect(result).toMatch(new RegExp(`<p>${LEFT_DOUBLE_QUOTE}Hello${RIGHT_DOUBLE_QUOTE}</p>`))
-      expect(result).toMatch(new RegExp(`<p>${LEFT_DOUBLE_QUOTE}World${RIGHT_DOUBLE_QUOTE}</p>`))
-      // pre should not
+    it("handles mixed skip and non-skip siblings", async () => {
+      const result = await processHtml('<article><p>"Hello"</p><pre>"Code"</pre><p>"World"</p></article>')
+      expect(result).toMatch(new RegExp(`<p>${LDQ}Hello${RDQ}</p>`))
+      expect(result).toMatch(new RegExp(`<p>${LDQ}World${RDQ}</p>`))
       expect(result).toContain('<pre>"Code"</pre>')
     })
   })

--- a/src/tests/rehype.test.ts
+++ b/src/tests/rehype.test.ts
@@ -36,29 +36,27 @@ async function processHtml(html: string, options?: RehypePunctilioOptions): Prom
 describe("rehypePunctilio", () => {
   describe("basic transformations", () => {
     it.each([
-      ["quotes", '<p>"Hello," she said.</p>', [LDQ, RDQ]],
-      ["apostrophes", "<p>It's a test.</p>", [RSQ]],
-      ["em dashes", "<p>Wait -- here it comes.</p>", [EM_DASH]],
-      ["en dashes", "<p>Pages 1-5</p>", [EN_DASH]],
-      ["ellipses", "<p>Wait...</p>", [ELLIPSIS]],
-      ["multiplication", "<p>5x5</p>", [MULTIPLICATION]],
-      ["math symbols", "<p>x != y</p>", [NOT_EQUAL]],
-      ["legal symbols", "<p>(c) 2024</p>", [COPYRIGHT]],
+      ["quotes", '<p>"Hello," she said.</p>', `<p>${LDQ}Hello,${RDQ} she said.</p>`],
+      ["apostrophes", "<p>It's a test.</p>", `<p>It${RSQ}s a test.</p>`],
+      ["em dashes", "<p>Wait -- here it comes.</p>", `<p>Wait${EM_DASH}here it comes.</p>`],
+      ["en dashes", "<p>Pages 1-5</p>", `<p>Pages 1${EN_DASH}5</p>`],
+      ["ellipses", "<p>Wait...</p>", `<p>Wait${ELLIPSIS}</p>`],
+      ["multiplication", "<p>5x5</p>", `<p>5${MULTIPLICATION}5</p>`],
+      ["math symbols", "<p>x != y</p>", `<p>x ${NOT_EQUAL} y</p>`],
+      ["legal symbols", "<p>(c) 2024</p>", `<p>${COPYRIGHT} 2024</p>`],
     ])("transforms %s", async (_name, html, expected) => {
-      const result = await processHtml(html)
-      expected.forEach((char) => expect(result).toContain(char))
+      expect(await processHtml(html)).toEqual(expected)
     })
   })
 
   describe("HTML structure preservation", () => {
     it.each([
-      ["nested elements", '<p><em>"Hello,"</em> she said.</p>', ["<em>", "</em>", LDQ, RDQ]],
-      ["text spanning elements", '<p><em>"Wait</em>..."</p>', [LDQ, RDQ, ELLIPSIS]],
-      ["deeply nested", '<div><p><span><strong>"Hello"</strong></span></p></div>', [LDQ, RDQ]],
-      ["attributes", '<p class="intro" id="first">"Hello"</p>', ['class="intro"', 'id="first"']],
+      ["nested elements", '<p><em>"Hello,"</em> she said.</p>', `<p><em>${LDQ}Hello,${RDQ}</em> she said.</p>`],
+      ["text spanning elements", '<p><em>"Wait</em>..."</p>', `<p><em>${LDQ}Wait</em>${ELLIPSIS}${RDQ}</p>`],
+      ["deeply nested", '<div><p><span><strong>"Hello"</strong></span></p></div>', `<div><p><span><strong>${LDQ}Hello${RDQ}</strong></span></p></div>`],
+      ["attributes", '<p class="intro" id="first">"Hello"</p>', `<p class="intro" id="first">${LDQ}Hello${RDQ}</p>`],
     ])("preserves %s", async (_name, html, expected) => {
-      const result = await processHtml(html)
-      expected.forEach((str) => expect(result).toContain(str))
+      expect(await processHtml(html)).toEqual(expected)
     })
   })
 
@@ -66,57 +64,46 @@ describe("rehypePunctilio", () => {
     it.each(["code", "pre", "script", "style", "kbd", "var", "samp"])(
       "skips %s elements",
       async (tag) => {
-        const result = await processHtml(`<${tag}>"Hello"</${tag}>`)
-        expect(result).toContain('"Hello"')
-        expect(result).not.toContain(LDQ)
+        expect(await processHtml(`<${tag}>"Hello"</${tag}>`)).toEqual(`<${tag}>"Hello"</${tag}>`)
       }
     )
 
     it("skips nested content inside code blocks", async () => {
-      const result = await processHtml('<pre><code>"Hello" -- test...</code></pre>')
-      expect(result).toContain('"Hello"')
-      expect(result).toContain("--")
-      expect(result).toContain("...")
+      expect(await processHtml('<pre><code>"Hello" -- test...</code></pre>')).toEqual(
+        '<pre><code>"Hello" -- test...</code></pre>'
+      )
     })
 
     it("transforms siblings of skipped elements", async () => {
-      const result = await processHtml('<p><code>code</code> "Hello"</p>')
-      expect(result).toContain(LDQ)
-      expect(result).toContain(RDQ)
+      expect(await processHtml('<p><code>code</code> "Hello"</p>')).toEqual(
+        `<p><code>code</code> ${LDQ}Hello${RDQ}</p>`
+      )
     })
   })
 
   describe("custom skip options", () => {
     it.each([
-      ["custom tags", '<custom-tag>"Hello"</custom-tag>', { skipTags: ["custom-tag"] }],
-      ["custom classes", '<p class="no-transform">"Hello"</p>', { skipClasses: ["no-transform"] }],
-      ["descendants of skip classes", '<div class="raw"><p>"Hello"</p></div>', { skipClasses: ["raw"] }],
-    ])("skips %s", async (_name, html, options) => {
-      const result = await processHtml(html, options)
-      expect(result).toContain('"Hello"')
+      ["custom tags", '<custom-tag>"Hello"</custom-tag>', { skipTags: ["custom-tag"] }, '<custom-tag>"Hello"</custom-tag>'],
+      ["custom classes", '<p class="no-transform">"Hello"</p>', { skipClasses: ["no-transform"] }, '<p class="no-transform">"Hello"</p>'],
+      ["descendants of skip classes", '<div class="raw"><p>"Hello"</p></div>', { skipClasses: ["raw"] }, '<div class="raw"><p>"Hello"</p></div>'],
+    ])("skips %s", async (_name, html, options, expected) => {
+      expect(await processHtml(html, options)).toEqual(expected)
     })
   })
 
   describe("transform options passthrough", () => {
     it.each([
-      ["punctuationStyle american", '<p>"Hello."</p>', { punctuationStyle: "american" as const }, `${LDQ}Hello.${RDQ}`],
-      ["punctuationStyle british", '<p>"Hello."</p>', { punctuationStyle: "british" as const }, `${LDQ}Hello${RDQ}.`],
-      ["dashStyle american", "<p>word - word</p>", { dashStyle: "american" as const }, EM_DASH],
-      ["dashStyle british", "<p>word - word</p>", { dashStyle: "british" as const }, EN_DASH],
-      ["symbols enabled", "<p>5x5</p>", { symbols: true }, MULTIPLICATION],
-      ["fractions enabled", "<p>1/2 cup</p>", { fractions: true }, FRACTION_1_2],
-      ["custom separator", '<p>"Hello"</p>', { separator: "\uE001" }, LDQ],
+      ["punctuationStyle american", '<p>"Hello."</p>', { punctuationStyle: "american" as const }, `<p>${LDQ}Hello.${RDQ}</p>`],
+      ["punctuationStyle british", '<p>"Hello."</p>', { punctuationStyle: "british" as const }, `<p>${LDQ}Hello${RDQ}.</p>`],
+      ["dashStyle american", "<p>word - word</p>", { dashStyle: "american" as const }, `<p>word${EM_DASH}word</p>`],
+      ["dashStyle british", "<p>word - word</p>", { dashStyle: "british" as const }, `<p>word ${EN_DASH} word</p>`],
+      ["symbols enabled", "<p>5x5</p>", { symbols: true }, `<p>5${MULTIPLICATION}5</p>`],
+      ["symbols disabled", "<p>5x5</p>", { symbols: false }, "<p>5x5</p>"],
+      ["fractions enabled", "<p>1/2 cup</p>", { fractions: true }, `<p>${FRACTION_1_2} cup</p>`],
+      ["fractions disabled", "<p>1/2 cup</p>", { fractions: false }, "<p>1/2 cup</p>"],
+      ["custom separator", '<p>"Hello"</p>', { separator: "\uE001" }, `<p>${LDQ}Hello${RDQ}</p>`],
     ])("respects %s", async (_name, html, options, expected) => {
-      const result = await processHtml(html, options)
-      expect(result).toContain(expected)
-    })
-
-    it.each([
-      ["symbols disabled", "<p>5x5</p>", { symbols: false }, "5x5"],
-      ["fractions disabled", "<p>1/2 cup</p>", { fractions: false }, "1/2"],
-    ])("respects %s", async (_name, html, options, expected) => {
-      const result = await processHtml(html, options)
-      expect(result).toContain(expected)
+      expect(await processHtml(html, options)).toEqual(expected)
     })
   })
 
@@ -125,39 +112,37 @@ describe("rehypePunctilio", () => {
       [
         "article content",
         `<article><h1>"Title's"</h1><p>"quotes" -- dashes</p><p>Pages 1-5</p></article>`,
-        [LDQ, RDQ, RSQ, EM_DASH, EN_DASH],
+        `<article><h1>${LDQ}Title${RSQ}s${RDQ}</h1><p>${LDQ}quotes${RDQ}${EM_DASH}dashes</p><p>Pages 1${EN_DASH}5</p></article>`,
       ],
       [
         "mixed code and prose",
         '<p>The function <code>getValue()</code> returns "the value" -- useful.</p>',
-        ["getValue()", LDQ, RDQ, EM_DASH],
+        `<p>The function <code>getValue()</code> returns ${LDQ}the value${RDQ}${EM_DASH}useful.</p>`,
       ],
       [
         "table content",
         '<table><tr><th>"Header"</th><td>Pages 1-5</td></tr></table>',
-        [LDQ, RDQ, EN_DASH],
+        `<table><tbody><tr><th>${LDQ}Header${RDQ}</th><td>Pages 1${EN_DASH}5</td></tr></tbody></table>`,
       ],
       [
         "list content",
         '<ul><li>"First" -- important</li><li>Pages 1-5</li></ul>',
-        [LDQ, EM_DASH, EN_DASH],
+        `<ul><li>${LDQ}First${RDQ}${EM_DASH}important</li><li>Pages 1${EN_DASH}5</li></ul>`,
       ],
     ])("handles %s", async (_name, html, expected) => {
-      const result = await processHtml(html)
-      expected.forEach((str) => expect(result).toContain(str))
+      expect(await processHtml(html)).toEqual(expected)
     })
   })
 
   describe("edge cases", () => {
     it.each([
       ["empty paragraphs", "<p></p>", "<p></p>"],
-      ["whitespace-only", "<p>   </p>", "<p>"],
-      ["special characters", "<p>Café &amp; résumé</p>", "Café"],
-      ["emoji", '<p>"Hello 👋"</p>', "👋"],
-      ["links", '<p><a href="https://example.com">"Link"</a></p>', 'href="https://example.com"'],
+      ["whitespace-only", "<p>   </p>", "<p> </p>"],
+      ["special characters", "<p>Café &amp; résumé</p>", "<p>Café &#x26; résumé</p>"],
+      ["emoji", '<p>"Hello 👋"</p>', `<p>${LDQ}Hello 👋${RDQ}</p>`],
+      ["links", '<p><a href="https://example.com">"Link"</a></p>', `<p><a href="https://example.com">${LDQ}Link${RDQ}</a></p>`],
     ])("handles %s", async (_name, html, expected) => {
-      const result = await processHtml(html)
-      expect(result).toContain(expected)
+      expect(await processHtml(html)).toEqual(expected)
     })
 
     it("is idempotent", async () => {
@@ -282,28 +267,26 @@ describe("rehypePunctilio", () => {
 
   describe("coverage edge cases", () => {
     it.each([
-      ["space-separated class string", '<p class="foo bar no-transform">"Hello"</p>', { skipClasses: ["no-transform"] }, '"Hello"'],
-      ["HTML comments", '<p>"Hello"<!-- comment --></p>', {}, "<!-- comment -->"],
-      ["non-text children only", '<div><img src="test.jpg" alt="test"></div>', {}, '<img src="test.jpg"'],
-      ["skip class at root", '<p class="skip">"Hello"</p>', { skipClasses: ["skip"] }, '"Hello"'],
-      ["nested skipped elements", '<pre><p>"Hello"</p></pre>', {}, '"Hello"'],
-      ["multiple skip classes", '<p class="a b">"Hello"</p>', { skipClasses: ["b"] }, '"Hello"'],
+      ["space-separated class string", '<p class="foo bar no-transform">"Hello"</p>', { skipClasses: ["no-transform"] }, '<p class="foo bar no-transform">"Hello"</p>'],
+      ["HTML comments", '<p>"Hello"<!-- comment --></p>', {}, `<p>${LDQ}Hello${RDQ}<!-- comment --></p>`],
+      ["non-text children only", '<div><img src="test.jpg" alt="test"></div>', {}, '<div><img src="test.jpg" alt="test"></div>'],
+      ["skip class at root", '<p class="skip">"Hello"</p>', { skipClasses: ["skip"] }, '<p class="skip">"Hello"</p>'],
+      ["nested skipped elements", '<pre><p>"Hello"</p></pre>', {}, '<pre><p>"Hello"</p></pre>'],
+      ["multiple skip classes", '<p class="a b">"Hello"</p>', { skipClasses: ["b"] }, '<p class="a b">"Hello"</p>'],
     ])("handles %s", async (_name, html, options, expected) => {
-      const result = await processHtml(html, options)
-      expect(result).toContain(expected)
+      expect(await processHtml(html, options)).toEqual(expected)
     })
 
     it("handles skipped child within non-skipped parent", async () => {
-      const result = await processHtml('<div>"Before" <code>"Inside"</code> "After"</div>')
-      expect(result).toContain(LDQ)
-      expect(result).toContain('"Inside"')
+      expect(await processHtml('<div>"Before" <code>"Inside"</code> "After"</div>')).toEqual(
+        `<div>${LDQ}Before${RDQ} <code>"Inside"</code> ${LDQ}After${RDQ}</div>`
+      )
     })
 
     it("handles mixed skip and non-skip siblings", async () => {
-      const result = await processHtml('<article><p>"Hello"</p><pre>"Code"</pre><p>"World"</p></article>')
-      expect(result).toMatch(new RegExp(`<p>${LDQ}Hello${RDQ}</p>`))
-      expect(result).toMatch(new RegExp(`<p>${LDQ}World${RDQ}</p>`))
-      expect(result).toContain('<pre>"Code"</pre>')
+      expect(await processHtml('<article><p>"Hello"</p><pre>"Code"</pre><p>"World"</p></article>')).toEqual(
+        `<article><p>${LDQ}Hello${RDQ}</p><pre>"Code"</pre><p>${LDQ}World${RDQ}</p></article>`
+      )
     })
   })
 })

--- a/src/tests/rehype.test.ts
+++ b/src/tests/rehype.test.ts
@@ -204,6 +204,14 @@ describe("rehypePunctilio", () => {
       const withoutFractions = await processHtml(html, { fractions: false })
       expect(withoutFractions).toContain("1/2")
     })
+
+    it("respects custom separator option", async () => {
+      const customSep = "\uE001"
+      const html = '<p>"Hello"</p>'
+      const result = await processHtml(html, { separator: customSep })
+      expect(result).toContain(LEFT_DOUBLE_QUOTE)
+      expect(result).toContain(RIGHT_DOUBLE_QUOTE)
+    })
   })
 
   describe("complex real-world scenarios", () => {
@@ -345,9 +353,7 @@ describe("rehypePunctilio", () => {
       expect(result).toContain('"Hello"')
     })
 
-    it("handles elements without children property", async () => {
-      // Tests the !node?.children early return in transformElement
-      // This is mainly defensive code, but can be triggered by raw HTML
+    it("handles basic paragraph transformation", async () => {
       const html = '<p>"Test"</p>'
       const result = await processHtml(html)
       expect(result).toContain(LEFT_DOUBLE_QUOTE)

--- a/src/tests/utils.test.ts
+++ b/src/tests/utils.test.ts
@@ -1,4 +1,7 @@
-import { countSeparators, assertSeparatorCountPreserved } from "../utils.js"
+import { existsSync, readFileSync, unlinkSync } from "node:fs"
+import { tmpdir } from "node:os"
+
+import { countSeparators, assertSeparatorCountPreserved, formatErrorString } from "../utils.js"
 import { DEFAULT_SEPARATOR } from "../constants.js"
 
 describe("countSeparators", () => {
@@ -55,5 +58,41 @@ describe("assertSeparatorCountPreserved", () => {
         expect(() => assertSeparatorCountPreserved(original, transformed)).not.toThrow()
       }
     })
+  })
+})
+
+describe("formatErrorString", () => {
+  it("returns JSON-stringified content for short strings", () => {
+    const result = formatErrorString("short text", "test")
+    expect(result).toBe('"short text"')
+  })
+
+  it("writes to temp file for strings over 500 chars", () => {
+    const longText = "x".repeat(501)
+    const result = formatErrorString(longText, "long-test")
+
+    expect(result).toMatch(/^\[written to .+punctilio-error-long-test-\d+\.txt\]$/)
+
+    // Extract filepath and verify file contents
+    const match = result.match(/\[written to (?<path>.+)\]/)
+    const filepath = match?.groups?.path ?? ""
+    expect(filepath).not.toBe("")
+    expect(existsSync(filepath)).toBe(true)
+    expect(readFileSync(filepath, "utf-8")).toBe(longText)
+
+    // Cleanup
+    unlinkSync(filepath)
+  })
+
+  it("writes to temp directory", () => {
+    const longText = "y".repeat(600)
+    const result = formatErrorString(longText, "tmpdir")
+
+    const match = result.match(/\[written to (?<path>.+)\]/)
+    const filepath = match?.groups?.path ?? ""
+    expect(filepath).not.toBe("")
+    expect(filepath.startsWith(tmpdir())).toBe(true)
+
+    unlinkSync(filepath)
   })
 })

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -4,7 +4,30 @@
  * @module utils
  */
 
+import { writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+
 import { DEFAULT_SEPARATOR } from "./constants.js"
+
+/** Threshold above which strings are written to temp files in error messages. */
+const ERROR_STRING_THRESHOLD = 500
+
+/**
+ * Formats a string for error messages. If the string exceeds the threshold,
+ * writes it to a temp file and returns a reference to the file path.
+ */
+export function formatErrorString(content: string, label: string): string {
+  if (content.length <= ERROR_STRING_THRESHOLD) {
+    return JSON.stringify(content)
+  }
+
+  const timestamp = Date.now()
+  const filename = `punctilio-error-${label}-${timestamp}.txt`
+  const filepath = join(tmpdir(), filename)
+  writeFileSync(filepath, content, "utf-8")
+  return `[written to ${filepath}]`
+}
 
 export function countSeparators(text: string, separator: string = DEFAULT_SEPARATOR): number {
   let count = 0


### PR DESCRIPTION
## Summary

This PR adds a new rehype plugin that integrates punctilio typography transformations with the unified/rehype ecosystem, enabling smart typography improvements to be applied to HTML ASTs.

## Key Changes

- **New rehype plugin** (`src/rehype.ts`): Implements `rehypePunctilio` function that:
  - Applies punctilio text transformations to HTML elements while preserving document structure
  - Uses a marker-based technique to handle text spanning multiple HTML elements
  - Supports configurable skip lists for tags and CSS classes
  - Passes through all punctilio transform options (punctuation style, dash style, symbols, fractions, etc.)

- **Package exports**: Added `./rehype` export path to `package.json` for easy importing of the plugin

- **Dependencies**: 
  - Added `unist-util-visit-parents` as a production dependency for AST traversal
  - Added dev dependencies: `@types/hast`, `rehype-parse`, `rehype-stringify` for testing and type support
  - Added `unified` as an optional peer dependency

- **Comprehensive test suite** (`src/tests/rehype.test.ts`): 397 lines of tests covering:
  - Basic typography transformations (quotes, dashes, ellipses, symbols)
  - HTML structure preservation and nested elements
  - Default and custom skip behaviors
  - Transform option passthrough
  - Real-world scenarios (articles, code blocks, tables, lists)
  - Edge cases and idempotency

- **Keywords**: Updated package.json keywords to include rehype, rehype-plugin, unified, markdown, and html

## Implementation Details

The plugin uses a sophisticated text transformation approach:
1. Identifies transformable elements (paragraphs, headings, semantic elements, etc.)
2. Collects text nodes within each element
3. Appends a private-use Unicode separator to each text node
4. Concatenates and transforms the combined text
5. Splits the result back into original text nodes using the separator as a boundary marker

This technique allows punctilio's text-based transformations to work correctly even when text spans multiple HTML elements, while maintaining the original document structure.

Default skip tags include code, pre, script, style, kbd, var, and samp to prevent transformations in code and technical content.

https://claude.ai/code/session_01SGaGy9UWcj7BNsbYmZ19Ty