### PR TITLE
Fix nbsp handling for accented letters and unit word boundaries

### DIFF
--- a/src/nbsp.ts
+++ b/src/nbsp.ts
@@ -10,7 +10,7 @@
 
 import escapeStringRegexp from "escape-string-regexp"
 
-import { UNICODE_SYMBOLS, ESCAPED_DEFAULT_SEPARATOR } from "./constants.js"
+import { UNICODE_SYMBOLS, ESCAPED_DEFAULT_SEPARATOR, LATIN_LETTERS, wordBoundaryEnd } from "./constants.js"
 import type { SymbolOptions } from "./symbols.js"
 
 const {
@@ -43,31 +43,31 @@ const UNICODE_UPPERCASE = "\\p{Lu}"
  */
 export const UNITS = [
   // Length
-  "km", "m", "cm", "mm", "mi", "ft", "in", "yd", "nm", "pm",
+  "km", "cm", "mm", "mi", "ft", "in", "yd", "nm", "pm", "m",
   // Mass
-  "kg", "g", "mg", "lb", "lbs", "oz", "t",
+  "kg", "mg", "lbs", "lb", "oz", "g", "t",
   // Volume
-  "l", "L", "ml", "mL", "gal", "fl",
+  "ml", "mL", "gal", "fl", "l", "L",
   // Time
-  "s", "ms", "min", "h", "hr", "hrs",
+  "min", "ms", "hr", "hrs", "h", "s",
   // Speed / frequency
-  "Hz", "kHz", "MHz", "GHz", "THz", "rpm",
+  "kHz", "MHz", "GHz", "THz", "rpm", "Hz",
   // Digital
-  "KB", "MB", "GB", "TB", "PB", "kB", "Mb", "Gb", "kbps", "Mbps", "Gbps",
+  "kbps", "Mbps", "Gbps", "KB", "MB", "GB", "TB", "PB", "kB", "Mb", "Gb",
   // Energy / power
-  "W", "kW", "MW", "GW", "J", "kJ", "MJ", "Wh", "kWh", "MWh",
+  "kWh", "MWh", "kW", "MW", "GW", "kJ", "MJ", "Wh", "W", "J",
   // Temperature
   "K",
   // Electrical
-  "V", "kV", "mV", "A", "mA",
+  "kV", "mV", "mA", "V", "A",
   // Pressure / area
-  "Pa", "kPa", "MPa", "bar", "psi", "ha",
+  "kPa", "MPa", "bar", "psi", "ha", "Pa",
   // Typography / CSS
-  "px", "pt", "em", "rem", "vw", "vh", "dpi",
+  "rem", "dpi", "px", "pt", "em", "vw", "vh",
   // Finance
   "MM", "M", "B", "T",
   // Misc
-  "dB", "cal", "kcal", "mol",
+  "kcal", "mol", "cal", "dB",
 ]
 
 export const HONORIFICS = [
@@ -97,7 +97,7 @@ const COPYRIGHT_SYMBOLS = `[${COPYRIGHT}${REGISTERED}${TRADEMARK}]`
 export function nbspAfterShortWords(text: string, options: NbspOptions = {}): string {
   const sep = escapedSeparator(options)
   const pattern = new RegExp(
-    `(?<=^|${SPACE}|${PUNCTUATION_OR_QUOTE}|>)(?<shortWord>[a-zA-Z]{1,2})(?<marker>${sep}?)${SPACE}`,
+    `(?<=^|${SPACE}|${PUNCTUATION_OR_QUOTE}|>)(?<shortWord>[${LATIN_LETTERS}]{1,2})(?<marker>${sep}?)${SPACE}`,
     "gmu"
   )
   return text.replace(pattern, `$<shortWord>$<marker>${NBSP}`)
@@ -110,8 +110,9 @@ export function nbspAfterShortWords(text: string, options: NbspOptions = {}): st
  */
 export function nbspBetweenNumberAndUnit(text: string, options: NbspOptions = {}): string {
   const sep = escapedSeparator(options)
+  const wbe = wordBoundaryEnd(sep)
   const pattern = new RegExp(
-    `(?<digit>\\d)(?<marker1>${sep}?)${SPACE}(?<marker2>${sep}?)(?<unit>${UNIT_PATTERN})\\b`,
+    `(?<digit>\\d)(?<marker1>${sep}?)${SPACE}(?<marker2>${sep}?)(?<unit>${UNIT_PATTERN})${wbe}`,
     "gm"
   )
   return text.replace(pattern, `$<digit>$<marker1>${NBSP}$<marker2>$<unit>`)

--- a/src/nbsp.ts
+++ b/src/nbsp.ts
@@ -71,14 +71,30 @@ export const UNITS = [
 ]
 
 export const HONORIFICS = [
+  // English
   "Mr", "Mrs", "Ms", "Dr", "Prof", "Rev",
   "St", "Sr", "Jr", "Hon", "Gov", "Sen", "Rep",
+  // French
+  "Mme", "Mlle", "Mgr",
+  // German / Nordic
+  "Hr", "Fr",
+  // Spanish / Portuguese
+  "Sra", "Srta",
+  // Italian
+  "Sig", "Dott",
+  // Dutch
+  "Dhr", "Mevr",
 ]
 
 export const REFERENCE_ABBREVIATIONS = [
+  // English / Latin
   "Fig", "Figs", "Vol", "No", "Nos",
   "p", "pp", "Ch", "Chap", "Sec",
   "Eq", "Eqs", "Art", "Tab", "Ex",
+  // German
+  "Abb", "Bd", "Nr", "Kap",
+  // Romance (Spanish / Portuguese / Italian)
+  "Cap",
 ]
 
 // Precomputed regex fragments

--- a/src/tests/nbsp.test.ts
+++ b/src/tests/nbsp.test.ts
@@ -150,7 +150,20 @@ describe("nbspAfterSectionSymbols", () => {
 })
 
 describe("nbspAfterHonorifics", () => {
-  const names = ["Smith", "Jones", "Brown", "Davis", "Wilson", "King", "Patrick", "Martinez", "Judge", "Brown", "Warren", "Lee", "Lee"]
+  const names = [
+    // English
+    "Smith", "Jones", "Brown", "Davis", "Wilson", "King", "Patrick", "Martinez", "Judge", "Brown", "Warren", "Lee", "Lee",
+    // French
+    "Dupont", "Laurent", "Lefebvre",
+    // German / Nordic
+    "Schmidt", "Weber",
+    // Spanish / Portuguese
+    "García", "Rodríguez",
+    // Italian
+    "Rossi", "Bianchi",
+    // Dutch
+    "Bakker", "Jansen",
+  ]
   it.each([
     ...HONORIFICS.map((h, i) => [`${h}. ${names[i]}`, `${h}.${NBSP}${names[i]}`]),
     ["Dr. Élodie", `Dr.${NBSP}Élodie`],

--- a/src/tests/nbsp.test.ts
+++ b/src/tests/nbsp.test.ts
@@ -43,6 +43,10 @@ describe("nbspAfterShortWords", () => {
     ["the cat sat on a mat", `the cat sat on${NBSP}a${NBSP}mat`],
     ["Go to the store", `Go${NBSP}to${NBSP}the store`],
     ["the cat", "the cat"],
+    // Accented Latin short words
+    ["à chat", `à${NBSP}chat`],
+    ["où aller", `où${NBSP}aller`],
+    ["ça va", `ça${NBSP}va`],
   ])('"%s" → "%s"', (input, expected) => {
     expect(nbspAfterShortWords(input)).toBe(expected)
   })
@@ -80,6 +84,12 @@ describe("nbspBetweenNumberAndUnit", () => {
       [`5 ${SEP}kg`, `5${NBSP}${SEP}kg`],
       [`5${SEP} ${SEP}kg`, `5${SEP}${NBSP}${SEP}kg`],
     ])
+  })
+
+  it("does not match unit letter that starts a cross-element word", () => {
+    // "5 m" + SEP + "ade" simulates <span>5 m</span><span>ade</span> ("made")
+    expect(nbspBetweenNumberAndUnit(`5 m${SEP}ade`, { separator: SEP }))
+      .toBe(`5 m${SEP}ade`)
   })
 })
 


### PR DESCRIPTION
## Summary
This PR improves the non-breaking space (nbsp) insertion logic to properly handle accented Latin characters and prevent incorrect matches when units appear at word boundaries across elements.

## Key Changes

- **Accented letter support**: Updated `nbspAfterShortWords()` to recognize accented Latin letters (à, ç, é, etc.) as valid short words by using a new `LATIN_LETTERS` constant instead of hardcoded `[a-zA-Z]`

- **Unit word boundary fix**: Modified `nbspBetweenNumberAndUnit()` to use a new `wordBoundaryEnd()` function instead of `\b` word boundary, preventing false matches when a unit letter is followed by additional letters that form a complete word (e.g., "5 m" in "made")

- **Unit ordering**: Reordered units in the `UNITS` array to prioritize longer/more specific units before shorter ones, ensuring correct pattern matching (e.g., "kHz" before "Hz", "kbps" before "KB")

- **Test coverage**: Added test cases for:
  - Accented short words in French (à, où, ça)
  - Edge case where unit letters span across element boundaries

## Implementation Details

The `wordBoundaryEnd()` function provides context-aware boundary detection that respects custom separators, preventing matches when a unit is part of a larger word split across HTML elements.

https://claude.ai/code/session_013CMULgPzQhUckXQBMkwL1p