### PR TITLE
Fix minus sign replacement for subtraction of negative numbers

### DIFF
--- a/src/dashes.ts
+++ b/src/dashes.ts
@@ -109,7 +109,14 @@ export function enDashDateRange(text: string, options: DashOptions = {}): string
 export function minusReplace(text: string, options: DashOptions = {}): string {
   const chr = escapeStringRegexp(options.separator ?? DEFAULT_SEPARATOR)
 
-  // Pattern 1: Spaced math subtraction (e.g., "5 - 3" → "5 − 3")
+  // Pattern 1a: Subtraction of negative number (e.g., "5 - -3" → "5 − −3")
+  // Must come before Pattern 1b so the negative hyphen is consumed first
+  text = text.replaceAll(
+    new RegExp(`(?<=\\d${chr}?) - -(?<num>${chr}?\\d*\\.?\\d+)`, "g"),
+    ` ${MINUS} ${MINUS}$<num>`
+  )
+
+  // Pattern 1b: Spaced math subtraction (e.g., "5 - 3" → "5 − 3")
   // Only when preceded by a digit - this distinguishes "5 - 3" from "Safari) - 9"
   text = text.replaceAll(
     new RegExp(`(?<=\\d${chr}?) - (?<num>${chr}?\\d*\\.?\\d+)`, "g"),

--- a/src/tests/dashes.test.ts
+++ b/src/tests/dashes.test.ts
@@ -276,10 +276,7 @@ describe("minusReplace", () => {
   })
 
   it("should handle subtraction of negative numbers", () => {
-    // Note: First hyphen doesn't match (not preceded by digit-space pattern),
-    // second hyphen becomes minus. The first hyphen is left for em-dash handling.
-    // "5 - -3" is rare in prose - typically written as "5 − (−3)" or "5 + 3"
-    expect(minusReplace("5 - -3")).toBe(`5 - ${MINUS}3`)
+    expect(minusReplace("5 - -3")).toBe(`5 ${MINUS} ${MINUS}3`)
   })
 })
 


### PR DESCRIPTION
## Summary
Fixed the `minusReplace` function to properly handle subtraction of negative numbers (e.g., "5 - -3") by converting both the subtraction operator and the negative sign to proper minus characters.

## Changes
- Added a new regex pattern (Pattern 1a) that specifically matches subtraction of negative numbers before the general subtraction pattern
- The pattern `(?<=\d${chr}?) - -(?<num>${chr}?\d*\.\d+)` captures cases where a minus sign immediately follows the subtraction operator
- Both the subtraction operator and negative sign are now converted to the MINUS character (−)
- Updated test expectation: "5 - -3" now correctly converts to `5 − −3` instead of `5 - −3`

## Implementation Details
- The new pattern must be applied before Pattern 1b (general spaced subtraction) to ensure the negative hyphen is consumed first
- Uses a positive lookbehind to verify the subtraction operator is preceded by a digit
- Maintains the same number capture group logic as the existing pattern to handle optional separators and decimal points

https://claude.ai/code/session_01PGX9TihHGZnrTQoYxV2mou