### PR TITLE
fix: preserve whitespace after separator in dash conversion

### DIFF
--- a/src/dashes.ts
+++ b/src/dashes.ts
@@ -126,10 +126,14 @@ function convertParentheticalDashes(text: string, sep: string, style: DashStyle)
   const escapedSep = escapeStringRegexp(sep)
 
   // Convert spaced dashes: "word - word" or "word — word"
-  text = text.replace(
-    new RegExp(`(?<=[^\\s]|^)(?:(?<sepBefore>${escapedSep}?)[ ]+|(?<sepOnly>${escapedSep}))[~${EN_DASH}${EM_DASH}-]+[ ]*(?<sepAfter>${escapedSep}?)(?:[ ]+|$)`, "g"),
-    `$<sepBefore>$<sepOnly>${maybeSpace}${localizedDash}${maybeSpace}$<sepAfter>`
+  // When a separator follows the dash, preserve trailing spaces (they belong to the next text segment).
+  const spacedDashPattern = new RegExp(
+    `(?<=[^\\s]|^)(?<sepBefore>${escapedSep}?)[ ]+[~${EN_DASH}${EM_DASH}-]+[ ]*(?<sepAfter>${escapedSep}?)(?<trailing>[ ]*)(?=\\S|$)`, "g"
   )
+  text = text.replace(spacedDashPattern, (_match, sepBefore, sepAfter, trailing) => {
+    // Preserve trailing spaces only after a separator (they belong to the next text segment)
+    return `${sepBefore}${maybeSpace}${localizedDash}${maybeSpace}${sepAfter}${sepAfter ? trailing : ""}`
+  })
   // Convert multiple dashes: "word--word" or "word---word" or "quote"--"quote"
   const quoteChars = `"'${LEFT_DOUBLE_QUOTE}${RIGHT_DOUBLE_QUOTE}${LEFT_SINGLE_QUOTE}${RIGHT_SINGLE_QUOTE}`
   text = text.replace(

--- a/src/tests/dashes.test.ts
+++ b/src/tests/dashes.test.ts
@@ -109,6 +109,9 @@ describe("hyphenReplace", () => {
     it.each([
       [`word${sep} - ${sep}another`, `word${sep}${EM_DASH}${sep}another`, "em dash context"],
       [`pages 1${sep}-${sep}5`, `pages 1${sep}${EN_DASH}${sep}5`, "number ranges"],
+      // Whitespace after separator should be preserved (not consumed by dash conversion)
+      [`text ${EM_DASH} ${sep} more text`, `text${EM_DASH}${sep} more text`, "preserves whitespace after separator"],
+      [`text - ${sep} more`, `text${EM_DASH}${sep} more`, "preserves space after separator with hyphen"],
     ])("%s → %s (%s)", (input, expected) => {
       expect(hyphenReplace(input, { separator: sep })).toBe(expected)
     })


### PR DESCRIPTION
## Summary
When converting dashes (e.g., ` — ` → `—`), trailing whitespace after a separator character was incorrectly consumed. This caused text like `text — [sep] more` to lose the space before "more".

This bug manifests when processing HTML with inline elements adjacent to em-dashes:
```html
<!-- Input -->
text — <span></span> more

<!-- Before fix (buggy) -->
text—<span></span>more  <!-- space before "more" is lost -->

<!-- After fix -->
text—<span></span> more  <!-- space preserved -->
```

## Changes
- Modified `convertParentheticalDashes` to capture trailing spaces and preserve them only when they follow a separator
- Added test cases for whitespace preservation after separators

## Test plan
- [x] All 894 existing tests pass
- [x] Added new test cases verifying whitespace preservation

https://claude.ai/code/session_01VQzcZUNXw864StuyHrPvUi