### PR TITLE
fix: escape separator in regex patterns to prevent injection

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -87,6 +87,12 @@ export const DEFAULT_SEPARATOR = "\uE000"
 export const ESCAPED_DEFAULT_SEPARATOR = escapeStringRegexp(DEFAULT_SEPARATOR)
 
 /**
+ * Characters that have special meaning in regular expressions.
+ * Used for testing that separator escaping works correctly.
+ */
+export const REGEX_SPECIAL_CHARS = [".", "*", "+", "?", "^", "$", "[", "]", "\\", "|", "(", ")"] as const
+
+/**
  * Creates a marker-aware word boundary pattern for the START of a match.
  *
  * Standard `\b` can create false boundaries when separator markers appear between

--- a/src/dashes.ts
+++ b/src/dashes.ts
@@ -107,7 +107,7 @@ export function enDashDateRange(text: string, options: DashOptions = {}): string
 
 /** Convert hyphens to minus signs in numeric contexts (e.g., "-5" → "−5"). */
 export function minusReplace(text: string, options: DashOptions = {}): string {
-  const chr = options.separator ?? DEFAULT_SEPARATOR
+  const chr = escapeStringRegexp(options.separator ?? DEFAULT_SEPARATOR)
   // Match after: start of line, whitespace, (, separator, or quotes (straight or curly)
   return text.replaceAll(
     new RegExp(`(?<before>^|[\\s\\("${chr}${LEFT_DOUBLE_QUOTE}${RIGHT_DOUBLE_QUOTE}])-(?<num>\\s?\\d*\\.?\\d+)`, "gm"),
@@ -123,24 +123,25 @@ function convertParentheticalDashes(text: string, sep: string, style: DashStyle)
   if (style === "none") return text
   const localizedDash = style === "british" ? EN_DASH : EM_DASH
   const maybeSpace = style === "british" ? " " : ""
+  const escapedSep = escapeStringRegexp(sep)
 
   // Convert spaced dashes: "word - word" or "word — word"
   text = text.replace(
-    new RegExp(`(?<=[^\\s]|^)(?:(?<sepBefore>${sep}?)[ ]+|(?<sepOnly>${sep}))[~${EN_DASH}${EM_DASH}-]+[ ]*(?<sepAfter>${sep}?)(?:[ ]+|$)`, "g"),
+    new RegExp(`(?<=[^\\s]|^)(?:(?<sepBefore>${escapedSep}?)[ ]+|(?<sepOnly>${escapedSep}))[~${EN_DASH}${EM_DASH}-]+[ ]*(?<sepAfter>${escapedSep}?)(?:[ ]+|$)`, "g"),
     `$<sepBefore>$<sepOnly>${maybeSpace}${localizedDash}${maybeSpace}$<sepAfter>`
   )
   // Convert multiple dashes: "word--word" or "word---word" or "quote"--"quote"
   const quoteChars = `"'${LEFT_DOUBLE_QUOTE}${RIGHT_DOUBLE_QUOTE}${LEFT_SINGLE_QUOTE}${RIGHT_SINGLE_QUOTE}`
   text = text.replace(
-    new RegExp(`(?<=[${LATIN_LETTERS}\\d${quoteChars}])(?<sepBefore>${sep}?)[~${EN_DASH}${EM_DASH}-]{2,}(?<sepAfter>${sep}?)(?=[${LATIN_LETTERS}${quoteChars} ])`, "g"),
+    new RegExp(`(?<=[${LATIN_LETTERS}\\d${quoteChars}])(?<sepBefore>${escapedSep}?)[~${EN_DASH}${EM_DASH}-]{2,}(?<sepAfter>${escapedSep}?)(?=[${LATIN_LETTERS}${quoteChars} ])`, "g"),
     `$<sepBefore>${maybeSpace}${localizedDash}${maybeSpace}$<sepAfter>`
   )
   // Convert dashes at start of line
-  text = text.replace(new RegExp(`^(?<leadingSep>${sep})?[-]+ `, "gm"), `$<leadingSep>${localizedDash} `)
+  text = text.replace(new RegExp(`^(?<leadingSep>${escapedSep})?[-]+ `, "gm"), `$<leadingSep>${localizedDash} `)
   // British: convert unspaced em-dashes to spaced en-dashes (word—word → word – word)
   if (style === "british") {
     text = text.replace(
-      new RegExp(`(?<=[${LATIN_LETTERS}.!?'"])(?<sepBefore>${sep}?)${EM_DASH}(?<sepAfter>${sep}?)(?=[${LATIN_LETTERS}])`, "g"),
+      new RegExp(`(?<=[${LATIN_LETTERS}.!?'"])(?<sepBefore>${escapedSep}?)${EM_DASH}(?<sepAfter>${escapedSep}?)(?=[${LATIN_LETTERS}])`, "g"),
       `$<sepBefore>${maybeSpace}${localizedDash}${maybeSpace}$<sepAfter>`
     )
   }
@@ -155,15 +156,17 @@ function convertParentheticalDashes(text: string, sep: string, style: DashStyle)
  * allows a space after the dash: "Don't inter— Hey! Who threw that?"
  */
 function normalizeEmDashSpacing(text: string, sep: string): string {
+  const escapedSep = escapeStringRegexp(sep)
+
   // Remove all spaces around em-dashes
   text = text.replace(
-    new RegExp(`(?<before>${sep}?)[ ]*${EM_DASH}[ ]*(?<after>${sep}?)`, "g"),
+    new RegExp(`(?<before>${escapedSep}?)[ ]*${EM_DASH}[ ]*(?<after>${escapedSep}?)`, "g"),
     `$<before>${EM_DASH}$<after>`
   )
 
   // Preserve space after em-dash at start of line (e.g., attribution)
   text = text.replace(
-    new RegExp(`^(?<sep>${sep}?)${EM_DASH}(?<after>[A-Z0-9])`, "gm"),
+    new RegExp(`^(?<sep>${escapedSep}?)${EM_DASH}(?<after>[A-Z0-9])`, "gm"),
     `$<sep>${EM_DASH} $<after>`
   )
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -181,6 +181,17 @@ const defaultOpts: Required<Omit<TransformOptions, "separator">> = {
 
 export function transform(text: string, options: TransformOptions = {}): string {
   const separator = options.separator ?? DEFAULT_SEPARATOR
+
+  // Validate separator: must be a single UTF-16 code unit (BMP character)
+  // Multi-codepoint characters (surrogate pairs like emoji) cause issues with regex patterns
+  if (separator.length !== 1) {
+    throw new Error(
+      `Invalid separator: must be a single character. ` +
+      `Received "${separator}" (length: ${separator.length}). ` +
+      `Use a single-codepoint character like the default "\\uE000".`
+    )
+  }
+
   const original = text
   const { symbols, fractions, degrees, superscript, ligatures, collapseSpaces, checkIdempotency, ...separatorOpts } = { ...defaultOpts, ...options }
 

--- a/src/quotes.ts
+++ b/src/quotes.ts
@@ -2,6 +2,7 @@
  * Smart quote transformation: straight quotes → curly quotes.
  */
 
+import escapeStringRegexp from "escape-string-regexp"
 import { UNICODE_SYMBOLS, DEFAULT_SEPARATOR, LATIN_LETTERS } from "./constants.js"
 
 const {
@@ -24,6 +25,8 @@ export interface QuoteOptions {
 
 /** Convert straight single quotes to curly quotes and apostrophes */
 function convertSingleQuotes(text: string, sep: string): string {
+  const escapedSep = escapeStringRegexp(sep)
+
   // Handle empty single quotes '' and whitespace-only quotes ' ' first
   // Only match straight quotes, not already-converted curly quotes
   const singleQuoteChars = `'${LEFT_SINGLE_QUOTE}${RIGHT_SINGLE_QUOTE}`
@@ -31,11 +34,11 @@ function convertSingleQuotes(text: string, sep: string): string {
   text = text.replace(new RegExp(`(?<![${singleQuoteChars}])'(\\s+)'(?![${singleQuoteChars}])`, "g"), `${LEFT_SINGLE_QUOTE}$1${RIGHT_SINGLE_QUOTE}`)
 
   const afterEndingSinglePatterns = `\\s\\.!?;,\\)${EM_DASH}\\-\\]"`
-  const afterEndingSingle = `(?=${sep}?(?:s${sep}?)?(?:[${afterEndingSinglePatterns}]|$))`
+  const afterEndingSingle = `(?=${escapedSep}?(?:s${escapedSep}?)?(?:[${afterEndingSinglePatterns}]|$))`
   const endingSingle = `(?<=[^\\s${LEFT_DOUBLE_QUOTE}'])[']${afterEndingSingle}`
   text = text.replace(new RegExp(endingSingle, "gm"), RIGHT_SINGLE_QUOTE)
 
-  const contraction = `(?<=[${LATIN_LETTERS}])['${RIGHT_SINGLE_QUOTE}](?=${sep}?[${LATIN_LETTERS}])`
+  const contraction = `(?<=[${LATIN_LETTERS}])['${RIGHT_SINGLE_QUOTE}](?=${escapedSep}?[${LATIN_LETTERS}])`
   text = text.replace(new RegExp(contraction, "gm"), RIGHT_SINGLE_QUOTE)
 
   const apostropheWhitelist = `(?=n${RIGHT_SINGLE_QUOTE} )`
@@ -46,7 +49,7 @@ function convertSingleQuotes(text: string, sep: string): string {
   )
   text = text.replace(apostropheRegex, RIGHT_SINGLE_QUOTE)
 
-  const beginningSingle = `(?<beforeContext>(?:^|[\\s${LEFT_DOUBLE_QUOTE}${RIGHT_DOUBLE_QUOTE}${EM_DASH}\\-\\(])${sep}?)['](?=${sep}?\\S)`
+  const beginningSingle = `(?<beforeContext>(?:^|[\\s${LEFT_DOUBLE_QUOTE}${RIGHT_DOUBLE_QUOTE}${EM_DASH}\\-\\(])${escapedSep}?)['](?=${escapedSep}?\\S)`
   text = text.replace(new RegExp(beginningSingle, "gm"), `$<beforeContext>${LEFT_SINGLE_QUOTE}`)
 
   return text
@@ -54,6 +57,8 @@ function convertSingleQuotes(text: string, sep: string): string {
 
 /** Convert straight double quotes to curly quotes */
 function convertDoubleQuotes(text: string, sep: string): string {
+  const escapedSep = escapeStringRegexp(sep)
+
   // Handle empty quotes "" first - match only when not part of adjacent quotes
   // Require word boundary or start/end of string on at least one side
   text = text.replace(/(?<=^|[\s([{])""(?=$|[\s)\]}.!?,;:])/g, `${LEFT_DOUBLE_QUOTE}${RIGHT_DOUBLE_QUOTE}`)
@@ -61,17 +66,17 @@ function convertDoubleQuotes(text: string, sep: string): string {
   text = text.replace(/(?<=^|[\s([{])"(?<whitespace>\s+)"(?=$|[\s)\]}.!?,;:])/g, `${LEFT_DOUBLE_QUOTE}$<whitespace>${RIGHT_DOUBLE_QUOTE}`)
 
   const beginningDouble = new RegExp(
-    `(?<=^|[\\s\\(\\/\\[\\{\\-${EM_DASH}${sep}])(?<beforeChr>${sep}?)["](?<afterChr>(?<sepWithPunct>${sep}[ .,])|(?=${sep}?\\.{3}|${sep}?[^\\s\\)\\${EM_DASH},!?${sep};:.\\}]))`,
+    `(?<=^|[\\s\\(\\/\\[\\{\\-${EM_DASH}${escapedSep}])(?<beforeChr>${escapedSep}?)["](?<afterChr>(?<sepWithPunct>${escapedSep}[ .,])|(?=${escapedSep}?\\.{3}|${escapedSep}?[^\\s\\)\\${EM_DASH},!?${escapedSep};:.\\}]))`,
     "gm"
   )
   text = text.replace(beginningDouble, `$<beforeChr>${LEFT_DOUBLE_QUOTE}$<afterChr>`)
 
-  text = text.replace(new RegExp(`(?<=\\{)(?<sepSpace>${sep}? )?["]`, "g"), `$<sepSpace>${LEFT_DOUBLE_QUOTE}`)
+  text = text.replace(new RegExp(`(?<=\\{)(?<sepSpace>${escapedSep}? )?["]`, "g"), `$<sepSpace>${LEFT_DOUBLE_QUOTE}`)
 
-  const endingDouble = `(?<beforeQuote>[^\\s\\(])["]((?<sepAfter>${sep})?)(?=${sep}|[\\s/\\).,;${EM_DASH}:\\-\\}!?s]|$)`
+  const endingDouble = `(?<beforeQuote>[^\\s\\(])["]((?<sepAfter>${escapedSep})?)(?=${escapedSep}|[\\s/\\).,;${EM_DASH}:\\-\\}!?s]|$)`
   text = text.replace(new RegExp(endingDouble, "g"), `$<beforeQuote>${RIGHT_DOUBLE_QUOTE}$<sepAfter>`)
 
-  text = text.replace(new RegExp(`["](?<sepEnd>${sep}?)$`, "g"), `${RIGHT_DOUBLE_QUOTE}$<sepEnd>`)
+  text = text.replace(new RegExp(`["](?<sepEnd>${escapedSep}?)$`, "g"), `${RIGHT_DOUBLE_QUOTE}$<sepEnd>`)
   text = text.replace(new RegExp(`'(?=${RIGHT_DOUBLE_QUOTE})`, "gu"), RIGHT_SINGLE_QUOTE)
 
   return text
@@ -79,31 +84,33 @@ function convertDoubleQuotes(text: string, sep: string): string {
 
 /** Apply American or British punctuation style */
 function applyPunctuationStyle(text: string, sep: string, style: PunctuationStyle): string {
+  const escapedSep = escapeStringRegexp(sep)
+
   if (style === "american") {
     // Period outside → inside: "Hello". → "Hello."
     const periodOutsideRegex = new RegExp(
-      `(?<![!?:\\.${ELLIPSIS}])(?<sepBefore>${sep}?)(?<quote>[${RIGHT_SINGLE_QUOTE}${RIGHT_DOUBLE_QUOTE}])(?<sepAfter>${sep}?)(?!\\.\\.\\.)\\.`,
+      `(?<![!?:\\.${ELLIPSIS}])(?<sepBefore>${escapedSep}?)(?<quote>[${RIGHT_SINGLE_QUOTE}${RIGHT_DOUBLE_QUOTE}])(?<sepAfter>${escapedSep}?)(?!\\.\\.\\.)\\.`,
       "g"
     )
     text = text.replace(periodOutsideRegex, "$<sepBefore>.$<quote>$<sepAfter>")
 
     // Comma outside → inside: "Hello", → "Hello,"
     const commaOutsideRegex = new RegExp(
-      `(?<sepBefore>${sep}?)(?<quote>[${RIGHT_SINGLE_QUOTE}${RIGHT_DOUBLE_QUOTE}])(?<sepAfter>${sep}?),`,
+      `(?<sepBefore>${escapedSep}?)(?<quote>[${RIGHT_SINGLE_QUOTE}${RIGHT_DOUBLE_QUOTE}])(?<sepAfter>${escapedSep}?),`,
       "g"
     )
     text = text.replace(commaOutsideRegex, "$<sepBefore>,$<quote>$<sepAfter>")
   } else if (style === "british") {
     // Period inside → outside: "Hello." → "Hello".
     const periodInsideRegex = new RegExp(
-      `(?<![!?:\\.${ELLIPSIS}])(?<sepBefore>${sep}?)\\.(?<sepMiddle>${sep}?)(?<quote>[${RIGHT_SINGLE_QUOTE}${RIGHT_DOUBLE_QUOTE}])`,
+      `(?<![!?:\\.${ELLIPSIS}])(?<sepBefore>${escapedSep}?)\\.(?<sepMiddle>${escapedSep}?)(?<quote>[${RIGHT_SINGLE_QUOTE}${RIGHT_DOUBLE_QUOTE}])`,
       "g"
     )
     text = text.replace(periodInsideRegex, "$<sepBefore>$<sepMiddle>$<quote>.")
 
     // Comma inside → outside: "Hello," → "Hello",
     const commaInsideRegex = new RegExp(
-      `(?<![!?]),(?<sepAndQuote>${sep}?[${RIGHT_DOUBLE_QUOTE}${RIGHT_SINGLE_QUOTE}])`,
+      `(?<![!?]),(?<sepAndQuote>${escapedSep}?[${RIGHT_DOUBLE_QUOTE}${RIGHT_SINGLE_QUOTE}])`,
       "g"
     )
     text = text.replace(commaInsideRegex, "$<sepAndQuote>,")

--- a/src/tests/dashes.test.ts
+++ b/src/tests/dashes.test.ts
@@ -608,3 +608,11 @@ describe("phone number preservation", () => {
     expect(hyphenReplace(input)).toBe(expected)
   })
 })
+
+describe("minusReplace regex-special separators", () => {
+  const regexSpecialChars = [".", "*", "+", "?", "^", "$", "[", "]", "\\", "|", "(", ")"]
+
+  it.each(regexSpecialChars)("handles '%s' as separator", (sep) => {
+    expect(() => minusReplace("-5", { separator: sep })).not.toThrow()
+  })
+})

--- a/src/tests/index.test.ts
+++ b/src/tests/index.test.ts
@@ -1,6 +1,6 @@
 import { transform, DEFAULT_SEPARATOR, countSeparators } from "../index.js"
 import { ellipsis } from "../symbols.js"
-import { UNICODE_SYMBOLS } from "../constants.js"
+import { UNICODE_SYMBOLS, REGEX_SPECIAL_CHARS } from "../constants.js"
 
 const {
   LEFT_DOUBLE_QUOTE,
@@ -483,9 +483,7 @@ describe("transform", () => {
   })
 
   describe("regex-special separator characters", () => {
-    const regexSpecialChars = [".", "*", "+", "?", "^", "$", "[", "]", "\\", "|", "(", ")"]
-
-    it.each(regexSpecialChars)("handles '%s' as separator", (sep) => {
+    it.each(REGEX_SPECIAL_CHARS)("handles '%s' as separator", (sep) => {
       expect(transform('"Hello"', { separator: sep })).toEqual(
         `${LEFT_DOUBLE_QUOTE}Hello${RIGHT_DOUBLE_QUOTE}`
       )

--- a/src/tests/index.test.ts
+++ b/src/tests/index.test.ts
@@ -461,4 +461,70 @@ describe("transform", () => {
       expect(transform(input)).toBe(expected)
     })
   })
+
+  describe("separator validation", () => {
+    const invalidSeparators = [
+      ["🎉", "emoji (multi-codepoint)"],
+      ["ab", "multi-character"],
+      ["", "empty string"],
+    ] as const
+
+    it.each(invalidSeparators)("rejects %s separator (%s)", (sep) => {
+      expect(() => transform('"Hello"', { separator: sep })).toThrow(
+        /Invalid separator.*must be a single character/
+      )
+    })
+
+    const validSeparators = ["\uE000", "|", "\u2603"] // Default, pipe, snowman
+
+    it.each(validSeparators)("accepts '%s' as separator", (sep) => {
+      expect(() => transform('"Hello"', { separator: sep })).not.toThrow()
+    })
+  })
+
+  describe("regex-special separator characters", () => {
+    const regexSpecialChars = [".", "*", "+", "?", "^", "$", "[", "]", "\\", "|", "(", ")"]
+
+    it.each(regexSpecialChars)("handles '%s' as separator", (sep) => {
+      expect(transform('"Hello"', { separator: sep })).toEqual(
+        `${LEFT_DOUBLE_QUOTE}Hello${RIGHT_DOUBLE_QUOTE}`
+      )
+    })
+  })
+
+  describe("Unicode preservation", () => {
+    it.each([
+      ["emoji", '"Hello 👋 World"', `${LEFT_DOUBLE_QUOTE}Hello 👋 World${RIGHT_DOUBLE_QUOTE}`],
+      ["RTL text", '"שלום"', `${LEFT_DOUBLE_QUOTE}שלום${RIGHT_DOUBLE_QUOTE}`],
+      ["zero-width space", '"Hello\u200BWorld"', `${LEFT_DOUBLE_QUOTE}Hello\u200BWorld${RIGHT_DOUBLE_QUOTE}`],
+    ] as const)("preserves %s in input", (_, input, expected) => {
+      expect(transform(input)).toEqual(expected)
+    })
+  })
+
+  describe("large input handling", () => {
+    it("handles 1MB of text", () => {
+      const input = "Hello, world! ".repeat(70000)
+      const start = performance.now()
+      transform(input)
+      expect(performance.now() - start).toBeLessThan(2000)
+    })
+  })
+
+  describe("ReDoS resistance", () => {
+    const MAX_TIMEOUT_MS = 100
+
+    it.each([
+      ["10000 single quotes", "'".repeat(10000)],
+      ["10000 double quotes", '"'.repeat(10000)],
+      ["1000 unbalanced quotes", '"Hello '.repeat(1000)],
+      ["10000 hyphens", "-".repeat(10000)],
+      ["alternating digits/hyphens", "1-2-3-4-5-6-7-8-9-0".repeat(500)],
+      ["10000 dots", ".".repeat(10000)],
+    ] as const)("handles %s", (_, input) => {
+      const start = performance.now()
+      transform(input)
+      expect(performance.now() - start).toBeLessThan(MAX_TIMEOUT_MS)
+    })
+  })
 })

--- a/src/tests/quotes.test.ts
+++ b/src/tests/quotes.test.ts
@@ -340,4 +340,5 @@ describe("niceQuotes", () => {
       expect(niceQuotes(input)).toBe(expected)
     })
   })
+
 })

--- a/src/tests/symbols.test.ts
+++ b/src/tests/symbols.test.ts
@@ -705,3 +705,4 @@ describe("chained multiplications", () => {
     expect(multiplication(input)).toBe(expected)
   })
 })
+


### PR DESCRIPTION
## Summary
- Escape separator in regex patterns in quotes.ts and dashes.ts to prevent regex injection
- Add separator validation in transform() to require single BMP character
- Reject multi-codepoint separators (emoji/surrogate pairs)

## Test plan
- [x] 821 tests pass with 100% coverage
- [x] New tests for separator validation and escaping

https://claude.ai/code/session_01SGaGy9UWcj7BNsbYmZ19Ty