### PR TITLE
fix: distinguish spaced math subtraction from parenthetical dashes

### DIFF
--- a/src/dashes.ts
+++ b/src/dashes.ts
@@ -108,11 +108,23 @@ export function enDashDateRange(text: string, options: DashOptions = {}): string
 /** Convert hyphens to minus signs in numeric contexts (e.g., "-5" → "−5"). */
 export function minusReplace(text: string, options: DashOptions = {}): string {
   const chr = escapeStringRegexp(options.separator ?? DEFAULT_SEPARATOR)
+
+  // Pattern 1: Spaced math subtraction (e.g., "5 - 3" → "5 − 3")
+  // Only when preceded by a digit - this distinguishes "5 - 3" from "Safari) - 9"
+  text = text.replaceAll(
+    new RegExp(`(?<=\\d${chr}?) - (?<num>${chr}?\\d*\\.?\\d+)`, "g"),
+    ` ${MINUS} $<num>`
+  )
+
+  // Pattern 2: Direct negative numbers (e.g., "-5" → "−5", "(-3)" → "(−3)")
   // Match after: start of line, whitespace, (, separator, or quotes (straight or curly)
-  return text.replaceAll(
-    new RegExp(`(?<before>^|[\\s\\("${chr}${LEFT_DOUBLE_QUOTE}${RIGHT_DOUBLE_QUOTE}])-(?<num>\\s?\\d*\\.?\\d+)`, "gm"),
+  // No space allowed between hyphen and digit
+  text = text.replaceAll(
+    new RegExp(`(?<before>^|[\\s\\("${chr}${LEFT_DOUBLE_QUOTE}${RIGHT_DOUBLE_QUOTE}])-(?<num>\\d*\\.?\\d+)`, "gm"),
     `$<before>${MINUS}$<num>`
   )
+
+  return text
 }
 
 /**

--- a/src/dashes.ts
+++ b/src/dashes.ts
@@ -109,7 +109,14 @@ export function enDashDateRange(text: string, options: DashOptions = {}): string
 export function minusReplace(text: string, options: DashOptions = {}): string {
   const chr = escapeStringRegexp(options.separator ?? DEFAULT_SEPARATOR)
 
-  // Pattern 1: Spaced math subtraction (e.g., "5 - 3" → "5 − 3")
+  // Pattern 1a: Subtraction of negative number (e.g., "5 - -3" → "5 − −3")
+  // Must come before Pattern 1b so the negative hyphen is consumed first
+  text = text.replaceAll(
+    new RegExp(`(?<=\\d${chr}?) - -(?<num>${chr}?\\d*\\.?\\d+)`, "g"),
+    ` ${MINUS} ${MINUS}$<num>`
+  )
+
+  // Pattern 1b: Spaced math subtraction (e.g., "5 - 3" → "5 − 3")
   // Only when preceded by a digit - this distinguishes "5 - 3" from "Safari) - 9"
   text = text.replaceAll(
     new RegExp(`(?<=\\d${chr}?) - (?<num>${chr}?\\d*\\.?\\d+)`, "g"),

--- a/src/tests/dashes.test.ts
+++ b/src/tests/dashes.test.ts
@@ -276,10 +276,7 @@ describe("minusReplace", () => {
   })
 
   it("should handle subtraction of negative numbers", () => {
-    // Note: First hyphen doesn't match (not preceded by digit-space pattern),
-    // second hyphen becomes minus. The first hyphen is left for em-dash handling.
-    // "5 - -3" is rare in prose - typically written as "5 − (−3)" or "5 + 3"
-    expect(minusReplace("5 - -3")).toBe(`5 - ${MINUS}3`)
+    expect(minusReplace("5 - -3")).toBe(`5 ${MINUS} ${MINUS}3`)
   })
 })
 

--- a/src/tests/dashes.test.ts
+++ b/src/tests/dashes.test.ts
@@ -16,6 +16,8 @@ describe("hyphenReplace", () => {
   describe("em dashes from surrounded hyphens", () => {
     it.each([
       ["This is a - hyphen.", `This is a${EM_DASH}hyphen.`],
+      // Parenthetical dash before a digit (not math subtraction)
+      ["Safari) - 9 combinations", `Safari)${EM_DASH}9 combinations`],
       [`This is an ${EM_DASH} em dash.`, `This is an${EM_DASH}em dash.`],
       [`word ${EM_DASH} word`, `word${EM_DASH}word`],
       ["word ---", `word${EM_DASH}`],
@@ -254,6 +256,10 @@ describe("minusReplace", () => {
     ["The value is -10", `The value is ${MINUS}10`],
     [" -3", ` ${MINUS}3`],
     ['"-5"', `"${MINUS}5"`],
+    // Spaced math subtraction (digit before)
+    ["5 - 3", `5 ${MINUS} 3`],
+    ["10 - 5 = 5", `10 ${MINUS} 5 = 5`],
+    ["(100 - 50)", `(100 ${MINUS} 50)`],
   ])('should convert "%s" to use minus sign', (input, expected) => {
     expect(minusReplace(input)).toBe(expected)
   })
@@ -261,6 +267,19 @@ describe("minusReplace", () => {
   it("should not convert hyphens in other contexts", () => {
     expect(minusReplace("well-known")).toBe("well-known")
     expect(minusReplace("re-read")).toBe("re-read")
+  })
+
+  it("should not convert spaced hyphens without digit before (parenthetical)", () => {
+    // These should be left for em-dash conversion, not minus
+    expect(minusReplace("Safari) - 9 combinations")).toBe("Safari) - 9 combinations")
+    expect(minusReplace("word - 5")).toBe("word - 5")
+  })
+
+  it("should handle subtraction of negative numbers", () => {
+    // Note: First hyphen doesn't match (not preceded by digit-space pattern),
+    // second hyphen becomes minus. The first hyphen is left for em-dash handling.
+    // "5 - -3" is rare in prose - typically written as "5 − (−3)" or "5 + 3"
+    expect(minusReplace("5 - -3")).toBe(`5 - ${MINUS}3`)
   })
 })
 


### PR DESCRIPTION
## Summary
- Fixes issue where "Safari) - 9" incorrectly became "Safari) − 9" (minus) instead of "Safari)—9" (em-dash)
- Spaced hyphens before digits now only become minus signs when preceded by a digit (math subtraction)

## Changes
- Split minusReplace into two patterns: spaced math (digit before) and direct negative
- Added tests for parenthetical dashes before digits and spaced math subtraction

## Testing
All 898 tests pass with 100% coverage.

https://claude.ai/code/session_017kZQMRhtizG3uSCdmt598L