### PR TITLE
Improve version-bump script reliability and npm registry checks

### DIFF
--- a/scripts/version-bump.sh
+++ b/scripts/version-bump.sh
@@ -72,7 +72,7 @@ RESPONSE=$(curl -s https://api.anthropic.com/v1/messages \
   -d "$(jq -n \
     --arg prompt "$PROMPT" \
     '{
-      model: "claude-haiku-4-0",
+      model: "claude-3-5-haiku-20241022",
       max_tokens: 10,
       messages: [{role: "user", content: $prompt}]
     }')")

--- a/scripts/version-bump.sh
+++ b/scripts/version-bump.sh
@@ -80,11 +80,11 @@ RESPONSE=$(curl -s https://api.anthropic.com/v1/messages \
 # Extract the bump level from Claude's response
 BUMP=$(echo "$RESPONSE" | jq -r '.content[0].text' | tr '[:upper:]' '[:lower:]' | tr -d '[:space:]')
 
-# Validate response
+# Validate response - fail if Claude couldn't determine bump type
 if [[ "$BUMP" != "major" && "$BUMP" != "minor" && "$BUMP" != "patch" ]]; then
-  echo "Unexpected response from Claude: $BUMP"
-  echo "Defaulting to patch"
-  BUMP="patch"
+  echo "Error: Unexpected response from Claude: $BUMP"
+  echo "Full response: $RESPONSE"
+  exit 1
 fi
 
 echo "Claude determined bump level: $BUMP"
@@ -106,12 +106,40 @@ case $BUMP in
 esac
 fi
 
-echo "New version: $NEW_VERSION"
+echo "Calculated version: $NEW_VERSION"
 
 # Validate version format (strict semver: X.Y.Z where X, Y, Z are non-negative integers)
 if ! [[ "$NEW_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
   echo "Error: Invalid version format: $NEW_VERSION"
   exit 1
+fi
+
+# Check npm registry for the latest published version
+PACKAGE_NAME=$(node -p "require('./package.json').name")
+NPM_VERSION=$(npm view "$PACKAGE_NAME" version 2>/dev/null || echo "0.0.0")
+echo "Latest npm version: $NPM_VERSION"
+
+# Compare versions and bump if needed to avoid publishing duplicate
+# Parse both versions
+IFS='.' read -r NEW_MAJOR NEW_MINOR NEW_PATCH <<< "$NEW_VERSION"
+IFS='.' read -r NPM_MAJOR NPM_MINOR NPM_PATCH <<< "$NPM_VERSION"
+
+# Check if NEW_VERSION is less than or equal to NPM_VERSION
+version_lte() {
+  local v1_major=$1 v1_minor=$2 v1_patch=$3
+  local v2_major=$4 v2_minor=$5 v2_patch=$6
+
+  if [ "$v1_major" -lt "$v2_major" ]; then return 0; fi
+  if [ "$v1_major" -gt "$v2_major" ]; then return 1; fi
+  if [ "$v1_minor" -lt "$v2_minor" ]; then return 0; fi
+  if [ "$v1_minor" -gt "$v2_minor" ]; then return 1; fi
+  if [ "$v1_patch" -le "$v2_patch" ]; then return 0; fi
+  return 1
+}
+
+if version_lte "$NEW_MAJOR" "$NEW_MINOR" "$NEW_PATCH" "$NPM_MAJOR" "$NPM_MINOR" "$NPM_PATCH"; then
+  echo "Version $NEW_VERSION already exists on npm (latest: $NPM_VERSION). Skipping."
+  exit 0
 fi
 
 # Update package.json if version wasn't already changed

--- a/scripts/version-bump.sh
+++ b/scripts/version-bump.sh
@@ -72,7 +72,7 @@ RESPONSE=$(curl -s https://api.anthropic.com/v1/messages \
   -d "$(jq -n \
     --arg prompt "$PROMPT" \
     '{
-      model: "claude-3-5-haiku-20241022",
+      model: "claude-haiku-4-5-20250514",
       max_tokens: 10,
       messages: [{role: "user", content: $prompt}]
     }')")


### PR DESCRIPTION
## Summary
Enhanced the version-bump script with stricter error handling, updated Claude model version, and added npm registry validation to prevent publishing duplicate versions.

## Key Changes
- **Updated Claude model**: Changed from `claude-haiku-4-0` to `claude-haiku-4-5-20250514` for improved performance
- **Stricter error handling**: Changed from silently defaulting to "patch" to failing explicitly when Claude returns an unexpected bump type, with full response logging for debugging
- **NPM registry validation**: Added checks against the npm registry to detect if the calculated version already exists, preventing duplicate publishes
- **Version comparison logic**: Implemented `version_lte()` function to properly compare semantic versions and skip publishing if the new version is not greater than the latest published version
- **Improved messaging**: Updated console output for clarity ("Calculated version" instead of "New version")

## Implementation Details
- The script now queries npm registry for the latest published version of the package before attempting to publish
- If the calculated version is less than or equal to the npm registry version, the script exits gracefully with status 0
- Error cases now fail fast with exit code 1 rather than attempting to recover with defaults, making issues more visible in CI/CD pipelines
- Version comparison handles all three semver components (major, minor, patch) correctly

https://claude.ai/code/session_01VBa1xyFNUYuVmGrq9fnBjM