### PR TITLE
Fix prime conversion for consecutive measurements

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,8 @@
 - Prefer throwing errors that "fail loudly" over logging warnings for critical issues
 - Un-nest conditionals where possible; combine related checks into single blocks
 - Create shared helpers when the same logic is needed in multiple places
+- Use descriptive variable names; don't shorten for brevity
+- Split complex regex logic into named helper functions (pattern builder + replace callback)
 
 ### Testing
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ My [`benchmark.mjs`](https://github.com/alexander-turner/punctilio/blob/main/ben
 
 | Pattern | Behavior | Notes |
 |:--------|:---------|:------|
-| `don't measure 8'` | `8'` not converted to `8′` | Apostrophe in contraction is treated as an opening quote |
+| `the dogs' 5' leashes` | `5'` not converted to `5′` | Possessive-plural apostrophe is indistinguishable from an opening quote |
 | German/French quotes | Not supported | `« Bonjour »` requires language detection |
 
 ## Test suite

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ My [`benchmark.mjs`](https://github.com/alexander-turner/punctilio/blob/main/ben
 
 | Pattern | Behavior | Notes |
 |:--------|:---------|:------|
-| `10' x 12'` | Second `'` not converted | Quote balancing prevents double prime conversion |
+| `don't measure 8'` | `8'` not converted to `8′` | Apostrophe in contraction is treated as an opening quote |
 | German/French quotes | Not supported | `« Bonjour »` requires language detection |
 
 ## Test suite

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ My [`benchmark.mjs`](https://github.com/alexander-turner/punctilio/blob/main/ben
 | Pattern | Behavior | Notes |
 |:--------|:---------|:------|
 | `'Twas a 5' board` | `5'` not converted to `5′` | Leading apostrophe is indistinguishable from an opening quote without semantic understanding |
-| `«Bonjour»` | Not spaced to `« Bonjour »` | French quote spacing requires language detection |
+| `«Bonjour»` | Not spaced to `« Bonjour »` | French localization not supported |
 
 ## Test suite
 

--- a/README.md
+++ b/README.md
@@ -68,8 +68,8 @@ My [`benchmark.mjs`](https://github.com/alexander-turner/punctilio/blob/main/ben
 
 | Pattern | Behavior | Notes |
 |:--------|:---------|:------|
-| `'Twas a 5' board` | `5'` not converted to `5′` | Leading apostrophe is indistinguishable from an opening quote |
-| German/French quotes | Not supported | `« Bonjour »` requires language detection |
+| `'Twas a 5' board` | `5'` not converted to `5′` | Leading apostrophe is indistinguishable from an opening quote without semantic understanding |
+| `"Bonjour"` | Not converted to `« Bonjour »` | French/German quotes require language detection |
 
 ## Test suite
 

--- a/README.md
+++ b/README.md
@@ -34,14 +34,14 @@ I tested `punctilio` 1.2.9 against [`smartypants`](https://www.npmjs.com/package
 
 My [`benchmark.mjs`](https://github.com/alexander-turner/punctilio/blob/main/benchmark.mjs) measures how well libraries handle a [wide range of scenarios](https://github.com/alexander-turner/punctilio/blob/main/benchmark_cases.json). The benchmark normalizes stylistic differences (e.g. non-breaking vs regular space, British vs American dash spacing) for fair comparison.
 
-| Package | Passed (of 154) |
+| Package | Passed (of 159) |
 |--------:|:----------------|
-| `punctilio` | 149 (97%) |
-| `tipograph` | 88 (57%) |
-| `typograf` | 74 (48%) |
-| `smartypants` | 68 (44%) |
-| `smartquotes` | 67 (44%) |
-| `retext-smartypants` | 65 (42%) |
+| `punctilio` | 154 (97%) |
+| `tipograph` | 92 (58%) |
+| `typograf` | 74 (47%) |
+| `smartquotes` | 72 (45%) |
+| `smartypants` | 68 (43%) |
+| `retext-smartypants` | 65 (41%) |
 
 | Feature | Example | `punctilio` | `smartypants` | `tipograph` | `smartquotes` | `typograf` |
 |--------:|:-------:|:-------:|:-------:|:-------:|:-------:|:-------:|

--- a/README.md
+++ b/README.md
@@ -69,7 +69,6 @@ My [`benchmark.mjs`](https://github.com/alexander-turner/punctilio/blob/main/ben
 | Pattern | Behavior | Notes |
 |:--------|:---------|:------|
 | `'Twas a 5' board` | `5'` not converted to `5′` | Leading apostrophe is indistinguishable from an opening quote without semantic understanding |
-| `"Bonjour"` | Not converted to `« Bonjour »` | French/German quotes require language detection |
 
 ## Test suite
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ My [`benchmark.mjs`](https://github.com/alexander-turner/punctilio/blob/main/ben
 
 | Pattern | Behavior | Notes |
 |:--------|:---------|:------|
-| `the dogs' 5' leashes` | `5'` not converted to `5′` | Possessive-plural apostrophe is indistinguishable from an opening quote |
+| `'Twas a 5' board` | `5'` not converted to `5′` | Leading apostrophe is indistinguishable from an opening quote |
 | German/French quotes | Not supported | `« Bonjour »` requires language detection |
 
 ## Test suite

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ My [`benchmark.mjs`](https://github.com/alexander-turner/punctilio/blob/main/ben
 | Pattern | Behavior | Notes |
 |:--------|:---------|:------|
 | `'Twas a 5' board` | `5'` not converted to `5′` | Leading apostrophe is indistinguishable from an opening quote without semantic understanding |
+| `«Bonjour»` | Not spaced to `« Bonjour »` | French quote spacing requires language detection |
 
 ## Test suite
 

--- a/benchmark_cases.json
+++ b/benchmark_cases.json
@@ -127,8 +127,19 @@
   "Prime marks - coordinates": [
     ["Location: 45\u00B0 30' 15\"", "Location: 45\u00B0 30\u2032 15\u2033"]
   ],
-  "Prime marks - multiple (quote balancing)": [
-    ["Room is 10' x 12'", "Room is 10\u2032 x 12'"]
+  "Prime marks - multiple": [
+    ["Room is 10' x 12'", "Room is 10\u2032 x 12\u2032"],
+    ["5' and 8' boards", "5\u2032 and 8\u2032 boards"]
+  ],
+  "Prime marks - after contractions": [
+    ["it's 5' long", "it\u2019s 5\u2032 long"],
+    ["don't measure 8'", "don\u2019t measure 8\u2032"]
+  ],
+  "Prime marks - after possessives": [
+    ["the dogs' 5' leashes", "the dogs\u2019 5\u2032 leashes"]
+  ],
+  "Prime marks - leading apostrophe (ambiguous)": [
+    ["'Twas a 5' board", "\u2019Twas a 5\u2032 board"]
   ],
   "Degrees": [
     ["20 C", "20 \u00B0C"],

--- a/src/symbols.ts
+++ b/src/symbols.ts
@@ -171,66 +171,92 @@ export function degrees(text: string, options: SymbolOptions = {}): string {
   )
 }
 
+/**
+ * Build a regex that matches all quote characters in priority order:
+ * 1. Prime candidate: digit + quote + non-letter (e.g., 5', 12")
+ * 2. Contraction: letter + quote + letter (e.g., it's, don't, O'Brien)
+ * 3. Trailing apostrophe: letter + quote + non-letter (e.g., dogs')
+ * 4. Bare quote: anything else (typically preceded by space/start)
+ */
+function buildQuoteClassificationPattern(
+  escapedQuote: string,
+  escapedSeparator: string
+): RegExp {
+  const primeCandidate = `(?<digit>\\d)(?<sep>${escapedSeparator}?)${escapedQuote}(?<afterSep>${escapedSeparator}?)(?![${LATIN_LETTERS}])`
+  const contraction = `(?<=[${LATIN_LETTERS}])(?<contraction>${escapedQuote})(?=[${LATIN_LETTERS}])`
+  const trailingApostrophe = `(?<=[${LATIN_LETTERS}])(?<trailing>${escapedQuote})`
+  const bareQuote = escapedQuote
+  return new RegExp(
+    `${primeCandidate}|${contraction}|${trailingApostrophe}|${bareQuote}`,
+    "g"
+  )
+}
+
+/**
+ * Replace callback that converts prime candidates while respecting quote balance.
+ * Contractions and trailing apostrophes are recognized so they don't poison the
+ * balance tracker. A prime candidate converts only when no unmatched opening
+ * quote precedes it; otherwise it acts as a closing quote.
+ */
+function balancedPrimeReplacer(primeChar: string) {
+  let balance = 0
+  return (...args: unknown[]) => {
+    const fullMatch = args[0] as string
+    const groups = args[args.length - 1] as Record<string, string | undefined>
+
+    // Contraction (letter + quote + letter): skip entirely
+    if (groups.contraction !== undefined) {
+      return fullMatch
+    }
+
+    // Trailing apostrophe (letter + quote + non-letter): close if opener exists, else skip
+    if (groups.trailing !== undefined) {
+      if (balance > 0) balance--
+      return fullMatch
+    }
+
+    const { digit, sep, afterSep } = groups
+    if (digit !== undefined) {
+      // Prime candidate: convert only if no unmatched opening quote
+      if (balance <= 0) {
+        return `${digit}${sep}${primeChar}${afterSep}`
+      }
+      balance--
+      return fullMatch
+    }
+
+    // Bare quote (preceded by space/start): opener or closer
+    if (balance <= 0) {
+      balance = 1
+    } else {
+      balance--
+    }
+    return fullMatch
+  }
+}
+
 /** Convert 5'10" to 5′10″ (prime marks). Call before smart quotes. */
 export function primeMarks(text: string, options: SymbolOptions = {}): string {
-  const chr = options.separator
+  const escapedSeparator = options.separator
     ? escapeStringRegexp(options.separator)
     : ESCAPED_DEFAULT_SEPARATOR
 
-  // Convert quotes to primes by scanning left-to-right and tracking quote balance.
-  // Contractions (letter + quote + letter, e.g. it's, O'Brien) are skipped entirely.
-  // A prime candidate (digit + quote + non-letter) converts only when no unmatched opening
-  // quote precedes it; otherwise it's treated as a closing quote.
-  // Examples: 5' → 5′ ✓, 10' x 12' → 10′ x 12′ ✓, don't measure 8' → 8′ ✓, 'Term 1' ✗
-  const quotePrimePairs = [
+  const quotePrimePairs: [string, string][] = [
     ["'", PRIME],
     ['"', DOUBLE_PRIME],
   ]
 
-  for (const [quote, prime] of quotePrimePairs) {
-    const eq = escapeStringRegexp(quote)
-    // Alternatives matched in priority order (first match wins):
-    const primeCandidate = `(?<digit>\\d)(?<sep>${chr}?)${eq}(?<afterSep>${chr}?)(?![${LATIN_LETTERS}])`
-    const contraction = `(?<=[${LATIN_LETTERS}])(?<contraction>${eq})(?=[${LATIN_LETTERS}])`
-    const trailing = `(?<=[${L}])(?<trailing>${eq})`
-    const bareQuote = eq
-    const combinedPattern = new RegExp(
-      `${primeCandidate}|${contraction}|${trailing}|${bareQuote}`,
-      "g"
-    )
-    let balance = 0
-    text = text.replace(combinedPattern, (...args) => {
-      const fullMatch = args[0] as string
-      const groups = args[args.length - 1] as Record<string, string | undefined>
-      if (groups.contraction !== undefined) {
-        return fullMatch
-      }
-      if (groups.trailing !== undefined) {
-        // Trailing apostrophe (e.g., dogs'): close if there's an opener, otherwise skip
-        if (balance > 0) balance--
-        return fullMatch
-      }
-      const { digit, sep, afterSep } = groups
-      if (digit !== undefined) {
-        // Prime candidate: convert only if no unmatched opening quote
-        if (balance <= 0) {
-          return `${digit}${sep}${prime}${afterSep}`
-        }
-        balance--
-        return fullMatch
-      }
-      // Bare quote (preceded by space/start): opener or closer
-      if (balance <= 0) {
-        balance = 1
-      } else {
-        balance--
-      }
-      return fullMatch
-    })
+  for (const [quote, primeChar] of quotePrimePairs) {
+    const escapedQuote = escapeStringRegexp(quote)
+    const pattern = buildQuoteClassificationPattern(escapedQuote, escapedSeparator)
+    text = text.replace(pattern, balancedPrimeReplacer(primeChar))
   }
 
   // Feet-inches pattern: convert " after ′ + digit (e.g., 5′10" → 5′10″)
-  const feetInchesPattern = new RegExp(`(?<primeAndNum>${PRIME}${chr}?\\d${chr}?)"`, "g")
+  const feetInchesPattern = new RegExp(
+    `(?<primeAndNum>${PRIME}${escapedSeparator}?\\d${escapedSeparator}?)"`,
+    "g"
+  )
   text = text.replace(feetInchesPattern, `$<primeAndNum>${DOUBLE_PRIME}`)
 
   return text

--- a/src/symbols.ts
+++ b/src/symbols.ts
@@ -178,9 +178,10 @@ export function primeMarks(text: string, options: SymbolOptions = {}): string {
     : ESCAPED_DEFAULT_SEPARATOR
 
   // Convert quotes to primes by scanning left-to-right and tracking quote balance.
+  // Contractions (letter + quote + letter, e.g. it's, O'Brien) are skipped entirely.
   // A prime candidate (digit + quote + non-letter) converts only when no unmatched opening
   // quote precedes it; otherwise it's treated as a closing quote.
-  // Examples: 5' → 5′ ✓, 10' x 12' → 10′ x 12′ ✓, 'Term 1' → 'Term 1' ✓
+  // Examples: 5' → 5′ ✓, 10' x 12' → 10′ x 12′ ✓, don't measure 8' → 8′ ✓, 'Term 1' ✗
   const quotePrimePairs = [
     ["'", PRIME],
     ['"', DOUBLE_PRIME],
@@ -188,20 +189,31 @@ export function primeMarks(text: string, options: SymbolOptions = {}): string {
 
   for (const [quote, prime] of quotePrimePairs) {
     const escapedQuote = escapeStringRegexp(quote)
-    // Match prime candidates (digit + quote + non-letter) OR bare quotes for balance tracking
+    // Match (in priority order):
+    // 1. Prime candidate: digit + quote + non-letter → convert or treat as closing quote
+    // 2. Contraction: letter + quote + letter (e.g., it's, don't) → skip, no balance change
+    // 3. Bare quote: anything else → track open/close balance
     const combinedPattern = new RegExp(
-      `(?<digit>\\d)(?<sep>${chr}?)${escapedQuote}(?<afterSep>${chr}?)(?![${LATIN_LETTERS}])|${escapedQuote}`,
+      `(?<digit>\\d)(?<sep>${chr}?)${escapedQuote}(?<afterSep>${chr}?)(?![${LATIN_LETTERS}])` +
+      `|(?<=[${LATIN_LETTERS}])(?<contraction>${escapedQuote})(?=[${LATIN_LETTERS}])` +
+      `|${escapedQuote}`,
       "g"
     )
     let balance = 0
-    text = text.replace(combinedPattern, (match, digit, sep, afterSep) => {
+    text = text.replace(combinedPattern, (...args) => {
+      const fullMatch = args[0] as string
+      const groups = args[args.length - 1] as Record<string, string | undefined>
+      if (groups.contraction !== undefined) {
+        return fullMatch
+      }
+      const { digit, sep, afterSep } = groups
       if (digit !== undefined) {
         // Prime candidate: convert only if no unmatched opening quote
         if (balance <= 0) {
           return `${digit}${sep}${prime}${afterSep}`
         }
         balance--
-        return match
+        return fullMatch
       }
       // Non-prime quote: track open/close balance
       if (balance <= 0) {
@@ -209,7 +221,7 @@ export function primeMarks(text: string, options: SymbolOptions = {}): string {
       } else {
         balance--
       }
-      return match
+      return fullMatch
     })
   }
 

--- a/src/symbols.ts
+++ b/src/symbols.ts
@@ -252,7 +252,9 @@ export function primeMarks(text: string, options: SymbolOptions = {}): string {
     text = text.replace(pattern, balancedPrimeReplacer(primeChar))
   }
 
-  // Feet-inches pattern: convert " after ′ + digit (e.g., 5′10" → 5′10″)
+  // Fallback for feet-inches notation: the loop above processes ' and " in separate
+  // passes, so 5'10" becomes 5′10" after the single-quote pass. This catches any
+  // remaining " that directly follows a prime + digit sequence (e.g., 5′10" → 5′10″).
   const feetInchesPattern = new RegExp(
     `(?<primeAndNum>${PRIME}${escapedSeparator}?\\d${escapedSeparator}?)"`,
     "g"

--- a/src/symbols.ts
+++ b/src/symbols.ts
@@ -188,15 +188,15 @@ export function primeMarks(text: string, options: SymbolOptions = {}): string {
   ]
 
   for (const [quote, prime] of quotePrimePairs) {
-    const escapedQuote = escapeStringRegexp(quote)
-    // Match (in priority order):
-    // 1. Prime candidate: digit + quote + non-letter → convert or treat as closing quote
-    // 2. Contraction: letter + quote + letter (e.g., it's, don't) → skip, no balance change
-    // 3. Bare quote: anything else → track open/close balance
+    const eq = escapeStringRegexp(quote)
+    const L = LATIN_LETTERS
+    // Alternatives matched in priority order (first match wins):
+    const primeCandidate = `(?<digit>\\d)(?<sep>${chr}?)${eq}(?<afterSep>${chr}?)(?![${L}])`
+    const contraction = `(?<=[${L}])(?<contraction>${eq})(?=[${L}])`
+    const trailing = `(?<=[${L}])(?<trailing>${eq})`
+    const bareQuote = eq
     const combinedPattern = new RegExp(
-      `(?<digit>\\d)(?<sep>${chr}?)${escapedQuote}(?<afterSep>${chr}?)(?![${LATIN_LETTERS}])` +
-      `|(?<=[${LATIN_LETTERS}])(?<contraction>${escapedQuote})(?=[${LATIN_LETTERS}])` +
-      `|${escapedQuote}`,
+      `${primeCandidate}|${contraction}|${trailing}|${bareQuote}`,
       "g"
     )
     let balance = 0
@@ -204,6 +204,11 @@ export function primeMarks(text: string, options: SymbolOptions = {}): string {
       const fullMatch = args[0] as string
       const groups = args[args.length - 1] as Record<string, string | undefined>
       if (groups.contraction !== undefined) {
+        return fullMatch
+      }
+      if (groups.trailing !== undefined) {
+        // Trailing apostrophe (e.g., dogs'): close if there's an opener, otherwise skip
+        if (balance > 0) balance--
         return fullMatch
       }
       const { digit, sep, afterSep } = groups
@@ -215,7 +220,7 @@ export function primeMarks(text: string, options: SymbolOptions = {}): string {
         balance--
         return fullMatch
       }
-      // Non-prime quote: track open/close balance
+      // Bare quote (preceded by space/start): opener or closer
       if (balance <= 0) {
         balance = 1
       } else {

--- a/src/symbols.ts
+++ b/src/symbols.ts
@@ -197,8 +197,22 @@ function buildQuoteClassificationPattern(
  * Contractions and trailing apostrophes are recognized so they don't poison the
  * balance tracker. A prime candidate converts only when no unmatched opening
  * quote precedes it; otherwise it acts as a closing quote.
+ *
+ * For double primes (″): since ' and " are processed in separate passes,
+ * 5'10" becomes 5′10" after the single-quote pass. Inside balanced double
+ * quotes (e.g., "He is 5′10" tall"), the balance tracker would normally treat
+ * the " after 10 as a closing quote. To handle this, we check whether the "
+ * is preceded by ′ + digits — if so, it's inches notation and converts
+ * regardless of balance.
  */
-function balancedPrimeReplacer(primeChar: string) {
+function balancedPrimeReplacer(primeChar: string, escapedSeparator: string) {
+  // Pre-compile the feet-inches context pattern for the double-prime pass.
+  // Matches when the text before a prime candidate ends with ′ followed by
+  // any mix of digits and separators (e.g., "5′1" before the "0" in 5′10").
+  const feetInchesContext = primeChar === DOUBLE_PRIME
+    ? new RegExp(`${PRIME}(?:${escapedSeparator}|\\d)*$`)
+    : null
+
   let balance = 0
   return (...args: unknown[]) => {
     const fullMatch = args[0] as string
@@ -220,6 +234,15 @@ function balancedPrimeReplacer(primeChar: string) {
       // Prime candidate: convert only if no unmatched opening quote
       if (balance <= 0) {
         return `${digit}${sep}${primeChar}${afterSep}`
+      }
+      // Inside balanced quotes: check if this is feet-inches notation
+      // (e.g., 5′10" where ″ is inches, not a closing quote)
+      if (feetInchesContext) {
+        const offset = args[args.length - 3] as number
+        const fullString = args[args.length - 2] as string
+        if (feetInchesContext.test(fullString.substring(0, offset))) {
+          return `${digit}${sep}${primeChar}${afterSep}`
+        }
       }
       balance--
       return fullMatch
@@ -249,17 +272,8 @@ export function primeMarks(text: string, options: SymbolOptions = {}): string {
   for (const [quote, primeChar] of quotePrimePairs) {
     const escapedQuote = escapeStringRegexp(quote)
     const pattern = buildQuoteClassificationPattern(escapedQuote, escapedSeparator)
-    text = text.replace(pattern, balancedPrimeReplacer(primeChar))
+    text = text.replace(pattern, balancedPrimeReplacer(primeChar, escapedSeparator))
   }
-
-  // Fallback for feet-inches notation: the loop above processes ' and " in separate
-  // passes, so 5'10" becomes 5′10" after the single-quote pass. This catches any
-  // remaining " that directly follows a prime + digit sequence (e.g., 5′10" → 5′10″).
-  const feetInchesPattern = new RegExp(
-    `(?<primeAndNum>${PRIME}${escapedSeparator}?\\d+${escapedSeparator}?)"`,
-    "g"
-  )
-  text = text.replace(feetInchesPattern, `$<primeAndNum>${DOUBLE_PRIME}`)
 
   return text
 }

--- a/src/symbols.ts
+++ b/src/symbols.ts
@@ -183,8 +183,8 @@ function buildQuoteClassificationPattern(
   escapedSeparator: string
 ): RegExp {
   const primeCandidate = `(?<digit>\\d)(?<sep>${escapedSeparator}?)${escapedQuote}(?<afterSep>${escapedSeparator}?)(?![${LATIN_LETTERS}])`
-  const contraction = `(?<=[${LATIN_LETTERS}])(?<contraction>${escapedQuote})(?=[${LATIN_LETTERS}])`
-  const trailingApostrophe = `(?<=[${LATIN_LETTERS}])(?<trailing>${escapedQuote})`
+  const contraction = `(?<=[${LATIN_LETTERS}]${escapedSeparator}?)(?<contraction>${escapedQuote})(?=${escapedSeparator}?[${LATIN_LETTERS}])`
+  const trailingApostrophe = `(?<=[${LATIN_LETTERS}]${escapedSeparator}?)(?<trailing>${escapedQuote})`
   const bareQuote = escapedQuote
   return new RegExp(
     `${primeCandidate}|${contraction}|${trailingApostrophe}|${bareQuote}`,

--- a/src/symbols.ts
+++ b/src/symbols.ts
@@ -177,25 +177,37 @@ export function primeMarks(text: string, options: SymbolOptions = {}): string {
     ? escapeStringRegexp(options.separator)
     : ESCAPED_DEFAULT_SEPARATOR
 
-  // Convert quotes to primes using quote balancing
-  // Only convert if quotes are balanced (even count before) to avoid converting closing quotes
-  // Examples: 5' → 5′ ✓, 12" → 12″ ✓, 'Term 1' → 'Term 1' ✓, "Term 1" → "Term 1" ✓
+  // Convert quotes to primes by scanning left-to-right and tracking quote balance.
+  // A prime candidate (digit + quote + non-letter) converts only when no unmatched opening
+  // quote precedes it; otherwise it's treated as a closing quote.
+  // Examples: 5' → 5′ ✓, 10' x 12' → 10′ x 12′ ✓, 'Term 1' → 'Term 1' ✓
   const quotePrimePairs = [
     ["'", PRIME],
     ['"', DOUBLE_PRIME],
   ]
 
   for (const [quote, prime] of quotePrimePairs) {
-    const pattern = new RegExp(
-      `(?<digit>\\d)(?<sep>${chr}?)${quote}(?<afterSep>${chr}?)(?![${LATIN_LETTERS}])`,
+    const escapedQuote = escapeStringRegexp(quote)
+    // Match prime candidates (digit + quote + non-letter) OR bare quotes for balance tracking
+    const combinedPattern = new RegExp(
+      `(?<digit>\\d)(?<sep>${chr}?)${escapedQuote}(?<afterSep>${chr}?)(?![${LATIN_LETTERS}])|${escapedQuote}`,
       "g"
     )
-    const quoteCountPattern = new RegExp(escapeStringRegexp(quote), "g")
-    text = text.replace(pattern, (match, digit, sep, afterSep, offset) => {
-      const textBefore = text.slice(0, offset)
-      const quoteCount = (textBefore.match(quoteCountPattern) || []).length
-      if (quoteCount % 2 === 0) {
-        return `${digit}${sep}${prime}${afterSep}`
+    let balance = 0
+    text = text.replace(combinedPattern, (match, digit, sep, afterSep) => {
+      if (digit !== undefined) {
+        // Prime candidate: convert only if no unmatched opening quote
+        if (balance <= 0) {
+          return `${digit}${sep}${prime}${afterSep}`
+        }
+        balance--
+        return match
+      }
+      // Non-prime quote: track open/close balance
+      if (balance <= 0) {
+        balance = 1
+      } else {
+        balance--
       }
       return match
     })

--- a/src/symbols.ts
+++ b/src/symbols.ts
@@ -256,7 +256,7 @@ export function primeMarks(text: string, options: SymbolOptions = {}): string {
   // passes, so 5'10" becomes 5′10" after the single-quote pass. This catches any
   // remaining " that directly follows a prime + digit sequence (e.g., 5′10" → 5′10″).
   const feetInchesPattern = new RegExp(
-    `(?<primeAndNum>${PRIME}${escapedSeparator}?\\d${escapedSeparator}?)"`,
+    `(?<primeAndNum>${PRIME}${escapedSeparator}?\\d+${escapedSeparator}?)"`,
     "g"
   )
   text = text.replace(feetInchesPattern, `$<primeAndNum>${DOUBLE_PRIME}`)

--- a/src/symbols.ts
+++ b/src/symbols.ts
@@ -189,10 +189,9 @@ export function primeMarks(text: string, options: SymbolOptions = {}): string {
 
   for (const [quote, prime] of quotePrimePairs) {
     const eq = escapeStringRegexp(quote)
-    const L = LATIN_LETTERS
     // Alternatives matched in priority order (first match wins):
-    const primeCandidate = `(?<digit>\\d)(?<sep>${chr}?)${eq}(?<afterSep>${chr}?)(?![${L}])`
-    const contraction = `(?<=[${L}])(?<contraction>${eq})(?=[${L}])`
+    const primeCandidate = `(?<digit>\\d)(?<sep>${chr}?)${eq}(?<afterSep>${chr}?)(?![${LATIN_LETTERS}])`
+    const contraction = `(?<=[${LATIN_LETTERS}])(?<contraction>${eq})(?=[${LATIN_LETTERS}])`
     const trailing = `(?<=[${L}])(?<trailing>${eq})`
     const bareQuote = eq
     const combinedPattern = new RegExp(

--- a/src/tests/symbols.test.ts
+++ b/src/tests/symbols.test.ts
@@ -210,6 +210,11 @@ describe("primeMarks", () => {
     ["The room is 10' x 12' x 8' tall", `The room is 10${UNICODE_SYMBOLS.PRIME} x 12${UNICODE_SYMBOLS.PRIME} x 8${UNICODE_SYMBOLS.PRIME} tall`],
     ['10" x 12"', `10${UNICODE_SYMBOLS.DOUBLE_PRIME} x 12${UNICODE_SYMBOLS.DOUBLE_PRIME}`],
     [`5' and 8' boards`, `5${UNICODE_SYMBOLS.PRIME} and 8${UNICODE_SYMBOLS.PRIME} boards`],
+    // Contractions before primes
+    ["it's 5' long", `it's 5${UNICODE_SYMBOLS.PRIME} long`],
+    ["don't measure 8'", `don't measure 8${UNICODE_SYMBOLS.PRIME}`],
+    ["she's 5'10\"", `she's 5${UNICODE_SYMBOLS.PRIME}10${UNICODE_SYMBOLS.DOUBLE_PRIME}`],
+    ["O'Brien's 6' fence", `O'Brien's 6${UNICODE_SYMBOLS.PRIME} fence`],
   ])('converts "%s" to "%s"', (input, expected) => {
     expect(primeMarks(input)).toBe(expected)
   })

--- a/src/tests/symbols.test.ts
+++ b/src/tests/symbols.test.ts
@@ -215,6 +215,9 @@ describe("primeMarks", () => {
     ["don't measure 8'", `don't measure 8${UNICODE_SYMBOLS.PRIME}`],
     ["she's 5'10\"", `she's 5${UNICODE_SYMBOLS.PRIME}10${UNICODE_SYMBOLS.DOUBLE_PRIME}`],
     ["O'Brien's 6' fence", `O'Brien's 6${UNICODE_SYMBOLS.PRIME} fence`],
+    // Possessive plurals before primes
+    ["the dogs' 5' leashes", `the dogs' 5${UNICODE_SYMBOLS.PRIME} leashes`],
+    ["the cats' and dogs' 5' run", `the cats' and dogs' 5${UNICODE_SYMBOLS.PRIME} run`],
   ])('converts "%s" to "%s"', (input, expected) => {
     expect(primeMarks(input)).toBe(expected)
   })

--- a/src/tests/symbols.test.ts
+++ b/src/tests/symbols.test.ts
@@ -239,6 +239,15 @@ describe("primeMarks", () => {
     expect(primeMarks(input)).toBe(expected)
   })
 
+  // Feet-inches fallback: when balanced quotes prevent the main loop from converting ",
+  // the fallback pattern (′ + digits + ") should still convert the double prime
+  it.each([
+    ['"He is 5\'10" tall"', `"He is 5${UNICODE_SYMBOLS.PRIME}10${UNICODE_SYMBOLS.DOUBLE_PRIME} tall"`],
+    ['"The shelf is 5\'11" wide"', `"The shelf is 5${UNICODE_SYMBOLS.PRIME}11${UNICODE_SYMBOLS.DOUBLE_PRIME} wide"`],
+  ])('feet-inches fallback converts "%s"', (input, expected) => {
+    expect(primeMarks(input)).toBe(expected)
+  })
+
   it("handles separator characters", () => {
     const sep = "\uE000"
     expect(primeMarks(`5${sep}'${sep}10${sep}"`, { separator: sep })).toBe(

--- a/src/tests/symbols.test.ts
+++ b/src/tests/symbols.test.ts
@@ -205,6 +205,11 @@ describe("primeMarks", () => {
     ["40° 44' 54\" N", `40° 44${UNICODE_SYMBOLS.PRIME} 54${UNICODE_SYMBOLS.DOUBLE_PRIME} N`],
     ['The board is 12" wide', `The board is 12${UNICODE_SYMBOLS.DOUBLE_PRIME} wide`],
     ['12" long', `12${UNICODE_SYMBOLS.DOUBLE_PRIME} long`],
+    // Multiple primes in one string
+    ["10' x 12'", `10${UNICODE_SYMBOLS.PRIME} x 12${UNICODE_SYMBOLS.PRIME}`],
+    ["The room is 10' x 12' x 8' tall", `The room is 10${UNICODE_SYMBOLS.PRIME} x 12${UNICODE_SYMBOLS.PRIME} x 8${UNICODE_SYMBOLS.PRIME} tall`],
+    ['10" x 12"', `10${UNICODE_SYMBOLS.DOUBLE_PRIME} x 12${UNICODE_SYMBOLS.DOUBLE_PRIME}`],
+    [`5' and 8' boards`, `5${UNICODE_SYMBOLS.PRIME} and 8${UNICODE_SYMBOLS.PRIME} boards`],
   ])('converts "%s" to "%s"', (input, expected) => {
     expect(primeMarks(input)).toBe(expected)
   })
@@ -658,7 +663,7 @@ describe("prime marks edge cases", () => {
     ['100\'50"', `100${UNICODE_SYMBOLS.PRIME}50${UNICODE_SYMBOLS.DOUBLE_PRIME}`],
     ["5' boards", `5${UNICODE_SYMBOLS.PRIME} boards`],
     ['12" pipe', `12${UNICODE_SYMBOLS.DOUBLE_PRIME} pipe`],
-    ["5', 10'", `5${UNICODE_SYMBOLS.PRIME}, 10'`],
+    ["5', 10'", `5${UNICODE_SYMBOLS.PRIME}, 10${UNICODE_SYMBOLS.PRIME}`],
   ])('handles prime mark edge: "%s"', (input, expected) => {
     expect(primeMarks(input)).toBe(expected)
   })

--- a/src/tests/symbols.test.ts
+++ b/src/tests/symbols.test.ts
@@ -239,12 +239,12 @@ describe("primeMarks", () => {
     expect(primeMarks(input)).toBe(expected)
   })
 
-  // Feet-inches fallback: when balanced quotes prevent the main loop from converting ",
-  // the fallback pattern (′ + digits + ") should still convert the double prime
+  // Feet-inches inside balanced quotes: the balance tracker detects ′ + digits
+  // before a " prime candidate and converts it to ″ regardless of quote balance
   it.each([
     ['"He is 5\'10" tall"', `"He is 5${UNICODE_SYMBOLS.PRIME}10${UNICODE_SYMBOLS.DOUBLE_PRIME} tall"`],
     ['"The shelf is 5\'11" wide"', `"The shelf is 5${UNICODE_SYMBOLS.PRIME}11${UNICODE_SYMBOLS.DOUBLE_PRIME} wide"`],
-  ])('feet-inches fallback converts "%s"', (input, expected) => {
+  ])('feet-inches inside balanced quotes converts "%s"', (input, expected) => {
     expect(primeMarks(input)).toBe(expected)
   })
 

--- a/src/tests/symbols.test.ts
+++ b/src/tests/symbols.test.ts
@@ -254,6 +254,19 @@ describe("primeMarks", () => {
       `5${sep}${UNICODE_SYMBOLS.PRIME}${sep}10${sep}${UNICODE_SYMBOLS.DOUBLE_PRIME}`
     )
   })
+
+  // Separator-aware contractions: the quote classification pattern must recognize
+  // contractions even when separators split the word across HTML element boundaries
+  it.each([
+    // Contraction with separator before the apostrophe: it<sep>'s
+    [`it${"\uE000"}'${"\uE000"}s 5'`, `it${"\uE000"}'${"\uE000"}s 5${UNICODE_SYMBOLS.PRIME}`],
+    // Contraction with separator after the apostrophe: don't
+    [`don${"\uE000"}'t measure 8'`, `don${"\uE000"}'t measure 8${UNICODE_SYMBOLS.PRIME}`],
+    // Trailing apostrophe with separator: dogs<sep>'
+    [`the dogs${"\uE000"}' 5' leashes`, `the dogs${"\uE000"}' 5${UNICODE_SYMBOLS.PRIME} leashes`],
+  ])('separator-aware contraction/trailing in "%s"', (input, expected) => {
+    expect(primeMarks(input, { separator: "\uE000" })).toBe(expected)
+  })
 })
 
 describe("fractions", () => {


### PR DESCRIPTION
## Summary
- Fix prime conversion failing for consecutive measurements like `10' x 12'` — the quote balancing algorithm now scans left-to-right tracking balance state instead of counting all prior quotes
- Skip contractions (`it's`, `don't`, `O'Brien`) and trailing apostrophes (`dogs'`) so they don't poison the balance tracker and block subsequent prime conversions
- Refactor `primeMarks` into focused helpers: `buildQuoteClassificationPattern` (4-alternative regex) and `balancedPrimeReplacer` (stateful callback)
- Add benchmark cases for multiple primes, primes after contractions/possessives, and the ambiguous leading-apostrophe case; update README scores (154→159 cases)
- Add CLAUDE.md guidance on descriptive variable names and splitting complex regex logic

## Test plan
- [x] All 1162 existing tests pass with 100% branch coverage
- [x] New test cases cover: multiple primes (`10' x 12'`), primes after contractions (`it's 5'`), primes after possessives (`dogs' 5'`)
- [x] Benchmark updated and run — punctilio 154/159 (97%)
- [ ] Verify known limitation: `'Twas a 5' board` correctly does not convert (leading apostrophe is ambiguous)

https://claude.ai/code/session_01AkAfmNdDS2DKW69UHxyruV