### PR TITLE
Fix symbol replacement to avoid false positives in operators and legal text

### DIFF
--- a/src/symbols.ts
+++ b/src/symbols.ts
@@ -122,23 +122,21 @@ const LEGAL_SYMBOL_MAP: [RegExp, string][] = [
   [/\(tm\)/gi, TRADEMARK],
 ]
 
-/** Matches a parenthesized single letter like (a), (b), (d), etc. — excludes (c). */
-const ENUMERATION_LABEL = /\([abd-z]\)/i
-
 /** Convert (c), (r), (tm) to ©, ®, ™. */
 export function legalSymbols(text: string): string {
-  // (c) needs context-aware replacement to avoid false positives:
-  // - Enumerations like "(a), (b), (c), (d)" where (c) is a list label
-  // - Legal subsections like "(c)(2)(A)" where (c) is a section reference
+  // (c) needs context-aware replacement to avoid false positives in essays,
+  // enumerations like "(a), (b), (c)", and legal citations like "(c)(2)(A)".
+  // Only convert when there's positive copyright evidence:
+  //   - Followed by a 4-digit year (19xx/20xx) within a short window
+  //   - Preceded by the word "copyright"
   text = text.replace(/\(c\)/gi, (match, offset, str) => {
-    // Skip legal subsections: (c)(2)(A) — opening paren immediately follows
-    if (str[offset + 3] === "(") return match
+    const after = str.slice(offset + 3, offset + 25)
+    if (/^\s*(?:19|20)\d{2}\b/.test(after)) return COPYRIGHT
 
-    // Skip enumerations: (a), (b), (c) — preceded by another parenthesized letter
-    const before = str.slice(Math.max(0, offset - 55), offset)
-    if (ENUMERATION_LABEL.test(before)) return match
+    const before = str.slice(Math.max(0, offset - 20), offset)
+    if (/\bcopyright\s*$/i.test(before)) return COPYRIGHT
 
-    return COPYRIGHT
+    return match
   })
 
   for (const [pattern, replacement] of LEGAL_SYMBOL_MAP) {

--- a/src/symbols.ts
+++ b/src/symbols.ts
@@ -99,11 +99,11 @@ export function multiplication(text: string, options: SymbolOptions = {}): strin
 
 /** Math symbol replacement map: ASCII → Unicode */
 const MATH_SYMBOL_MAP: [RegExp, string][] = [
-  [/!=/g, NOT_EQUAL],
+  [/!=(?!=)/g, NOT_EQUAL],
   [/\+\/-/g, PLUS_MINUS],
   [/\+-/g, PLUS_MINUS],
-  [/<=/g, LESS_EQUAL],
-  [/>=/g, GREATER_EQUAL],
+  [/<=(?!=)/g, LESS_EQUAL],
+  [/>=(?!=)/g, GREATER_EQUAL],
   [/~=/g, APPROXIMATE],
   [/=~/g, APPROXIMATE],
 ]
@@ -118,13 +118,29 @@ export function mathSymbols(text: string): string {
 
 /** Legal symbol replacement map: ASCII → Unicode */
 const LEGAL_SYMBOL_MAP: [RegExp, string][] = [
-  [/\(c\)/gi, COPYRIGHT],
   [/\(r\)/gi, REGISTERED],
   [/\(tm\)/gi, TRADEMARK],
 ]
 
+/** Matches a parenthesized single letter like (a), (b), (d), etc. — excludes (c). */
+const ENUMERATION_LABEL = /\([abd-z]\)/i
+
 /** Convert (c), (r), (tm) to ©, ®, ™. */
 export function legalSymbols(text: string): string {
+  // (c) needs context-aware replacement to avoid false positives:
+  // - Enumerations like "(a), (b), (c), (d)" where (c) is a list label
+  // - Legal subsections like "(c)(2)(A)" where (c) is a section reference
+  text = text.replace(/\(c\)/gi, (match, offset, str) => {
+    // Skip legal subsections: (c)(2)(A) — opening paren immediately follows
+    if (str[offset + 3] === "(") return match
+
+    // Skip enumerations: (a), (b), (c) — preceded by another parenthesized letter
+    const before = str.slice(Math.max(0, offset - 55), offset)
+    if (ENUMERATION_LABEL.test(before)) return match
+
+    return COPYRIGHT
+  })
+
   for (const [pattern, replacement] of LEGAL_SYMBOL_MAP) {
     text = text.replace(pattern, replacement)
   }

--- a/src/tests/symbols.test.ts
+++ b/src/tests/symbols.test.ts
@@ -122,23 +122,35 @@ describe("mathSymbols", () => {
 
 describe("legalSymbols", () => {
   it.each([
+    // (c) with year → copyright
     ["Copyright (c) 2024", `Copyright ${UNICODE_SYMBOLS.COPYRIGHT} 2024`],
-    ["(C) Acme Inc", `${UNICODE_SYMBOLS.COPYRIGHT} Acme Inc`],
+    ["(c) 2024 (r) Brand(tm)", `${UNICODE_SYMBOLS.COPYRIGHT} 2024 ${UNICODE_SYMBOLS.REGISTERED} Brand${UNICODE_SYMBOLS.TRADEMARK}`],
+    ["(C) 1999 Company", `${UNICODE_SYMBOLS.COPYRIGHT} 1999 Company`],
+    // (c) preceded by "copyright" → copyright
+    ["Copyright (c) Company", `Copyright ${UNICODE_SYMBOLS.COPYRIGHT} Company`],
+    ["copyright (C) by Author", `copyright ${UNICODE_SYMBOLS.COPYRIGHT} by Author`],
+    // (r) and (tm) always convert
     ["Brand(r)", `Brand${UNICODE_SYMBOLS.REGISTERED}`],
     ["Product (R)", `Product ${UNICODE_SYMBOLS.REGISTERED}`],
     ["Name(tm)", `Name${UNICODE_SYMBOLS.TRADEMARK}`],
     ["Name (TM)", `Name ${UNICODE_SYMBOLS.TRADEMARK}`],
-    ["(c) 2024 (r) Brand(tm)", `${UNICODE_SYMBOLS.COPYRIGHT} 2024 ${UNICODE_SYMBOLS.REGISTERED} Brand${UNICODE_SYMBOLS.TRADEMARK}`],
   ])('converts "%s" to "%s"', (input, expected) => {
     expect(legalSymbols(input)).toBe(expected)
   })
 
   it.each([
+    // Enumerations
     ["(a), (b), (c), (d)", "(a), (b), (c), (d)"],
     ["(a), (b), (C), (d)", "(a), (b), (C), (d)"],
     ["options (A) and (B) and (C)", "options (A) and (B) and (C)"],
+    // Legal subsections
     ["paragraph (c)(2)(A)", "paragraph (c)(2)(A)"],
     ["section 5(c)(1)", "section 5(c)(1)"],
+    // Standalone references without copyright context
+    ["subsection (c)", "subsection (c)"],
+    ["the (c) symbol", "the (c) symbol"],
+    ["discussed in (c) above", "discussed in (c) above"],
+    ["(C) Acme Inc", "(C) Acme Inc"],
   ])('preserves (c) in non-copyright context "%s"', (input, expected) => {
     expect(legalSymbols(input)).toBe(expected)
   })

--- a/src/tests/symbols.test.ts
+++ b/src/tests/symbols.test.ts
@@ -108,6 +108,16 @@ describe("mathSymbols", () => {
   ])('converts "%s" to "%s"', (input, expected) => {
     expect(mathSymbols(input)).toBe(expected)
   })
+
+  it.each([
+    ["!==", "!=="],
+    ["x !== y", "x !== y"],
+    ["a !== b !== c", "a !== b !== c"],
+    ["<==", "<=="],
+    [">==", ">=="],
+  ])('preserves multi-char operator "%s"', (input, expected) => {
+    expect(mathSymbols(input)).toBe(expected)
+  })
 })
 
 describe("legalSymbols", () => {
@@ -120,6 +130,16 @@ describe("legalSymbols", () => {
     ["Name (TM)", `Name ${UNICODE_SYMBOLS.TRADEMARK}`],
     ["(c) 2024 (r) Brand(tm)", `${UNICODE_SYMBOLS.COPYRIGHT} 2024 ${UNICODE_SYMBOLS.REGISTERED} Brand${UNICODE_SYMBOLS.TRADEMARK}`],
   ])('converts "%s" to "%s"', (input, expected) => {
+    expect(legalSymbols(input)).toBe(expected)
+  })
+
+  it.each([
+    ["(a), (b), (c), (d)", "(a), (b), (c), (d)"],
+    ["(a), (b), (C), (d)", "(a), (b), (C), (d)"],
+    ["options (A) and (B) and (C)", "options (A) and (B) and (C)"],
+    ["paragraph (c)(2)(A)", "paragraph (c)(2)(A)"],
+    ["section 5(c)(1)", "section 5(c)(1)"],
+  ])('preserves (c) in non-copyright context "%s"', (input, expected) => {
     expect(legalSymbols(input)).toBe(expected)
   })
 })


### PR DESCRIPTION
## Summary
This PR improves the symbol replacement logic to prevent unintended conversions in mathematical operators and legal citations, making the replacements more context-aware.

## Key Changes

- **Math symbols**: Updated regex patterns for `!=`, `<=`, and `>=` operators to use negative lookahead (`(?!=)`) to prevent matching multi-character operators like `!==`, `!==`, `<==`, and `>==`

- **Legal symbols**: Implemented context-aware replacement for `(c)` to distinguish between copyright notices and other uses:
  - Converts `(c)` when followed by a 4-digit year (19xx/20xx)
  - Converts `(c)` when preceded by the word "copyright"
  - Preserves `(c)` in enumerations like "(a), (b), (c)"
  - Preserves `(c)` in legal citations like "section 5(c)(1)"
  - Preserves `(c)` in standalone references without copyright context

- **Tests**: Added comprehensive test cases covering:
  - Multi-character operator preservation for math symbols
  - Copyright detection with years and "copyright" keyword
  - False positive prevention in enumerations, legal subsections, and standalone references

## Implementation Details

The `(c)` replacement now uses a callback function with `String.replace()` to examine surrounding context within a 20-character window before and after the match. This approach balances accuracy with performance while avoiding the complexity of more sophisticated parsing.

https://claude.ai/code/session_012EKiur6qHV8KBS3vUmhx2v