### PR TITLE
Fix dash handling across HTML element boundaries

### DIFF
--- a/src/dashes.ts
+++ b/src/dashes.ts
@@ -47,7 +47,7 @@ export function enDashNumberRange(text: string, options: DashOptions = {}): stri
   const notAfterDash = `(?<![${disallowed}${LATIN_LETTERS}.])`           // prevent Llama-2-7B
   const rangeStart = `(?<start>(?:p\\.?|[${currencies}])?\\d[\\d.,]*${chr}?)`  // p.10, $100, 1,000
   const rangeEnd = `(?<end>${chr}?[${currencies}]?\\d[\\d.,]*)`          // 20, $200, 2,000
-  const moreSegments = `(?<following>(?:${chr}?-${chr}?\\d+)*)`          // -4567 in phone numbers
+  const moreSegments = `(?<following>(?:${chr}?[-${MINUS}]${chr}?\\d+)*)` // -4567 in phone numbers
   const unitSuffix = `(?<suffix>${chr}?(?:[AaPp][Mm]|[xKBTM]))?`         // am/pm, K/M/B
 
   // Positive ranges: 1-5, $100-$200, €5-€10, p.10-15
@@ -124,10 +124,18 @@ export function minusReplace(text: string, options: DashOptions = {}): string {
   )
 
   // Pattern 2: Direct negative numbers (e.g., "-5" → "−5", "(-3)" → "(−3)")
-  // Match after: start of line, whitespace, (, separator, or quotes (straight or curly)
+  // Match after: start of line, whitespace, (, or quotes (straight or curly)
   // No space allowed between hyphen and digit
   text = text.replaceAll(
-    new RegExp(`(?<before>^|[\\s\\("${chr}${LEFT_DOUBLE_QUOTE}${RIGHT_DOUBLE_QUOTE}])-(?<num>\\d*\\.?\\d+)`, "gm"),
+    new RegExp(`(?<before>^|[\\s\\("${LEFT_DOUBLE_QUOTE}${RIGHT_DOUBLE_QUOTE}])-(?<num>\\d*\\.?\\d+)`, "gm"),
+    `$<before>${MINUS}$<num>`
+  )
+
+  // Pattern 2b: Direct negative numbers after separator boundary (e.g., <em>-5</em>)
+  // Only when no word character precedes the separator — prevents both
+  // "2{SEP}-3" in "1-2-3" and "GPT{SEP}-3" from being misidentified as negative 3
+  text = text.replaceAll(
+    new RegExp(`(?<![\\d.,${LATIN_LETTERS}])(?<before>${chr})-(?<num>\\d*\\.?\\d+)`, "gm"),
     `$<before>${MINUS}$<num>`
   )
 

--- a/src/tests/dashes.test.ts
+++ b/src/tests/dashes.test.ts
@@ -651,3 +651,28 @@ describe("minusReplace regex-special separators", () => {
     expect(() => minusReplace("-5", { separator: sep })).not.toThrow()
   })
 })
+
+describe("minusReplace separator boundary", () => {
+  const sep = DEFAULT_SEPARATOR
+
+  it.each([
+    ["genuine negative at element start", `${sep}-5${sep}`, `${sep}${MINUS}5${sep}`],
+    ["negative in parens across boundary", `(${sep}-5${sep})`, `(${sep}${MINUS}5${sep})`],
+    ["no false negative after digit+sep", `2${sep}-3`, `2${sep}-3`],
+    ["no false negative after letter+sep", `GPT${sep}-3`, `GPT${sep}-3`],
+    ["multi-segment 1-2-3 with seps", `1-${sep}2${sep}-3`, `1-${sep}2${sep}-3`],
+  ])("%s", (_desc, input, expected) => {
+    expect(minusReplace(input, { separator: sep })).toBe(expected)
+  })
+})
+
+describe("hyphenReplace preserves multi-segment numbers across separators", () => {
+  const sep = DEFAULT_SEPARATOR
+
+  it.each([
+    ["1-2-3 across elements", `1-${sep}2${sep}-3`, `1-${sep}2${sep}-3`],
+    ["model name across elements", `${sep}GPT${sep}-3`, `${sep}GPT${sep}-3`],
+  ])("%s", (_desc, input, expected) => {
+    expect(hyphenReplace(input, { separator: sep })).toBe(expected)
+  })
+})

--- a/src/tests/dashes.test.ts
+++ b/src/tests/dashes.test.ts
@@ -652,27 +652,30 @@ describe("minusReplace regex-special separators", () => {
   })
 })
 
-describe("minusReplace separator boundary", () => {
-  const sep = DEFAULT_SEPARATOR
+const sep = DEFAULT_SEPARATOR
 
+describe("minusReplace separator boundary", () => {
   it.each([
     ["genuine negative at element start", `${sep}-5${sep}`, `${sep}${MINUS}5${sep}`],
     ["negative in parens across boundary", `(${sep}-5${sep})`, `(${sep}${MINUS}5${sep})`],
-    ["no false negative after digit+sep", `2${sep}-3`, `2${sep}-3`],
-    ["no false negative after letter+sep", `GPT${sep}-3`, `GPT${sep}-3`],
-    ["multi-segment 1-2-3 with seps", `1-${sep}2${sep}-3`, `1-${sep}2${sep}-3`],
   ])("%s", (_desc, input, expected) => {
     expect(minusReplace(input, { separator: sep })).toBe(expected)
+  })
+
+  it.each([
+    ["no false negative after digit+sep", `2${sep}-3`],
+    ["no false negative after letter+sep", `GPT${sep}-3`],
+    ["multi-segment 1-2-3 with seps", `1-${sep}2${sep}-3`],
+  ])("%s", (_desc, input) => {
+    expect(minusReplace(input, { separator: sep })).toBe(input)
   })
 })
 
 describe("hyphenReplace preserves multi-segment numbers across separators", () => {
-  const sep = DEFAULT_SEPARATOR
-
   it.each([
-    ["1-2-3 across elements", `1-${sep}2${sep}-3`, `1-${sep}2${sep}-3`],
-    ["model name across elements", `${sep}GPT${sep}-3`, `${sep}GPT${sep}-3`],
-  ])("%s", (_desc, input, expected) => {
-    expect(hyphenReplace(input, { separator: sep })).toBe(expected)
+    ["1-2-3 across elements", `1-${sep}2${sep}-3`],
+    ["model name across elements", `${sep}GPT${sep}-3`],
+  ])("%s", (_desc, input) => {
+    expect(hyphenReplace(input, { separator: sep })).toBe(input)
   })
 })

--- a/src/tests/rehype.test.ts
+++ b/src/tests/rehype.test.ts
@@ -64,6 +64,17 @@ describe("rehypePunctilio", () => {
     })
   })
 
+  describe("dashes across element boundaries", () => {
+    it.each([
+      ["multi-segment number preserved", "<p>1-<em>2</em>-3</p>", "<p>1-<em>2</em>-3</p>"],
+      ["model name preserved", "<p><em>GPT</em>-3</p>", "<p><em>GPT</em>-3</p>"],
+      ["simple range still converts", "<p>pages <em>1</em>-5</p>", `<p>pages <em>1</em>${EN_DASH}5</p>`],
+      ["genuine negative at element start", "<p><em>-5</em> degrees</p>", "<p><em>\u22125</em> degrees</p>"],
+    ])("%s", async (_name, html, expected) => {
+      expect(await processHtml(html)).toEqual(expected)
+    })
+  })
+
   describe("skipped elements", () => {
     it.each(["code", "pre", "script", "style", "kbd", "var", "samp"])(
       "skips %s elements",


### PR DESCRIPTION
## Summary
This PR fixes incorrect dash conversions when dashes appear across HTML element boundaries (e.g., `1-<em>2</em>-3`). The changes prevent false positives for negative numbers and multi-segment identifiers while preserving correct conversions for genuine ranges and negatives.

## Key Changes

- **Pattern 2b in `minusReplace`**: Added a new regex pattern to handle negative numbers that appear after a separator character (e.g., `<em>-5</em>`). This pattern includes a negative lookbehind to prevent matching when a digit, letter, or punctuation precedes the separator, which avoids false positives in cases like `2{SEP}-3` or `GPT{SEP}-3`.

- **Updated Pattern 2 in `minusReplace`**: Removed the separator character from the "before" character class, delegating separator-adjacent cases to the new Pattern 2b. This simplifies the logic and prevents overlap.

- **Enhanced `enDashNumberRange`**: Updated the `moreSegments` regex to use `[-${MINUS}]` instead of just `-`, allowing the pattern to match both hyphens and minus signs in multi-segment numbers.

## Implementation Details

The fix uses a negative lookbehind `(?<![\\d.,${LATIN_LETTERS}])` in Pattern 2b to ensure that separators preceded by word characters or digits are not treated as boundaries for negative numbers. This preserves multi-segment identifiers like "1-2-3" and "GPT-3" while still correctly converting genuine negatives like "-5" at element boundaries.

## Testing

Added comprehensive test coverage for:
- Negative numbers at element boundaries
- Multi-segment numbers across separators (preserved unchanged)
- Model names with dashes across elements (preserved unchanged)
- Integration tests with actual HTML elements

https://claude.ai/code/session_01GtzjtJwRGeiGn6GZEvXHcJ