### PR TITLE
Enable non-breaking spaces by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ For manual DOM walking or custom transforms, use `transformElement` from `puncti
 
 ## Options
 
-`punctilio` doesn't enable all transformations by default. Fractions and degrees tend to match too aggressively (perfectly applying the degree transformation requires semantic meaning). Superscript letters and punctuation ligatures have spotty font support. Furthermore, `ligatures = true` can change the meaning of text by collapsing question and exclamation marks. Non-breaking spaces are also opt-in since they alter whitespace throughout the text.
+`punctilio` doesn't enable all transformations by default. Fractions and degrees tend to match too aggressively (perfectly applying the degree transformation requires semantic meaning). Superscript letters and punctuation ligatures have spotty font support. Furthermore, `ligatures = true` can change the meaning of text by collapsing question and exclamation marks. 
 
 ```typescript
 transform(text, {

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ transform(text, {
   degrees: false,          // 20 C → 20 °C
   superscript: false,      // 1st → 1ˢᵗ
   ligatures: false,        // ??? → ⁇, ?! → ⁈, !? → ⁉, !!! → !
-  nbsp: false,             // non-breaking spaces (after honorifics, between numbers and units, etc.)
+  nbsp: true,              // non-breaking spaces (after honorifics, between numbers and units, etc.)
   checkIdempotency: true,  // verify transform(transform(x)) === transform(x)
 })
 ```

--- a/src/index.ts
+++ b/src/index.ts
@@ -134,7 +134,7 @@ export interface TransformOptions {
    * Whether to insert non-breaking spaces in typographically appropriate
    * locations (after short words, between numbers and units, before
    * last words to prevent widows, after honorifics, etc.).
-   * Default: false
+   * Default: true
    */
   nbsp?: boolean
 
@@ -171,8 +171,8 @@ export { DEFAULT_SEPARATOR } from "./constants.js"
  * 6. degrees (disabled by default)
  * 7. superscript (disabled by default)
  * 8. ligatures (disabled by default)
- * 9. nbsp (non-breaking spaces, disabled by default)
- * 10. collapseSpaces (collapses multiple spaces into one)
+ * 9. collapseSpaces (collapses multiple spaces into one)
+ * 10. nbsp (non-breaking spaces, enabled by default)
  *
  * @param text - The text to transform
  * @param options - Configuration options
@@ -198,7 +198,7 @@ const defaultOpts: Required<Omit<TransformOptions, "separator">> = {
   degrees: false,
   superscript: false,
   ligatures: false,
-  nbsp: false,
+  nbsp: true,
   collapseSpaces: true,
   checkIdempotency: true,
   punctuationStyle: "american",
@@ -245,12 +245,12 @@ export function transform(text: string, options: TransformOptions = {}): string 
     text = ligaturesTransform(text, separatorOpts)
   }
 
-  if (nbsp) {
-    text = nbspTransformFn(text, separatorOpts)
-  }
-
   if (collapseSpaces) {
     text = collapseSpacesTransform(text)
+  }
+
+  if (nbsp) {
+    text = nbspTransformFn(text, separatorOpts)
   }
 
   assertSeparatorCountPreserved(original, text, separator, "transform")

--- a/src/tests/index.test.ts
+++ b/src/tests/index.test.ts
@@ -26,43 +26,43 @@ describe("transform", () => {
   it("applies both quote and dash transformations", () => {
     const input = '"Hello," she said - "it\'s pages 1-5."'
     const expected = `${LEFT_DOUBLE_QUOTE}Hello,${RIGHT_DOUBLE_QUOTE} she said${EM_DASH}${LEFT_DOUBLE_QUOTE}it${RIGHT_SINGLE_QUOTE}s pages 1${EN_DASH}5.${RIGHT_DOUBLE_QUOTE}`
-    expect(transform(input)).toBe(expected)
+    expect(transform(input, { nbsp: false })).toBe(expected)
   })
 
   it("handles complex mixed content", () => {
     const input = 'I was born in \'99 - "the best year" - and pages 10-20 are my favorite.'
     const expected = `I was born in ${RIGHT_SINGLE_QUOTE}99${EM_DASH}${LEFT_DOUBLE_QUOTE}the best year${RIGHT_DOUBLE_QUOTE}${EM_DASH}and pages 10${EN_DASH}20 are my favorite.`
-    expect(transform(input)).toBe(expected)
+    expect(transform(input, { nbsp: false })).toBe(expected)
   })
 
   it("preserves separator character", () => {
     const sep = DEFAULT_SEPARATOR
     const input = `"Hello${sep}" - test`
-    expect(transform(input, { separator: sep })).toBe(`${LEFT_DOUBLE_QUOTE}Hello${sep}${RIGHT_DOUBLE_QUOTE}${EM_DASH}test`)
+    expect(transform(input, { separator: sep, nbsp: false })).toBe(`${LEFT_DOUBLE_QUOTE}Hello${sep}${RIGHT_DOUBLE_QUOTE}${EM_DASH}test`)
   })
 
   describe("symbol transforms", () => {
     it("applies symbol transforms by default", () => {
-      expect(transform('Wait... 5x5 != 25 (c) 2024')).toBe(`Wait${ELLIPSIS} 5${MULTIPLICATION}5 ${NOT_EQUAL} 25 ${COPYRIGHT} 2024`)
+      expect(transform('Wait... 5x5 != 25 (c) 2024', { nbsp: false })).toBe(`Wait${ELLIPSIS} 5${MULTIPLICATION}5 ${NOT_EQUAL} 25 ${COPYRIGHT} 2024`)
     })
 
     it("can disable symbol transforms", () => {
-      expect(transform('Wait... 5x5 != 25', { symbols: false })).toBe('Wait... 5x5 != 25')
+      expect(transform('Wait... 5x5 != 25', { symbols: false, nbsp: false })).toBe('Wait... 5x5 != 25')
     })
   })
 
   describe("optional transforms", () => {
     it.each([
-      ["fractions disabled", "1/2", {}, "1/2"],
-      ["fractions enabled", "1/2", { fractions: true }, UNICODE_SYMBOLS.FRACTION_1_2],
-      ["degrees disabled", "20 C", {}, "20 C"],
-      ["degrees enabled", "20 C", { degrees: true }, `20 ${UNICODE_SYMBOLS.DEGREE}C`],
-      ["superscript disabled", "1st", {}, "1st"],
-      ["superscript enabled", "1st", { superscript: true }, `1${UNICODE_SYMBOLS.SUPERSCRIPT_ST}`],
-      ["ligatures disabled", "??", {}, "??"],
-      ["ligatures enabled", "??", { ligatures: true }, UNICODE_SYMBOLS.DOUBLE_QUESTION],
-      ["nbsp disabled", "Dr. Smith", {}, "Dr. Smith"],
-      ["nbsp enabled", "Dr. Smith", { nbsp: true }, `Dr.${NBSP}Smith`],
+      ["fractions disabled", "1/2", { nbsp: false }, "1/2"],
+      ["fractions enabled", "1/2", { fractions: true, nbsp: false }, UNICODE_SYMBOLS.FRACTION_1_2],
+      ["degrees disabled", "20 C", { nbsp: false }, "20 C"],
+      ["degrees enabled", "20 C", { degrees: true, nbsp: false }, `20 ${UNICODE_SYMBOLS.DEGREE}C`],
+      ["superscript disabled", "1st", { nbsp: false }, "1st"],
+      ["superscript enabled", "1st", { superscript: true, nbsp: false }, `1${UNICODE_SYMBOLS.SUPERSCRIPT_ST}`],
+      ["ligatures disabled", "??", { nbsp: false }, "??"],
+      ["ligatures enabled", "??", { ligatures: true, nbsp: false }, UNICODE_SYMBOLS.DOUBLE_QUESTION],
+      ["nbsp enabled (default)", "Dr. Smith", {}, `Dr.${NBSP}Smith`],
+      ["nbsp disabled", "Dr. Smith", { nbsp: false }, "Dr. Smith"],
     ] as const)("%s: %s → %s", (_desc, input, options, expected) => {
       expect(transform(input, options)).toBe(expected)
     })
@@ -77,7 +77,7 @@ describe("transform", () => {
       ['"Hello."', "british", periodOutside, "british"],
       ['"Hello".', "none", periodOutside, "none"],
     ] as const)("handles %s with %s style", (input, style, expected) => {
-      expect(transform(input, style ? { punctuationStyle: style } : {})).toBe(expected)
+      expect(transform(input, { ...(style ? { punctuationStyle: style } : {}), nbsp: false })).toBe(expected)
     })
   })
 
@@ -88,14 +88,14 @@ describe("transform", () => {
       [`a ${NBSP}b`, `a${NBSP}b`, "mixed spaces prefer nbsp"],
       [`a${NBSP} b`, `a${NBSP}b`, "mixed spaces prefer nbsp"],
     ])("collapses %s by default", (input, expected) => {
-      expect(transform(input)).toBe(expected)
+      expect(transform(input, { nbsp: false })).toBe(expected)
     })
 
     it.each([
       ["hello  world", "hello  world", "multiple spaces"],
       [`foo${NBSP}${NBSP}bar`, `foo${NBSP}${NBSP}bar`, "multiple nbsp"],
     ])("preserves %s when disabled", (input, expected) => {
-      expect(transform(input, { collapseSpaces: false })).toBe(expected)
+      expect(transform(input, { collapseSpaces: false, nbsp: false })).toBe(expected)
     })
   })
 
@@ -130,8 +130,8 @@ describe("transform", () => {
       [`"Hello${DEFAULT_SEPARATOR}" - ${DEFAULT_SEPARATOR}she${DEFAULT_SEPARATOR} said`, 3],
       [`.${DEFAULT_SEPARATOR}.${DEFAULT_SEPARATOR}.`, 2],
     ])('preserves %i separators in "%s"', (input, expectedCount) => {
-      expect(() => transform(input, { separator: DEFAULT_SEPARATOR })).not.toThrow()
-      expect(countSeparators(transform(input, { separator: DEFAULT_SEPARATOR }), DEFAULT_SEPARATOR)).toBe(expectedCount)
+      expect(() => transform(input, { separator: DEFAULT_SEPARATOR, nbsp: false })).not.toThrow()
+      expect(countSeparators(transform(input, { separator: DEFAULT_SEPARATOR, nbsp: false }), DEFAULT_SEPARATOR)).toBe(expectedCount)
     })
 
     it("preserves separator in ellipsis", () => {
@@ -142,7 +142,7 @@ describe("transform", () => {
 
     it("preserves consecutive separators", () => {
       const input = `a${DEFAULT_SEPARATOR}${DEFAULT_SEPARATOR}${DEFAULT_SEPARATOR}b`
-      expect(transform(input)).toBe(input)
+      expect(transform(input, { nbsp: false })).toBe(input)
     })
   })
 
@@ -154,7 +154,7 @@ describe("transform", () => {
       '"שלום"',
       "a\u200Bb",
     ])('preserves content in "%s"', (input) => {
-      expect(transform(input)).toBe(transform(input)) // idempotent
+      expect(transform(input, { nbsp: false })).toBe(transform(input, { nbsp: false })) // idempotent
     })
   })
 
@@ -181,7 +181,7 @@ describe("transform", () => {
         ['5\'10"', `5′10″`],
         ['He is 6\'2" tall', `He is 6′2″ tall`],
       ])('correctly transforms: "%s"', (input, expected) => {
-        expect(transform(input, { symbols: true, degrees: true })).toBe(expected)
+        expect(transform(input, { symbols: true, degrees: true, nbsp: false })).toBe(expected)
       })
     })
 
@@ -194,7 +194,7 @@ describe("transform", () => {
         "self-aware",
         "high-quality",
       ])('preserves compound word: "%s"', (input) => {
-        expect(transform(input)).toBe(input)
+        expect(transform(input, { nbsp: false })).toBe(input)
       })
     })
 
@@ -207,7 +207,7 @@ describe("transform", () => {
         "Claude-3-Opus",
         "Qwen1.5-1.8B",
       ])('preserves model name: "%s"', (input) => {
-        expect(transform(input)).toBe(input)
+        expect(transform(input, { nbsp: false })).toBe(input)
       })
     })
   })
@@ -216,25 +216,25 @@ describe("transform", () => {
     it("handles dialogue with dashes and quotes", () => {
       const input = '"Wait," she said -- "I don\'t think that\'s right."'
       const expected = `${LEFT_DOUBLE_QUOTE}Wait,${RIGHT_DOUBLE_QUOTE} she said${EM_DASH}${LEFT_DOUBLE_QUOTE}I don${RIGHT_SINGLE_QUOTE}t think that${RIGHT_SINGLE_QUOTE}s right.${RIGHT_DOUBLE_QUOTE}`
-      expect(transform(input)).toEqual(expected)
+      expect(transform(input, { nbsp: false })).toEqual(expected)
     })
 
     it("handles technical documentation", () => {
       const input = 'The API returns x != y when a <= b and c >= d. Error tolerance: +-5%.'
       const expected = `The API returns x ${NOT_EQUAL} y when a ≤ b and c ≥ d. Error tolerance: ±5%.`
-      expect(transform(input)).toBe(expected)
+      expect(transform(input, { nbsp: false })).toBe(expected)
     })
 
     it("handles measurement text", () => {
       const input = 'He is 6\'2" tall.'
       const expected = `He is 6${PRIME}2${DOUBLE_PRIME} tall.`
-      expect(transform(input, { symbols: true })).toEqual(expected)
+      expect(transform(input, { symbols: true, nbsp: false })).toEqual(expected)
     })
 
     it("handles copyright notices", () => {
       const input = '(c) 2024 Company(tm). All rights reserved(r).'
       const expected = `${COPYRIGHT} 2024 Company${TRADEMARK}. All rights reserved${REGISTERED}.`
-      expect(transform(input)).toEqual(expected)
+      expect(transform(input, { nbsp: false })).toEqual(expected)
     })
   })
 
@@ -244,7 +244,7 @@ describe("transform", () => {
       // When there's an open quote before a number, the quote after should close
       // not become a prime mark
       const input = '"Number 5"'
-      const result = transform(input)
+      const result = transform(input, { nbsp: false })
       // The 5" should be a closing quote, not a prime
       expect(result).toBe(`${LEFT_DOUBLE_QUOTE}Number 5${RIGHT_DOUBLE_QUOTE}`)
     })
@@ -261,7 +261,7 @@ describe("transform", () => {
         `${COPYRIGHT} 2024${EM_DASH}Room is 10×12, set to 72 °F`,
       ],
     ])('handles complex transform: "%s"', (input, expected) => {
-      expect(transform(input, { degrees: true })).toBe(expected)
+      expect(transform(input, { degrees: true, nbsp: false })).toBe(expected)
     })
   })
 
@@ -273,7 +273,7 @@ describe("transform", () => {
       ["\t", "\t"],
       ["   ", " "],
     ])('handles empty/whitespace: "%s"', (input, expected) => {
-      expect(transform(input)).toBe(expected)
+      expect(transform(input, { nbsp: false })).toBe(expected)
     })
   })
 
@@ -281,19 +281,19 @@ describe("transform", () => {
     it("handles long repeated patterns", () => {
       const input = '"Hello" '.repeat(100)
       const expected = `${LEFT_DOUBLE_QUOTE}Hello${RIGHT_DOUBLE_QUOTE} `.repeat(100)
-      expect(transform(input)).toEqual(expected)
+      expect(transform(input, { nbsp: false })).toEqual(expected)
     })
 
     it("handles long continuous text", () => {
       const input = "word ".repeat(1000)
-      const result = transform(input)
+      const result = transform(input, { nbsp: false })
       expect(result).toBe(input.trim() + " ")
     })
 
     it("converts ALL quote pairs in repeated pattern", () => {
       const count = 50
       const input = '"Hello" '.repeat(count)
-      const result = transform(input)
+      const result = transform(input, { nbsp: false })
       const leftCount = (result.match(new RegExp(LEFT_DOUBLE_QUOTE, "g")) || []).length
       const rightCount = (result.match(new RegExp(RIGHT_DOUBLE_QUOTE, "g")) || []).length
       expect(leftCount).toBe(count)
@@ -303,7 +303,7 @@ describe("transform", () => {
     it("converts ALL dashes in repeated pattern", () => {
       const count = 50
       const input = "pages 1-5 ".repeat(count)
-      const result = transform(input)
+      const result = transform(input, { nbsp: false })
       const enDashCount = (result.match(/–/g) || []).length
       expect(enDashCount).toBe(count)
     })
@@ -311,7 +311,7 @@ describe("transform", () => {
     it("converts ALL ellipses in repeated pattern", () => {
       const count = 50
       const input = "Wait... ".repeat(count)
-      const result = transform(input)
+      const result = transform(input, { nbsp: false })
       const ellipsisCount = (result.match(/…/g) || []).length
       expect(ellipsisCount).toBe(count)
     })
@@ -323,7 +323,7 @@ describe("transform", () => {
       ['"test\u200Fword"', `${LEFT_DOUBLE_QUOTE}test\u200Fword${RIGHT_DOUBLE_QUOTE}`],
       ['"caf\u0065\u0301"', `${LEFT_DOUBLE_QUOTE}caf\u0065\u0301${RIGHT_DOUBLE_QUOTE}`],
     ])('handles Unicode edge case', (input, expected) => {
-      expect(transform(input)).toBe(expected)
+      expect(transform(input, { nbsp: false })).toBe(expected)
     })
   })
 
@@ -336,6 +336,7 @@ describe("transform", () => {
         degrees: true,
         superscript: true,
         ligatures: true,
+        nbsp: false,
       })).toEqual(expected)
     })
 
@@ -345,6 +346,7 @@ describe("transform", () => {
       expect(transform(input, {
         fractions: true,
         degrees: false,
+        nbsp: false,
       })).toEqual(expected)
     })
   })
@@ -357,19 +359,19 @@ describe("transform", () => {
       [`"test${sep}word"`, `${LEFT_DOUBLE_QUOTE}test${sep}word${RIGHT_DOUBLE_QUOTE}`],
       [`${sep}${sep}"test"${sep}${sep}`, `${sep}${sep}${LEFT_DOUBLE_QUOTE}test${RIGHT_DOUBLE_QUOTE}${sep}${sep}`],
     ])('handles separator in quotes', (input, expected) => {
-      expect(transform(input, { separator: sep })).toBe(expected)
+      expect(transform(input, { separator: sep, nbsp: false })).toBe(expected)
     })
 
     it.each([
       [`word${sep} - ${sep}word`, `word${sep}${EM_DASH}${sep}word`],
       [`1${sep}-${sep}5`, `1${sep}–${sep}5`],
     ])('handles separator in dashes', (input, expected) => {
-      expect(transform(input, { separator: sep })).toBe(expected)
+      expect(transform(input, { separator: sep, nbsp: false })).toBe(expected)
     })
 
     it("preserves exact separator count through transform", () => {
       const input = `${sep}text${sep}more${sep}text${sep}`
-      const result = transform(input, { separator: sep })
+      const result = transform(input, { separator: sep, nbsp: false })
       const inputCount = (input.match(new RegExp(sep, "g")) || []).length
       const resultCount = (result.match(new RegExp(sep, "g")) || []).length
       expect(resultCount).toBe(inputCount)
@@ -377,7 +379,7 @@ describe("transform", () => {
 
     it("handles input containing separator character", () => {
       const input = `Text with ${sep} in it`
-      expect(() => transform(input, { separator: sep })).not.toThrow()
+      expect(() => transform(input, { separator: sep, nbsp: false })).not.toThrow()
     })
   })
 
@@ -399,8 +401,8 @@ describe("transform", () => {
       `1–5`,
       `Wait…`,
       `5×5`,
-      `20 °C`,
-      `${COPYRIGHT} 2024`,
+      `20${NBSP}°C`,
+      `${COPYRIGHT}${NBSP}2024`,
     ])('stable for: "%s"', (input) => {
       expect(transform(input)).toBe(input)
     })
@@ -410,19 +412,19 @@ describe("transform", () => {
     it("applies American conventions throughout", () => {
       const input = '"Hello." - word - "World."'
       const expected = `${LEFT_DOUBLE_QUOTE}Hello.${RIGHT_DOUBLE_QUOTE}${EM_DASH}word${EM_DASH}${LEFT_DOUBLE_QUOTE}World.${RIGHT_DOUBLE_QUOTE}`
-      expect(transform(input, { punctuationStyle: "american", dashStyle: "american" })).toEqual(expected)
+      expect(transform(input, { punctuationStyle: "american", dashStyle: "american", nbsp: false })).toEqual(expected)
     })
 
     it("applies British conventions throughout", () => {
       const input = '"Hello." - word - "World."'
       const expected = `${LEFT_DOUBLE_QUOTE}Hello${RIGHT_DOUBLE_QUOTE}. ${EN_DASH} word ${EN_DASH} ${LEFT_DOUBLE_QUOTE}World${RIGHT_DOUBLE_QUOTE}.`
-      expect(transform(input, { punctuationStyle: "british", dashStyle: "british" })).toEqual(expected)
+      expect(transform(input, { punctuationStyle: "british", dashStyle: "british", nbsp: false })).toEqual(expected)
     })
 
     it("applies American punctuation with British dashes", () => {
       const input = '"Hello." - word'
       const expected = `${LEFT_DOUBLE_QUOTE}Hello.${RIGHT_DOUBLE_QUOTE} ${EN_DASH} word`
-      expect(transform(input, { punctuationStyle: "american", dashStyle: "british" })).toEqual(expected)
+      expect(transform(input, { punctuationStyle: "american", dashStyle: "british", nbsp: false })).toEqual(expected)
     })
   })
 
@@ -470,7 +472,7 @@ describe("transform", () => {
       ['"test .dot"', `${LEFT_DOUBLE_QUOTE}test .dot${RIGHT_DOUBLE_QUOTE}`],
       ['"test |pipe"', `${LEFT_DOUBLE_QUOTE}test |pipe${RIGHT_DOUBLE_QUOTE}`],
     ])('handles regex special chars: "%s"', (input, expected) => {
-      expect(transform(input)).toBe(expected)
+      expect(transform(input, { nbsp: false })).toBe(expected)
     })
   })
 
@@ -485,7 +487,7 @@ describe("transform", () => {
       ["end...", `end…`],
       ["5x", `5×`],
     ])('handles boundary: "%s"', (input, expected) => {
-      expect(transform(input)).toBe(expected)
+      expect(transform(input, { nbsp: false })).toBe(expected)
     })
   })
 
@@ -497,7 +499,7 @@ describe("transform", () => {
     ] as const
 
     it.each(invalidSeparators)("rejects %s separator (%s)", (sep) => {
-      expect(() => transform('"Hello"', { separator: sep })).toThrow(
+      expect(() => transform('"Hello"', { separator: sep, nbsp: false })).toThrow(
         /Invalid separator.*must be a single character/
       )
     })
@@ -505,13 +507,13 @@ describe("transform", () => {
     const validSeparators = ["\uE000", "|", "\u2603"] // Default, pipe, snowman
 
     it.each(validSeparators)("accepts '%s' as separator", (sep) => {
-      expect(() => transform('"Hello"', { separator: sep })).not.toThrow()
+      expect(() => transform('"Hello"', { separator: sep, nbsp: false })).not.toThrow()
     })
   })
 
   describe("regex-special separator characters", () => {
     it.each(REGEX_SPECIAL_CHARS)("handles '%s' as separator", (sep) => {
-      expect(transform('"Hello"', { separator: sep })).toEqual(
+      expect(transform('"Hello"', { separator: sep, nbsp: false })).toEqual(
         `${LEFT_DOUBLE_QUOTE}Hello${RIGHT_DOUBLE_QUOTE}`
       )
     })
@@ -523,7 +525,7 @@ describe("transform", () => {
       ["RTL text", '"שלום"', `${LEFT_DOUBLE_QUOTE}שלום${RIGHT_DOUBLE_QUOTE}`],
       ["zero-width space", '"Hello\u200BWorld"', `${LEFT_DOUBLE_QUOTE}Hello\u200BWorld${RIGHT_DOUBLE_QUOTE}`],
     ] as const)("preserves %s in input", (_, input, expected) => {
-      expect(transform(input)).toEqual(expected)
+      expect(transform(input, { nbsp: false })).toEqual(expected)
     })
   })
 

--- a/src/tests/rehype.test.ts
+++ b/src/tests/rehype.test.ts
@@ -49,7 +49,7 @@ describe("rehypePunctilio", () => {
       ["math symbols", "<p>x != y</p>", `<p>x ${NOT_EQUAL} y</p>`],
       ["legal symbols", "<p>(c) 2024</p>", `<p>${COPYRIGHT} 2024</p>`],
     ])("transforms %s", async (_name, html, expected) => {
-      expect(await processHtml(html)).toEqual(expected)
+      expect(await processHtml(html, { nbsp: false })).toEqual(expected)
     })
   })
 
@@ -60,7 +60,7 @@ describe("rehypePunctilio", () => {
       ["deeply nested", '<div><p><span><strong>"Hello"</strong></span></p></div>', `<div><p><span><strong>${LDQ}Hello${RDQ}</strong></span></p></div>`],
       ["attributes", '<p class="intro" id="first">"Hello"</p>', `<p class="intro" id="first">${LDQ}Hello${RDQ}</p>`],
     ])("preserves %s", async (_name, html, expected) => {
-      expect(await processHtml(html)).toEqual(expected)
+      expect(await processHtml(html, { nbsp: false })).toEqual(expected)
     })
   })
 
@@ -71,7 +71,7 @@ describe("rehypePunctilio", () => {
       ["simple range still converts", "<p>pages <em>1</em>-5</p>", `<p>pages <em>1</em>${EN_DASH}5</p>`],
       ["genuine negative at element start", "<p><em>-5</em> degrees</p>", "<p><em>\u22125</em> degrees</p>"],
     ])("%s", async (_name, html, expected) => {
-      expect(await processHtml(html)).toEqual(expected)
+      expect(await processHtml(html, { nbsp: false })).toEqual(expected)
     })
   })
 
@@ -108,15 +108,15 @@ describe("rehypePunctilio", () => {
 
   describe("transform options passthrough", () => {
     it.each([
-      ["punctuationStyle american", '<p>"Hello."</p>', { punctuationStyle: "american" as const }, `<p>${LDQ}Hello.${RDQ}</p>`],
-      ["punctuationStyle british", '<p>"Hello."</p>', { punctuationStyle: "british" as const }, `<p>${LDQ}Hello${RDQ}.</p>`],
-      ["dashStyle american", "<p>word - word</p>", { dashStyle: "american" as const }, `<p>word${EM_DASH}word</p>`],
-      ["dashStyle british", "<p>word - word</p>", { dashStyle: "british" as const }, `<p>word ${EN_DASH} word</p>`],
-      ["symbols enabled", "<p>5x5</p>", { symbols: true }, `<p>5${MULTIPLICATION}5</p>`],
-      ["symbols disabled", "<p>5x5</p>", { symbols: false }, "<p>5x5</p>"],
-      ["fractions enabled", "<p>1/2 cup</p>", { fractions: true }, `<p>${FRACTION_1_2} cup</p>`],
-      ["fractions disabled", "<p>1/2 cup</p>", { fractions: false }, "<p>1/2 cup</p>"],
-      ["custom separator", '<p>"Hello"</p>', { separator: "\uE001" }, `<p>${LDQ}Hello${RDQ}</p>`],
+      ["punctuationStyle american", '<p>"Hello."</p>', { punctuationStyle: "american" as const, nbsp: false as const }, `<p>${LDQ}Hello.${RDQ}</p>`],
+      ["punctuationStyle british", '<p>"Hello."</p>', { punctuationStyle: "british" as const, nbsp: false as const }, `<p>${LDQ}Hello${RDQ}.</p>`],
+      ["dashStyle american", "<p>word - word</p>", { dashStyle: "american" as const, nbsp: false as const }, `<p>word${EM_DASH}word</p>`],
+      ["dashStyle british", "<p>word - word</p>", { dashStyle: "british" as const, nbsp: false as const }, `<p>word ${EN_DASH} word</p>`],
+      ["symbols enabled", "<p>5x5</p>", { symbols: true, nbsp: false as const }, `<p>5${MULTIPLICATION}5</p>`],
+      ["symbols disabled", "<p>5x5</p>", { symbols: false, nbsp: false as const }, "<p>5x5</p>"],
+      ["fractions enabled", "<p>1/2 cup</p>", { fractions: true, nbsp: false as const }, `<p>${FRACTION_1_2} cup</p>`],
+      ["fractions disabled", "<p>1/2 cup</p>", { fractions: false, nbsp: false as const }, "<p>1/2 cup</p>"],
+      ["custom separator", '<p>"Hello"</p>', { separator: "\uE001", nbsp: false as const }, `<p>${LDQ}Hello${RDQ}</p>`],
     ])("respects %s", async (_name, html, options, expected) => {
       expect(await processHtml(html, options)).toEqual(expected)
     })
@@ -145,7 +145,7 @@ describe("rehypePunctilio", () => {
         `<ul><li>${LDQ}First${RDQ}${EM_DASH}important</li><li>Pages 1${EN_DASH}5</li></ul>`,
       ],
     ])("handles %s", async (_name, html, expected) => {
-      expect(await processHtml(html)).toEqual(expected)
+      expect(await processHtml(html, { nbsp: false })).toEqual(expected)
     })
   })
 
@@ -157,7 +157,7 @@ describe("rehypePunctilio", () => {
       ["emoji", '<p>"Hello 👋"</p>', `<p>${LDQ}Hello 👋${RDQ}</p>`],
       ["links", '<p><a href="https://example.com">"Link"</a></p>', `<p><a href="https://example.com">${LDQ}Link${RDQ}</a></p>`],
     ])("handles %s", async (_name, html, expected) => {
-      expect(await processHtml(html)).toEqual(expected)
+      expect(await processHtml(html, { nbsp: false })).toEqual(expected)
     })
 
     it("is idempotent", async () => {
@@ -417,8 +417,14 @@ describe("rehypePunctilio", () => {
       expect(result).toContain(`5${NBSP}kg`)
     })
 
-    it("does not insert nbsp when option disabled (default)", async () => {
+    it("inserts nbsp by default", async () => {
       const result = await processHtml('<p>Dr. Smith has 5 kg of items.</p>')
+      expect(result).toContain(`Dr.${NBSP}Smith`)
+      expect(result).toContain(`5${NBSP}kg`)
+    })
+
+    it("does not insert nbsp when option disabled", async () => {
+      const result = await processHtml('<p>Dr. Smith has 5 kg of items.</p>', { nbsp: false })
       expect(result).not.toContain(NBSP)
     })
 
@@ -443,13 +449,13 @@ describe("rehypePunctilio", () => {
     })
 
     it("handles skipped child within non-skipped parent", async () => {
-      expect(await processHtml('<div>"Before" <code>"Inside"</code> "After"</div>')).toEqual(
+      expect(await processHtml('<div>"Before" <code>"Inside"</code> "After"</div>', { nbsp: false })).toEqual(
         `<div>${LDQ}Before${RDQ} <code>"Inside"</code> ${LDQ}After${RDQ}</div>`
       )
     })
 
     it("handles mixed skip and non-skip siblings", async () => {
-      expect(await processHtml('<article><p>"Hello"</p><pre>"Code"</pre><p>"World"</p></article>')).toEqual(
+      expect(await processHtml('<article><p>"Hello"</p><pre>"Code"</pre><p>"World"</p></article>', { nbsp: false })).toEqual(
         `<article><p>${LDQ}Hello${RDQ}</p><pre>"Code"</pre><p>${LDQ}World${RDQ}</p></article>`
       )
     })


### PR DESCRIPTION
## Summary
Changed the default behavior of the `nbsp` option from `false` to `true`, making non-breaking space insertion enabled by default. This improves typography by automatically inserting non-breaking spaces in typographically appropriate locations (after honorifics, between numbers and units, before last words to prevent widows, etc.).

## Key Changes
- Updated `defaultOpts` in `src/index.ts` to set `nbsp: true` instead of `false`
- Updated JSDoc comments to reflect that nbsp is now enabled by default
- Reordered the transform pipeline to apply `collapseSpaces` before `nbsp` transformation, ensuring proper spacing behavior
- Updated all test cases to explicitly pass `{ nbsp: false }` when testing non-nbsp behavior, maintaining test clarity and preventing unintended nbsp insertion in test assertions
- Updated README documentation to reflect the new default value

## Implementation Details
- The nbsp transformation now runs after space collapsing, which ensures that multiple spaces are properly collapsed before non-breaking spaces are inserted
- All existing tests continue to pass by explicitly disabling nbsp where needed, making the test intent clear
- The change is backward compatible for users who explicitly set `nbsp: false` in their options
- Users who want the old behavior (no nbsp insertion) can now explicitly pass `{ nbsp: false }` to the transform function

https://claude.ai/code/session_017vWKsDMbhLsz1XCGgnpUhR