### PR TITLE
feat: make 'none' style skip entire transform categories

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ transform(text, {
   punctuationStyle: 'american' | 'british' | 'none',  // default: 'american'
   dashStyle: 'american' | 'british' | 'none',         // default: 'american'
 
-  symbols: true,           // math, legal, arrows, primes
+  symbols: true,           // ellipsis, math, legal, arrows
   collapseSpaces: true,    // normalize whitespace
   fractions: false,        // 1/2 → ½
   degrees: false,          // 20 C → 20 °C
@@ -129,9 +129,10 @@ transform(text, {
 
 - Fully general prime mark conversion (e.g. `5'10"` → `5′10″`) requires semantic understanding to distinguish from closing quotes (e.g. `"Term 1"` should produce closing quotes). `punctilio` counts quotes to heuristically guess whether the matched number at the end of a quote (if not, it requires a prime mark). Other libraries like `tipograph` 0.7.4 use simpler patterns that make more mistakes.
 - The `american` style follows the [Chicago Manual of Style](https://www.chicagomanualofstyle.org/):
-  - Periods and commas go inside quotation marks (“Hello,” she said.)
+  - Periods and commas go inside quotation marks ("Hello," she said.)
   - Unspaced em-dashes between words (word—word)
 - The `british` style follows [Oxford style](https://www.ox.ac.uk/sites/files/oxford/Style%20Guide%20quick%20reference%20A-Z.pdf):
-  - Periods and commas go outside quotation marks (“Hello”, she said.)
+  - Periods and commas go outside quotation marks ("Hello", she said.)
   - Spaced en-dashes between words (word – word)
+- Setting either style to `none` skips the entire transform category: `punctuationStyle: 'none'` preserves straight quotes, apostrophes, and prime marks; `dashStyle: 'none'` preserves all hyphens, number ranges, date ranges, and minus signs.
 - `punctilio` is idempotent by design: `transform(transform(text))` always equals `transform(text)`. If performance is critical, set `checkIdempotency: false` to skip the verification pass.

--- a/README.md
+++ b/README.md
@@ -129,10 +129,10 @@ transform(text, {
 
 - Fully general prime mark conversion (e.g. `5'10"` → `5′10″`) requires semantic understanding to distinguish from closing quotes (e.g. `"Term 1"` should produce closing quotes). `punctilio` counts quotes to heuristically guess whether the matched number at the end of a quote (if not, it requires a prime mark). Other libraries like `tipograph` 0.7.4 use simpler patterns that make more mistakes.
 - The `american` style follows the [Chicago Manual of Style](https://www.chicagomanualofstyle.org/):
-  - Periods and commas go inside quotation marks ("Hello," she said.)
+  - Periods and commas go inside quotation marks (“Hello,” she said.)
   - Unspaced em-dashes between words (word—word)
 - The `british` style follows [Oxford style](https://www.ox.ac.uk/sites/files/oxford/Style%20Guide%20quick%20reference%20A-Z.pdf):
-  - Periods and commas go outside quotation marks ("Hello", she said.)
+  - Periods and commas go outside quotation marks (“Hello”, she said.)
   - Spaced en-dashes between words (word – word)
 - Setting either style to `none` skips the entire transform category: `punctuationStyle: 'none'` preserves straight quotes, apostrophes, and prime marks; `dashStyle: 'none'` preserves all hyphens, number ranges, date ranges, and minus signs.
 - `punctilio` is idempotent by design: `transform(transform(text))` always equals `transform(text)`. If performance is critical, set `checkIdempotency: false` to skip the verification pass.

--- a/src/dashes.ts
+++ b/src/dashes.ts
@@ -90,8 +90,9 @@ export function enDashNumberRange(text: string, options: DashOptions = {}): stri
 
 /** Convert month ranges to en-dash (e.g., "January-March" → "January–March"). */
 export function enDashDateRange(text: string, options: DashOptions = {}): string {
-  const chr = options.separator ? escapeStringRegexp(options.separator) : ESCAPED_DEFAULT_SEPARATOR
   const dashStyle = options.dashStyle ?? "american"
+  if (dashStyle === "none") return text
+  const chr = options.separator ? escapeStringRegexp(options.separator) : ESCAPED_DEFAULT_SEPARATOR
   const wb = wordBoundaryStart(chr)
   const wbe = wordBoundaryEnd(chr)
 
@@ -99,7 +100,7 @@ export function enDashDateRange(text: string, options: DashOptions = {}): string
     new RegExp(`${wb}(?<startMonth>${months})(?<startYear>${chr}? \\d{4})?(?<preSep>${chr}?)(?<preSpace> ?)-(?<postSpace> ?)(?<postSep>${chr}?)(?<endMonth>${months})(?<endYear> \\d{4})?${wbe}`, "g"),
     (...args) => {
       const g = args.at(-1) as Record<string, string>
-      const [pre, post] = dashStyle === "british" ? [" ", " "] : dashStyle === "none" ? [g.preSpace, g.postSpace] : ["", ""]
+      const [pre, post] = dashStyle === "british" ? [" ", " "] : ["", ""]
       return `${g.startMonth}${g.startYear || ""}${g.preSep}${pre}${EN_DASH}${post}${g.postSep}${g.endMonth}${g.endYear || ""}`
     }
   )

--- a/src/dashes.ts
+++ b/src/dashes.ts
@@ -147,7 +147,6 @@ export function minusReplace(text: string, options: DashOptions = {}): string {
  * Handles patterns like "word - word" → "word—word" (Chicago) or "word – word" (Oxford).
  */
 function convertParentheticalDashes(text: string, sep: string, style: DashStyle): string {
-  if (style === "none") return text
   const localizedDash = style === "british" ? EN_DASH : EM_DASH
   const maybeSpace = style === "british" ? " " : ""
   const escapedSep = escapeStringRegexp(sep)
@@ -216,6 +215,7 @@ function normalizeEmDashSpacing(text: string, sep: string): string {
 export function hyphenReplace(text: string, options: DashOptions = {}): string {
   const sep = options.separator ?? DEFAULT_SEPARATOR
   const style = options.dashStyle ?? "american"
+  if (style === "none") return text
   text = minusReplace(text, options)
   text = convertParentheticalDashes(text, sep, style)
   if (style === "american") text = normalizeEmDashSpacing(text, sep)

--- a/src/index.ts
+++ b/src/index.ts
@@ -81,24 +81,32 @@ export interface TransformOptions {
   collapseSpaces?: boolean
 
   /**
-   * How to handle punctuation placement around quotation marks.
+   * How to handle quotes and punctuation placement.
    *
-   * - `"american"` (default): Chicago style. Periods and commas go inside quotes.
+   * - `"american"` (default): Chicago style. Converts straight quotes to smart
+   *   quotes, converts prime marks, and places periods/commas inside quotes.
    *   Example: "Hello." and "Hello,"
-   * - `"british"`: Oxford style. Periods and commas go outside quotes.
+   * - `"british"`: Oxford style. Converts straight quotes to smart quotes,
+   *   converts prime marks, and places periods/commas outside quotes.
    *   Example: "Hello". and "Hello",
-   * - `"none"`: Don't modify punctuation placement
+   * - `"none"`: Skip all quote and punctuation transforms entirely.
+   *   Straight quotes, apostrophes, and prime marks are left unmodified.
    *
    * Default: "american"
    */
   punctuationStyle?: PunctuationStyle
 
   /**
-   * How to style parenthetical dashes.
+   * How to style dashes.
    *
-   * - `"american"` (default): Chicago style. Unspaced em dash (word—word)
-   * - `"british"`: Oxford style. Spaced en dash (word – word)
-   * - `"none"`: Don't convert parenthetical dashes
+   * - `"american"` (default): Chicago style. Converts parenthetical dashes to
+   *   unspaced em dashes (word—word), number ranges to en dashes (1–5),
+   *   date ranges to en dashes (January–March), and hyphens to minus signs (−5).
+   * - `"british"`: Oxford style. Converts parenthetical dashes to spaced en
+   *   dashes (word – word), with the same number range, date range, and minus
+   *   sign conversions.
+   * - `"none"`: Skip all dash transforms entirely. Hyphens, number ranges,
+   *   date ranges, and minus signs are left unmodified.
    *
    * Default: "american"
    */
@@ -222,7 +230,9 @@ export function transform(text: string, options: TransformOptions = {}): string 
   const { symbols, fractions, degrees, superscript, ligatures, nbsp, collapseSpaces, checkIdempotency, ...separatorOpts } = { ...defaultOpts, ...options }
 
   text = hyphenReplace(text, separatorOpts)
-  text = primeMarks(text, separatorOpts)
+  if (separatorOpts.punctuationStyle !== "none") {
+    text = primeMarks(text, separatorOpts)
+  }
   text = niceQuotes(text, separatorOpts)
 
   if (symbols) {

--- a/src/quotes.ts
+++ b/src/quotes.ts
@@ -123,6 +123,7 @@ function applyPunctuationStyle(text: string, sep: string, style: PunctuationStyl
 export function niceQuotes(text: string, options: QuoteOptions = {}): string {
   const sep = options.separator ?? DEFAULT_SEPARATOR
   const punctuationStyle = options.punctuationStyle ?? "american"
+  if (punctuationStyle === "none") return text
 
   text = convertSingleQuotes(text, sep)
   text = convertDoubleQuotes(text, sep)

--- a/src/tests/dashes.test.ts
+++ b/src/tests/dashes.test.ts
@@ -236,14 +236,14 @@ describe("enDashDateRange", () => {
     })
   })
 
-  describe("none style (preserve spacing)", () => {
+  describe("none style (skip entirely)", () => {
     it.each([
-      ["January-March", `January${EN_DASH}March`],
-      ["January - March", `January ${EN_DASH} March`],
-      ["October 2012 - December 2014", `October 2012 ${EN_DASH} December 2014`],
-      ["Oct 2012-Dec 2014", `Oct 2012${EN_DASH}Dec 2014`],
-    ])('should convert "%s" to "%s"', (input, expected) => {
-      expect(enDashDateRange(input, { dashStyle: "none" })).toBe(expected)
+      ["January-March"],
+      ["January - March"],
+      ["October 2012 - December 2014"],
+      ["Oct 2012-Dec 2014"],
+    ])("skips all date range transforms: %s", (input) => {
+      expect(enDashDateRange(input, { dashStyle: "none" })).toBe(input)
     })
   })
 

--- a/src/tests/dashes.test.ts
+++ b/src/tests/dashes.test.ts
@@ -493,16 +493,11 @@ describe("dashStyle option", () => {
     it.each([
       ["word - word"],
       ["word -- word"],
-    ])("leaves parenthetical dashes unchanged: %s", (input) => {
+      ["pages 1-5"],
+      ["-5"],
+      ["January-March"],
+    ])("skips all dash transforms: %s", (input) => {
       expect(hyphenReplace(input, { dashStyle: "none" })).toBe(input)
-    })
-
-    it("still converts number ranges", () => {
-      expect(hyphenReplace("pages 1-5", { dashStyle: "none" })).toBe(`pages 1${EN_DASH}5`)
-    })
-
-    it("still converts minus signs", () => {
-      expect(hyphenReplace("-5", { dashStyle: "none" })).toBe(`${MINUS}5`)
     })
   })
 

--- a/src/tests/index.test.ts
+++ b/src/tests/index.test.ts
@@ -75,9 +75,17 @@ describe("transform", () => {
     it.each([
       ['"Hello".', undefined, periodInside, "american (default)"],
       ['"Hello."', "british", periodOutside, "british"],
-      ['"Hello".', "none", periodOutside, "none"],
+      ['"Hello".', "none", '"Hello".', "none (skips all quote transforms)"],
     ] as const)("handles %s with %s style", (input, style, expected) => {
       expect(transform(input, { ...(style ? { punctuationStyle: style } : {}), nbsp: false })).toBe(expected)
+    })
+
+    it("none skips prime marks too", () => {
+      expect(transform('5\'10"', { punctuationStyle: "none", nbsp: false })).toBe('5\'10"')
+    })
+
+    it("none skips all quote transforms while other transforms still apply", () => {
+      expect(transform('"Wait..." she said', { punctuationStyle: "none", nbsp: false })).toBe(`"Wait${ELLIPSIS}" she said`)
     })
   })
 
@@ -425,6 +433,23 @@ describe("transform", () => {
       const input = '"Hello." - word'
       const expected = `${LEFT_DOUBLE_QUOTE}Hello.${RIGHT_DOUBLE_QUOTE} ${EN_DASH} word`
       expect(transform(input, { punctuationStyle: "american", dashStyle: "british", nbsp: false })).toEqual(expected)
+    })
+
+    it("skips all dash transforms with dashStyle none", () => {
+      const input = '"Hello" - pages 1-5, -3'
+      const expected = `${LEFT_DOUBLE_QUOTE}Hello${RIGHT_DOUBLE_QUOTE} - pages 1-5, -3`
+      expect(transform(input, { dashStyle: "none", nbsp: false })).toEqual(expected)
+    })
+
+    it("skips everything with both set to none", () => {
+      const input = '"Hello" - pages 1-5'
+      expect(transform(input, { punctuationStyle: "none", dashStyle: "none", nbsp: false })).toBe(input)
+    })
+
+    it("skips quotes but applies dashes with mixed none", () => {
+      const input = '"Hello" - pages 1-5'
+      const expected = `"Hello"${EM_DASH}pages 1${EN_DASH}5`
+      expect(transform(input, { punctuationStyle: "none", dashStyle: "american", nbsp: false })).toEqual(expected)
     })
   })
 

--- a/src/tests/quotes.test.ts
+++ b/src/tests/quotes.test.ts
@@ -320,12 +320,10 @@ describe("niceQuotes", () => {
         [periodOutsideDouble],
         [periodInsideDouble],
         [commaOutsideDouble],
-      ])("leaves punctuation unchanged: %s", (input) => {
+        ['"Hello".'],
+        ["It's a test"],
+      ])("skips all quote transforms: %s", (input) => {
         expect(niceQuotes(input, { punctuationStyle: "none" })).toBe(input)
-      })
-
-      it("still converts straight quotes to smart quotes", () => {
-        expect(niceQuotes('"Hello".', { punctuationStyle: "none" })).toBe(periodOutsideDouble)
       })
     })
   })


### PR DESCRIPTION
## Summary
- Previously, `punctuationStyle: "none"` only skipped punctuation placement but still converted straight quotes to smart quotes, and `dashStyle: "none"` only skipped parenthetical dashes but still converted minus signs, number ranges, and date ranges
- Now `"none"` truly means "skip the entire category," making punctilio fully customizable

## Changes
- `punctuationStyle: "none"` skips smart quotes, prime marks, and punctuation placement entirely
- `dashStyle: "none"` skips all dash transforms (parenthetical, number ranges, date ranges, minus signs) entirely
- Made `enDashDateRange` (exported sub-function) consistent with `hyphenReplace` for `dashStyle: "none"`
- Removed dead code: `convertParentheticalDashes` guard for `"none"` (now unreachable) and `enDashDateRange` dead ternary branch
- Updated JSDoc and README to document the new behavior
- Fixed README `symbols` comment (primes are tied to `punctuationStyle`, not `symbols`)

## Testing
- All 1191 tests pass with 100% branch coverage
- Updated existing `"none"` tests to expect no-op behavior
- Added new tests: prime marks skipped, mixed `none` combinations, `enDashDateRange` direct calls

https://claude.ai/code/session_01Qi3ssd1apynye81p9Bk3G4