### PR TITLE
chore: sync from template repository

### DIFF
--- a/.claude/README.md
+++ b/.claude/README.md
@@ -6,12 +6,12 @@ This directory contains configuration and skills for Claude Code.
 
 ```
 .claude/
-├── settings.json               # Claude Code hooks configuration
+├── settings.json              # Claude Code hooks configuration
 ├── hooks/
-│   ├── session-setup.sh       # Runs on session start (installs tools, configures git)
-│   ├── pre-push-check.sh     # Runs before git push / gh pr (build, lint, typecheck)
-│   ├── lib-checks.sh         # Shared library with utility functions for hooks
-│   └── verify-ci-on-stop.sh  # Runs on session stop (blocks if checks fail)
+│   ├── session-setup.sh      # Runs on session start (installs tools, configures git)
+│   ├── pre-push-check.sh    # Runs before git push / gh pr (build, lint, typecheck)
+│   ├── verify_ci.py          # Runs on session stop (blocks if checks fail, max 3 retries)
+│   └── lib-checks.sh        # Shared bash helpers (exists, has_script)
 └── skills/
     └── pr-creation/       # PR creation workflow with self-critique
         ├── SKILL.md       # Main skill entrypoint
@@ -27,7 +27,7 @@ When Claude Code starts a session, it automatically runs `session-setup.sh` whic
 
 1. **Installs tools**: shfmt, gh (GitHub CLI), jq, shellcheck
 2. **Configures git hooks**: Sets `core.hooksPath` to `.hooks/`
-3. **Validates GitHub CLI auth**: Warns if `gh` or `GH_TOKEN` is missing
+3. **Validates GitHub CLI auth**: Fails fast if `GH_TOKEN` is missing
 4. **Detects GitHub repo**: Extracts `owner/repo` from proxy remotes in web sessions
 5. **Installs dependencies**: Node (pnpm/npm) and Python (uv) if applicable
 
@@ -44,11 +44,13 @@ Only runs scripts that are actually configured in `package.json` — skips place
 
 ### Stop Hook
 
-When Claude finishes a session, `verify-ci-on-stop.sh` blocks completion if any checks fail:
+When Claude finishes a session, `verify_ci.py` blocks completion if any checks fail:
 
 - Runs test, lint, and typecheck (superset of pre-push checks — adds tests)
 - Returns `decision: "block"` with failure details so Claude continues fixing issues
 - Returns `decision: "approve"` if all checks pass
+- **Retry limit**: After 3 failed attempts (configurable via `MAX_STOP_RETRIES`), approves anyway with a warning to prevent infinite token burn
+- Written in Python for reliability — reads `package.json` directly, no `jq` dependency
 
 ### Skills
 

--- a/.claude/hooks/pre-push-check.sh
+++ b/.claude/hooks/pre-push-check.sh
@@ -12,14 +12,13 @@ FAILED=0
 
 run_check() {
   local name="$1" cmd="$2"
-  echo "=== $name ===" >&2
-  if ! $cmd 2>&1; then
-    echo "$name FAILED" >&2
+  local output
+  if ! output=$($cmd 2>&1); then
+    echo "=== $name FAILED ===" >&2
+    echo "$output" >&2
     FAILED=1
   fi
 }
-
-echo "=== PRE-PR CHECKS ===" >&2
 
 # Node.js checks (tests intentionally omitted — they run in CI and the stop hook)
 has_script build && run_check "build" "pnpm build"

--- a/.claude/hooks/session-setup.sh
+++ b/.claude/hooks/session-setup.sh
@@ -112,6 +112,7 @@ fi
 #######################################
 
 if [ -f "$PROJECT_DIR/package.json" ]; then
+	# Always run install (git hooks are configured in package.json postinstall)
 	if command -v pnpm &>/dev/null; then
 		pnpm install --silent || warn "Failed to install Node dependencies"
 	elif command -v npm &>/dev/null; then
@@ -121,6 +122,7 @@ fi
 
 if [ -f "$PROJECT_DIR/uv.lock" ] && command -v uv &>/dev/null; then
 	uv sync --quiet || warn "Failed to sync Python dependencies"
+	# Add .venv/bin to PATH so Python tools are available to hooks
 	if [ -d "$PROJECT_DIR/.venv/bin" ]; then
 		export PATH="$PROJECT_DIR/.venv/bin:$PATH"
 		if [ -n "${CLAUDE_ENV_FILE:-}" ]; then

--- a/.claude/skills/pr-creation/SKILL.md
+++ b/.claude/skills/pr-creation/SKILL.md
@@ -40,7 +40,7 @@ Do **NOT** use this skill for:
 ## Prerequisites
 
 - GitHub CLI (`gh`) must be authenticated
-- All changes must be committed to a feature branch (not `main`/`master`)
+- All changes must be committed to a feature branch (not `$CLAUDE_CODE_BASE_REF`/`master`)
 
 ## Updating an Existing PR
 
@@ -56,12 +56,12 @@ Before updating an existing PR (pushing new commits, editing the description, et
 
 ### Step 1: Gather Context
 
-1. Identify the base branch (typically `main` or `master`)
+1. The base branch is in the env variable `$CLAUDE_CODE_BASE_REF` 
 2. Run `git diff <base-branch>...HEAD` to see all changes
 3. Run `git log <base-branch>..HEAD --oneline` to see all commits
 4. Review the changed files to understand the scope
 
-### Step 2: Self-Critique (Required)
+### Step 2: Self-Critique
 
 **Before creating the PR**, you MUST read [critique-prompt.md](critique-prompt.md) and launch a critique sub-agent using the Task tool:
 
@@ -75,7 +75,7 @@ Do NOT skip reading the resource file — it contains the detailed checklist the
 
 1. For each issue raised, determine if it's valid
 2. Make necessary fixes and commit them
-3. If you fixed more than 3 issues or made structural changes, re-run the critique
+3. If you fixed more than 3 issues or made structural changes, re-run the critique (max 2 re-runs total — if issues persist after 2 rounds of critique, proceed to validation rather than looping indefinitely)
 
 ### Step 4: Run Validation
 
@@ -86,11 +86,16 @@ Run the project's test/lint/typecheck commands (see [pr-templates.md](pr-templat
 You MUST read [pr-templates.md](pr-templates.md) for the PR template and formatting guidelines before this step.
 
 1. Push the branch: `git push -u origin HEAD`
-2. Create the PR using `gh pr create` with the template from the resource file
+2. Check if a PR already exists for the current branch:
+   ```bash
+   EXISTING_PR=$(gh pr list --head "$(git branch --show-current)" --json number --jq '.[0].number' 2>/dev/null)
+   ```
+   If a PR already exists, update it with `gh pr edit` instead of creating a new one.
+3. Create the PR using `gh pr create` with the template from the resource file. Make sure that you use the target branch
 
 After creating the PR, and after any subsequent fix commits, update the PR description with `gh pr edit --body "..."` to reflect the current state of all changes.
 
-### Step 6: Wait for CI Checks
+### Step 6: Wait for CI Checks (MANDATORY)
 
 1. Run `gh pr checks <pr-number> --watch` to monitor
 2. If any checks fail, investigate and fix the issues
@@ -109,8 +114,8 @@ Provide the PR URL and confirm all CI checks have passed.
 
 **Claude's actions:**
 
-1. Runs `git diff main...HEAD` — sees changes in `src/auth/login.ts` and `tests/auth/login.test.ts`
-2. Runs `git log main..HEAD --oneline` — sees 2 commits
+1. Runs `git diff $CLAUDE_CODE_BASE_REF...HEAD` — sees changes in `src/auth/login.ts` and `tests/auth/login.test.ts`
+2. Runs `git log $CLAUDE_CODE_BASE_REF..HEAD --oneline` — sees 2 commits
 3. Launches critique sub-agent with the diff
 4. Critique returns: "Looks good, minor suggestion to add null check on line 42"
 5. Fixes the null check, commits: `fix: add null check for empty session token`
@@ -128,8 +133,8 @@ Provide the PR URL and confirm all CI checks have passed.
 
 **Claude's actions:**
 
-1. Runs `git diff main...HEAD` — sees changes across 8 files including new components, tests, and API routes
-2. Runs `git log main..HEAD --oneline` — sees 5 commits
+1. Runs `git diff $CLAUDE_CODE_BASE_REF...HEAD` — sees changes across 8 files including new components, tests, and API routes
+2. Runs `git log $CLAUDE_CODE_BASE_REF..HEAD --oneline` — sees 5 commits
 3. Launches critique sub-agent with the full diff
 4. Critique returns 4 issues: unused import, missing error boundary, test not covering edge case, over-engineered helper
 5. Fixes all 4 issues across 2 additional commits
@@ -144,7 +149,7 @@ Provide the PR URL and confirm all CI checks have passed.
 
 **User says:** "Push this up"
 
-**Claude asks:** "I see you have changes on branch `feat/user-dashboard`. Would you like me to create a pull request against `main`, or just push the branch without creating a PR?"
+**Claude asks:** "I see you have changes on branch `feat/user-dashboard`. Would you like me to create a pull request against `$CLAUDE_CODE_BASE_REF`, or just push the branch without creating a PR?"
 
 ## Error Handling
 
@@ -152,4 +157,5 @@ Provide the PR URL and confirm all CI checks have passed.
 - **Tests fail**: Fix the tests, don't skip them
 - **`gh` not authenticated**: Tell user to run `gh auth login` or set `GH_TOKEN`
 - **Push fails**: Check branch permissions and remote configuration
+- **PR already exists (HTTP 422)**: Check for existing PRs first with `gh pr list --head "$(git branch --show-current)"`, then use `gh pr edit` to update
 - **No changes to PR**: Confirm with the user that work is committed

--- a/.claude/skills/pr-creation/pr-templates.md
+++ b/.claude/skills/pr-creation/pr-templates.md
@@ -2,6 +2,14 @@
 
 ## PR Creation Command
 
+First, check if a PR already exists for the current branch:
+
+```bash
+EXISTING_PR=$(gh pr list --head "$(git branch --show-current)" --json number --jq '.[0].number' 2>/dev/null)
+```
+
+If `EXISTING_PR` is non-empty, update the existing PR with `gh pr edit` instead of creating a new one.
+
 ```bash
 gh pr create --title "<type>: <description>" --body "$(cat <<'EOF'
 ## Summary
@@ -12,6 +20,12 @@ gh pr create --title "<type>: <description>" --body "$(cat <<'EOF'
 
 ## Testing
 <How the changes were tested>
+
+## Lessons Learned
+<Optional: generalizable insights that could improve the template for all projects>
+<Leave this section empty or omit it if there are no lessons worth sharing>
+<Examples: "CLAUDE.md should mention X", "The pre-push hook should also check Y",
+ "Template sync should handle Z edge case">
 
 https://claude.ai/code/session_...
 EOF
@@ -34,6 +48,7 @@ Use imperative mood with a Conventional Commits type prefix:
 - Focus the summary on the "why", not the "what"
 - List concrete changes
 - Note any breaking changes
+- Include a "Lessons Learned" section if you discovered generalizable insights that could improve the template (this triggers the phone-home workflow to suggest improvements to the template repo)
 - Include the Claude session URL at the end
 
 ## Updating PR Description After Additional Commits
@@ -48,6 +63,9 @@ gh pr edit --body "$(cat <<'EOF'
 
 ## Testing
 <Updated testing information>
+
+## Lessons Learned
+<Optional: generalizable insights from this session>
 
 https://claude.ai/code/session_...
 EOF

--- a/.github/workflows/template-sync.yaml
+++ b/.github/workflows/template-sync.yaml
@@ -4,8 +4,23 @@ name: Sync from Template
 # Runs daily or manually via "Run workflow" button.
 # No setup required - works out of the box.
 #
-# When conflicts are detected (local customizations vs template updates),
-# the PR will include detailed conflict information for Claude to help resolve.
+# Features:
+# - Detects new files, changed files, and deleted files from the template
+# - Preserves local customizations (reports conflicts instead of overwriting)
+# - Tracks which template version the repo is synced to (.template-version)
+# - Requests @claude review for conflict resolution
+#
+# =============================================================================
+# HANDLING CUSTOMIZATIONS DURING SYNC
+# =============================================================================
+# Projects may have local customizations in synced files (e.g., project-specific
+# tools in session-setup.sh, custom pre-commit checks). When resolving conflicts:
+#
+# 1. Look for header comments like "IMPORTANT: This file has project-specific
+#    customizations" or "Future Claudes: Leave these customizations as-is"
+# 2. Preserve local customizations while adopting new template features
+# 3. When in doubt, keep local changes - they exist for a reason
+# =============================================================================
 
 on:
   workflow_dispatch:
@@ -22,7 +37,7 @@ on:
 env:
   TEMPLATE_REPO: "alexander-turner/claude-automation-template"
   # Only sync core automation files that don't need customization
-  SYNC_PATHS: ".claude .hooks .github/workflows/template-sync.yaml .github/workflows/dependabot-auto-merge.yaml"
+  SYNC_PATHS: ".claude .hooks .github/scripts .github/workflows/template-sync.yaml .github/workflows/dependabot-auto-merge.yaml .github/workflows/claude.yaml .github/workflows/phone-home.yaml"
   # These are excluded because they require project-specific customization
   # (comment-on-failed-checks needs workflow names, lint/test need project scripts)
   EXCLUDE_PATHS: ""
@@ -36,16 +51,33 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout child repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Checkout template repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: ${{ env.TEMPLATE_REPO }}
           path: _template
           token: ${{ secrets.TEMPLATE_SYNC_TOKEN || secrets.GITHUB_TOKEN }}
+
+      - name: Check token workflow scope
+        env:
+          TOKEN: ${{ secrets.TEMPLATE_SYNC_TOKEN || secrets.GITHUB_TOKEN }}
+        run: |
+          # GitHub requires 'workflow' scope on PATs to push .github/workflows/ changes.
+          # Check the x-oauth-scopes response header from the GitHub API.
+          SCOPES=$(curl -sS -I -H "Authorization: token $TOKEN" \
+            https://api.github.com/user 2>/dev/null \
+            | grep -i '^x-oauth-scopes:' | sed 's/^[^:]*: //' | tr -d '\r\n' || true)
+
+          if echo "$SCOPES" | tr ',' '\n' | sed 's/^ *//' | grep -qx 'workflow'; then
+            echo "Token has 'workflow' scope."
+          else
+            echo "::error::TEMPLATE_SYNC_TOKEN lacks the 'workflow' scope, which GitHub requires to push changes to .github/workflows/ files. Add the 'workflow' scope to your PAT at https://github.com/settings/tokens and update the TEMPLATE_SYNC_TOKEN repository secret."
+            exit 1
+          fi
 
       - name: Sync template files with conflict detection
         id: sync
@@ -55,6 +87,42 @@ jobs:
           # Initialize tracking files
           : > /tmp/conflict_files.txt
           : > /tmp/conflict_report.md
+          : > /tmp/deleted_files.txt
+
+          #############################################
+          # Version tracking
+          #############################################
+
+          TEMPLATE_SHA=$(git -C _template rev-parse HEAD)
+          TEMPLATE_SHA_SHORT=$(echo "$TEMPLATE_SHA" | head -c 7)
+          echo "template_sha=$TEMPLATE_SHA" >> $GITHUB_OUTPUT
+          echo "template_sha_short=$TEMPLATE_SHA_SHORT" >> $GITHUB_OUTPUT
+
+          PREV_SHA=""
+          if [ -f .template-version ]; then
+            PREV_SHA=$(cat .template-version)
+            echo "Previous template version: $PREV_SHA"
+          else
+            echo "No previous template version found (first sync)"
+          fi
+          echo "Current template version: $TEMPLATE_SHA"
+
+          # Generate changelog between versions if we have a previous SHA
+          if [ -n "$PREV_SHA" ] && [ "$PREV_SHA" != "$TEMPLATE_SHA" ]; then
+            CHANGELOG=$(git -C _template log --oneline "$PREV_SHA..$TEMPLATE_SHA" 2>/dev/null || echo "Could not generate changelog (previous SHA may no longer exist)")
+            if [ -n "$CHANGELOG" ]; then
+              echo "changelog<<CHANGELOG_DELIMITER_8a2b1c" >> $GITHUB_OUTPUT
+              echo "$CHANGELOG" >> $GITHUB_OUTPUT
+              echo "CHANGELOG_DELIMITER_8a2b1c" >> $GITHUB_OUTPUT
+            fi
+          fi
+
+          # Update version file
+          echo "$TEMPLATE_SHA" > .template-version
+
+          #############################################
+          # File processing
+          #############################################
 
           # Function to process a single file
           process_file() {
@@ -115,7 +183,42 @@ jobs:
             echo "  -> Preserved local version (manual merge required)"
           }
 
-          # Process each sync path
+          #############################################
+          # Detect deleted files
+          #############################################
+
+          # Only detect deletions if we have a previous version to compare against.
+          # A file is "deleted" only if it existed in the template at PREV_SHA but
+          # no longer exists at the current template HEAD. This avoids false positives
+          # for project-specific files that were never in the template.
+          if [ -n "$PREV_SHA" ]; then
+            # Get the list of files that existed in the template at the previous sync point
+            git -C _template ls-tree -r --name-only "$PREV_SHA" 2>/dev/null > /tmp/prev_template_files.txt || true
+
+            for path in $SYNC_PATHS; do
+              skip=false
+              for exclude in $EXCLUDE_PATHS; do
+                [ "$path" = "$exclude" ] && skip=true && break
+              done
+              [ "$skip" = "true" ] && continue
+
+              # Find files under this path that existed in the previous template but not in current
+              while IFS= read -r prev_file; do
+                # Only consider files under the current sync path
+                case "$prev_file" in "$path"|"$path/"*) ;; *) continue ;; esac
+
+                if [ ! -f "_template/$prev_file" ]; then
+                  echo "DELETED in template: $prev_file"
+                  echo "$prev_file" >> /tmp/deleted_files.txt
+                fi
+              done < /tmp/prev_template_files.txt
+            done
+          fi
+
+          #############################################
+          # Process sync paths
+          #############################################
+
           for path in $SYNC_PATHS; do
             # Skip if in exclude list
             skip=false
@@ -148,65 +251,98 @@ jobs:
           # Clean up template
           rm -rf _template
 
-          # Check for conflicts
+          #############################################
+          # Set outputs
+          #############################################
+
+          # Conflicts
           if [ -s /tmp/conflict_files.txt ]; then
             conflicts=$(tr '\n' ' ' < /tmp/conflict_files.txt)
             echo "has_conflicts=true" >> $GITHUB_OUTPUT
             echo "conflict_files=$conflicts" >> $GITHUB_OUTPUT
 
-            # Store conflict report using unique delimiter to avoid collisions
             echo "conflict_report<<CONFLICT_REPORT_DELIMITER_7f3d9a" >> $GITHUB_OUTPUT
             cat /tmp/conflict_report.md >> $GITHUB_OUTPUT
             echo "CONFLICT_REPORT_DELIMITER_7f3d9a" >> $GITHUB_OUTPUT
 
-            # Create marker file to ensure PR is created even if only conflicts exist
             echo "Template updates available for: $conflicts" > .template-sync-conflicts
           else
             echo "has_conflicts=false" >> $GITHUB_OUTPUT
-            # Remove marker if no conflicts
             rm -f .template-sync-conflicts
           fi
 
-          # Check for any changes (new files added)
+          # Deletions
+          if [ -s /tmp/deleted_files.txt ]; then
+            deleted=$(tr '\n' ' ' < /tmp/deleted_files.txt)
+            echo "has_deletions=true" >> $GITHUB_OUTPUT
+            echo "deleted_files=$deleted" >> $GITHUB_OUTPUT
+          else
+            echo "has_deletions=false" >> $GITHUB_OUTPUT
+          fi
+
+          # Changes (new files added or version file updated)
           if git diff --quiet && [ -z "$(git ls-files --others --exclude-standard)" ]; then
             echo "has_changes=false" >> $GITHUB_OUTPUT
           else
             echo "has_changes=true" >> $GITHUB_OUTPUT
-            # Combine changed and new files, convert newlines to spaces
             changed_paths=$({ git diff --name-only; git ls-files --others --exclude-standard; } | tr '\n' ' ')
             echo "changed_paths=$changed_paths" >> $GITHUB_OUTPUT
           fi
 
       - name: Show diff (dry run)
         if: inputs.dry-run == 'true' && steps.sync.outputs.has_changes == 'true'
+        env:
+          HAS_CONFLICTS: ${{ steps.sync.outputs.has_conflicts }}
+          HAS_DELETIONS: ${{ steps.sync.outputs.has_deletions }}
+          CONFLICT_FILES: ${{ steps.sync.outputs.conflict_files }}
+          DELETED_FILES: ${{ steps.sync.outputs.deleted_files }}
         run: |
           echo "=== Changes that would be made ==="
           git diff
-          if [ "${{ steps.sync.outputs.has_conflicts }}" = "true" ]; then
+          if [ "$HAS_CONFLICTS" = "true" ]; then
             echo ""
             echo "=== CONFLICTS DETECTED ==="
             echo "The following files have local customizations that would be overwritten:"
-            echo "${{ steps.sync.outputs.conflict_files }}"
+            echo "$CONFLICT_FILES"
+          fi
+          if [ "$HAS_DELETIONS" = "true" ]; then
+            echo ""
+            echo "=== FILES DELETED IN TEMPLATE ==="
+            echo "$DELETED_FILES"
           fi
 
       - name: Create Pull Request
-        if: inputs.dry-run != 'true' && (steps.sync.outputs.has_changes == 'true' || steps.sync.outputs.has_conflicts == 'true')
+        if: inputs.dry-run != 'true' && (steps.sync.outputs.has_changes == 'true' || steps.sync.outputs.has_conflicts == 'true' || steps.sync.outputs.has_deletions == 'true')
         id: create-pr
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@v8
         with:
           token: ${{ secrets.TEMPLATE_SYNC_TOKEN || secrets.GITHUB_TOKEN }}
-          commit-message: "chore: sync from template repository"
+          commit-message: "chore: sync from template repository (${{ steps.sync.outputs.template_sha_short }})"
           title: "chore: sync from template repository"
           body: |
             This PR syncs updates from the template repository.
 
+            **Template version:** `${{ steps.sync.outputs.template_sha_short }}`
             **Updated paths:** ${{ steps.sync.outputs.changed_paths }}
-
             **Template repository:** ${{ env.TEMPLATE_REPO }}
 
-            ${{ steps.sync.outputs.has_conflicts == 'true' && '---
+            ${{ steps.sync.outputs.changelog && format('### Changelog since last sync
 
-            ## ⚠️ Manual Merge Required
+            ```
+            {0}
+            ```
+
+            ', steps.sync.outputs.changelog) }}${{ steps.sync.outputs.has_deletions == 'true' && format('---
+
+            ## Files Removed from Template
+
+            The following files were **deleted in the template** but still exist locally. Consider removing them if they are no longer needed:
+
+            `{0}`
+
+            ', steps.sync.outputs.deleted_files) || '' }}${{ steps.sync.outputs.has_conflicts == 'true' && '---
+
+            ## Manual Merge Required
 
             The following files differ between your repository and the template. **Your local versions have been preserved** - this PR only adds new files.
 
@@ -220,15 +356,31 @@ jobs:
           delete-branch: true
           labels: ${{ steps.sync.outputs.has_conflicts == 'true' && 'template-sync,needs-conflict-resolution' || 'template-sync' }}
 
-      - name: Ask Claude for merge suggestions
-        if: inputs.dry-run != 'true' && steps.sync.outputs.has_conflicts == 'true' && steps.create-pr.outputs.pull-request-number
-        uses: anthropics/claude-code-action@beta
-        with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          pr_number: ${{ steps.create-pr.outputs.pull-request-number }}
-          prompt: |
-            This template sync PR has conflicts - files that differ between the local repo and template.
-            The local versions have been preserved. Please suggest how to merge each conflicting file,
-            keeping project-specific customizations while adopting template improvements.
+      - name: Request Claude review for conflicts
+        if: inputs.dry-run != 'true' && (steps.sync.outputs.has_conflicts == 'true' || steps.sync.outputs.has_deletions == 'true') && steps.create-pr.outputs.pull-request-number
+        env:
+          GH_TOKEN: ${{ secrets.TEMPLATE_SYNC_TOKEN || github.token }}
+          HAS_CONFLICTS: ${{ steps.sync.outputs.has_conflicts }}
+          HAS_DELETIONS: ${{ steps.sync.outputs.has_deletions }}
+          DELETED_FILES: ${{ steps.sync.outputs.deleted_files }}
+          PR_NUM: ${{ steps.create-pr.outputs.pull-request-number }}
+        run: |
+          BODY="@claude This template sync PR needs your help."
 
-            Be concise. For each file, suggest what to keep from local vs adopt from template.
+          if [ "$HAS_CONFLICTS" = "true" ]; then
+            BODY="$BODY
+
+          **Conflicts:** Files differ between the local repo and template. The local versions have been preserved. For each conflicting file:
+          1. Keep blocks marked with customization comments (e.g., 'project-specific', 'Future Claudes: Leave as-is')
+          2. Adopt new template features that don't conflict with local customizations
+          3. When in doubt, preserve local changes"
+          fi
+
+          if [ "$HAS_DELETIONS" = "true" ]; then
+            BODY="$BODY
+
+          **Deleted files:** These files were removed from the template: $DELETED_FILES
+          Check if they are still used locally. If not, remove them in this PR."
+          fi
+
+          gh pr comment "$PR_NUM" --body "$BODY"

--- a/.hooks/commit-msg
+++ b/.hooks/commit-msg
@@ -1,8 +1,16 @@
-#!/bin/sh
+#!/bin/bash
 # Commit message hook: Validate conventional commit format
 # Uses commitlint with @commitlint/config-conventional
 
+set -euo pipefail
+
 git_root="$(git rev-parse --show-toplevel)"
+
+# Git hooks run in a separate shell and don't inherit CLAUDE_ENV_FILE modifications.
+# Explicitly add .venv/bin to PATH so Python tools from uv are available.
+if [ -d "$git_root/.venv/bin" ]; then
+  export PATH="$git_root/.venv/bin:$PATH"
+fi
 
 # Run commitlint if available via pnpm or npm
 if command -v pnpm >/dev/null 2>&1 && [ -f "$git_root/node_modules/.bin/commitlint" ]; then

--- a/.hooks/lint-skills.sh
+++ b/.hooks/lint-skills.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+# Validates Claude Code skills have required structure per best practices.
+# Based on analysis of common skills failures:
+#   https://cashandcache.substack.com/p/i-analyzed-40-claude-skills-failures
+#
+# Checks enforced:
+#   1. YAML frontmatter present (starts with ---)
+#   2. name: field in frontmatter (descriptive identifier)
+#   3. description: field in frontmatter (2+ sentences for activation context)
+#   4. ## Examples section in body (real input/output pairs prevent generic output) [optional]
+#
+# Skills must use directory format: .claude/skills/<name>/SKILL.md
+# Flat files (.claude/skills/<name>.md) are rejected.
+#
+# Usage: lint-skills.sh [files...]
+
+set -euo pipefail
+
+errors=0
+
+for file in "$@"; do
+  # Skip if not under .claude/skills/
+  [[ "$file" != *".claude/skills/"* ]] && continue
+
+  basename_file=$(basename "$file")
+  grandparent=$(basename "$(dirname "$(dirname "$file")")")
+
+  # Reject flat files directly in .claude/skills/
+  dirname_file=$(basename "$(dirname "$file")")
+  if [[ "$dirname_file" == "skills" && "$basename_file" == *.md ]]; then
+    echo "ERROR: $file uses flat file format — convert to .claude/skills/$(basename "$file" .md)/SKILL.md" >&2
+    errors=$((errors + 1))
+    continue
+  fi
+
+  # Only validate SKILL.md entrypoints; skip supporting files
+  [[ "$grandparent" != "skills" || "$basename_file" != "SKILL.md" ]] && continue
+
+  # Check for YAML frontmatter
+  if ! head -1 "$file" | grep -q '^---$'; then
+    echo "ERROR: $file missing YAML frontmatter (must start with ---)" >&2
+    errors=$((errors + 1))
+    continue
+  fi
+
+  # Extract frontmatter (between first and second ---), filtering YAML comments
+  frontmatter=$(awk '/^---$/{n++; next} n==1' "$file" | grep -v '^#')
+
+  # Check frontmatter has name field
+  if ! echo "$frontmatter" | grep -q '^name:'; then
+    echo "ERROR: $file missing 'name:' in frontmatter" >&2
+    errors=$((errors + 1))
+  fi
+
+  # Check frontmatter has description field
+  if ! echo "$frontmatter" | grep -q '^description:'; then
+    echo "ERROR: $file missing 'description:' in frontmatter" >&2
+    errors=$((errors + 1))
+  fi
+
+  # Check description is multi-sentence (at least 2 periods)
+  # Extract description from frontmatter only (not body content)
+  desc_block=$(awk '/^---$/{n++; next} n==1' "$file" | sed -n '/^description:/,/^[a-z]/p')
+  period_count=$(echo "$desc_block" | grep -o '\.' | wc -l)
+  if [ "$period_count" -lt 2 ]; then
+    echo "ERROR: $file description too short — use 2-3 sentences with specific activation triggers" >&2
+    errors=$((errors + 1))
+  fi
+
+  # Warn (but don't fail) if Examples section is missing
+  body=$(awk '/^---$/{n++; next} n>=2' "$file")
+  if ! echo "$body" | grep -q '^## Examples'; then
+    echo "WARN: $file missing '## Examples' section — consider adding 2-3 real input/output examples" >&2
+  fi
+done
+
+[ "$errors" -gt 0 ] && exit 1 || exit 0

--- a/.hooks/pre-commit
+++ b/.hooks/pre-commit
@@ -2,10 +2,18 @@
 # Pre-commit hook: Format and lint staged files
 # Customize the lint-staged configuration in package.json
 
-GIT_ROOT=$(git rev-parse --show-toplevel)
+set -euo pipefail
+
+git_root=$(git rev-parse --show-toplevel)
+
+# Git hooks run in a separate shell and don't inherit CLAUDE_ENV_FILE modifications.
+# Explicitly add .venv/bin to PATH so Python tools from uv are available.
+if [ -d "$git_root/.venv/bin" ]; then
+  export PATH="$git_root/.venv/bin:$PATH"
+fi
 
 # Check if lint-staged is installed
-if [ ! -f "$GIT_ROOT/node_modules/.bin/lint-staged" ]; then
+if [ ! -f "$git_root/node_modules/.bin/lint-staged" ]; then
   echo "Warning: lint-staged not found. Run 'pnpm install' to enable pre-commit formatting." >&2
   exit 0
 fi

--- a/.template-sync-conflicts
+++ b/.template-sync-conflicts
@@ -1,0 +1,1 @@
+Template updates available for: .claude/README.md .claude/hooks/verify_ci.py .claude/hooks/pre-push-check.sh .claude/hooks/session-setup.sh .claude/skills/pr-creation/pr-templates.md .claude/skills/pr-creation/SKILL.md .hooks/commit-msg .hooks/pre-commit .github/workflows/template-sync.yaml 

--- a/.template-sync-conflicts
+++ b/.template-sync-conflicts
@@ -1,1 +1,0 @@
-Template updates available for: .claude/README.md .claude/hooks/verify_ci.py .claude/hooks/pre-push-check.sh .claude/hooks/session-setup.sh .claude/skills/pr-creation/pr-templates.md .claude/skills/pr-creation/SKILL.md .hooks/commit-msg .hooks/pre-commit .github/workflows/template-sync.yaml 


### PR DESCRIPTION
This PR syncs updates from the template repository.

**Updated paths:** .hooks/lint-skills.sh .template-sync-conflicts 

**Template repository:** alexander-turner/claude-automation-template

---

## ⚠️ Manual Merge Required

The following files differ between your repository and the template. **Your local versions have been preserved** - this PR only adds new files.

### Files Requiring Manual Merge

### `.claude/README.md`

<details>
<summary>View conflict details</summary>

**Your current version:**
```
# Claude Code Configuration

This directory contains configuration and skills for Claude Code.

## Structure

```
.claude/
├── settings.json               # Claude Code hooks configuration
├── hooks/
│   ├── session-setup.sh       # Runs on session start (installs tools, configures git)
│   ├── pre-push-check.sh     # Runs before git push / gh pr (build, lint, typecheck)
│   ├── lib-checks.sh         # Shared library with utility functions for hooks
│   └── verify-ci-on-stop.sh  # Runs on session stop (blocks if checks fail)
└── skills/
    └── pr-creation/       # PR creation workflow with self-critique
        ├── SKILL.md       # Main skill entrypoint
        ├── critique-prompt.md  # Self-critique checklist for sub-agent
        └── pr-templates.md     # PR formatting and validation reference
```

## How It Works

### Session Start Hook

When Claude Code starts a session, it automatically runs `session-setup.sh` which:

1. **Installs tools**: shfmt, gh (GitHub CLI), jq, shellcheck
2. **Configures git hooks**: Sets `core.hooksPath` to `.hooks/`
3. **Validates GitHub CLI auth**: Warns if `gh` or `GH_TOKEN` is missing
4. **Detects GitHub repo**: Extracts `owner/repo` from proxy remotes in web sessions
5. **Installs dependencies**: Node (pnpm/npm) and Python (uv) if applicable

### Pre-Push Check Hook

Before `git push` or `gh pr` commands, `pre-push-check.sh` runs any configured checks:

- **build** (`pnpm build`): Catches type errors in TypeScript projects
- **lint** (`pnpm lint`): Catches code quality issues
- **typecheck** (`pnpm check`): Additional type checking if configured
- **ruff**: Python linting if applicable

Only runs scripts that are actually configured in `package.json` — skips placeholder scripts.

### Stop Hook

When Claude finishes a session, `verify-ci-on-stop.sh` blocks completion if any checks fail:

- Runs test, lint, and typecheck (superset of pre-push checks — adds tests)
- Returns `decision: "block"` with failure details so Claude continues fixing issues
- Returns `decision: "approve"` if all checks pass

### Skills

Skills in `skills/` are reusable workflows that guide Claude through complex tasks:

- **pr-creation**: Creating pull requests with mandatory self-critique before submission (invoke with `/pr-creation`)

Skills are automatically available to Claude Code when working in this repository.

## Customization

### Adding Tools

Edit `hooks/session-setup.sh` to add more tools:

```bash
# Via uv
uv_install_if_missing mycommand mypackage

# Via webi (https://webinstall.dev)
webi_install_if_missing mytool

# Via apt (requires root)
if is_root; then
  apt-get install -y mytool
fi
```

### Adding Skills

Create new skill directories in `skills/` following the pattern in `pr-creation/SKILL.md`. Each skill should be a directory with a `SKILL.md` entrypoint and optional supporting files.

### Customizing Hooks

Modify `settings.json` to add more hooks. See the [Claude Code documentation](https://docs.anthropic.com/en/docs/claude-code) for available hook types.
```

**Template version:**
```
# Claude Code Configuration

This directory contains configuration and skills for Claude Code.

## Structure

```
.claude/
├── settings.json              # Claude Code hooks configuration
├── hooks/
│   ├── session-setup.sh      # Runs on session start (installs tools, configures git)
│   ├── pre-push-check.sh    # Runs before git push / gh pr (build, lint, typecheck)
│   ├── verify_ci.py          # Runs on session stop (blocks if checks fail, max 3 retries)
│   └── lib-checks.sh        # Shared bash helpers (exists, has_script)
└── skills/
    └── pr-creation/       # PR creation workflow with self-critique
        ├── SKILL.md       # Main skill entrypoint
        ├── critique-prompt.md  # Self-critique checklist for sub-agent
        └── pr-templates.md     # PR formatting and validation reference
```

## How It Works

### Session Start Hook

When Claude Code starts a session, it automatically runs `session-setup.sh` which:

1. **Installs tools**: shfmt, gh (GitHub CLI), jq, shellcheck
2. **Configures git hooks**: Sets `core.hooksPath` to `.hooks/`
3. **Validates GitHub CLI auth**: Fails fast if `GH_TOKEN` is missing
4. **Detects GitHub repo**: Extracts `owner/repo` from proxy remotes in web sessions
5. **Installs dependencies**: Node (pnpm/npm) and Python (uv) if applicable

### Pre-Push Check Hook

Before `git push` or `gh pr` commands, `pre-push-check.sh` runs any configured checks:

- **build** (`pnpm build`): Catches type errors in TypeScript projects
- **lint** (`pnpm lint`): Catches code quality issues
- **typecheck** (`pnpm check`): Additional type checking if configured
- **ruff**: Python linting if applicable

Only runs scripts that are actually configured in `package.json` — skips placeholder scripts.

### Stop Hook

When Claude finishes a session, `verify_ci.py` blocks completion if any checks fail:

- Runs test, lint, and typecheck (superset of pre-push checks — adds tests)
- Returns `decision: "block"` with failure details so Claude continues fixing issues
- Returns `decision: "approve"` if all checks pass
- **Retry limit**: After 3 failed attempts (configurable via `MAX_STOP_RETRIES`), approves anyway with a warning to prevent infinite token burn
- Written in Python for reliability — reads `package.json` directly, no `jq` dependency

### Skills

Skills in `skills/` are reusable workflows that guide Claude through complex tasks:

- **pr-creation**: Creating pull requests with mandatory self-critique before submission (invoke with `/pr-creation`)

Skills are automatically available to Claude Code when working in this repository.

## Customization

### Adding Tools

Edit `hooks/session-setup.sh` to add more tools:

```bash
# Via uv
uv_install_if_missing mycommand mypackage

# Via webi (https://webinstall.dev)
webi_install_if_missing mytool

# Via apt (requires root)
if is_root; then
  apt-get install -y mytool
fi
```

### Adding Skills

Create new skill directories in `skills/` following the pattern in `pr-creation/SKILL.md`. Each skill should be a directory with a `SKILL.md` entrypoint and optional supporting files.

### Customizing Hooks

Modify `settings.json` to add more hooks. See the [Claude Code documentation](https://docs.anthropic.com/en/docs/claude-code) for available hook types.
```

**Diff (your version → template):**
```diff
--- .claude/README.md	2026-02-21 09:05:21.916121873 +0000
+++ _template/.claude/README.md	2026-02-21 09:05:23.057119887 +0000
@@ -6,12 +6,12 @@
 
 ```
 .claude/
-├── settings.json               # Claude Code hooks configuration
+├── settings.json              # Claude Code hooks configuration
 ├── hooks/
-│   ├── session-setup.sh       # Runs on session start (installs tools, configures git)
-│   ├── pre-push-check.sh     # Runs before git push / gh pr (build, lint, typecheck)
-│   ├── lib-checks.sh         # Shared library with utility functions for hooks
-│   └── verify-ci-on-stop.sh  # Runs on session stop (blocks if checks fail)
+│   ├── session-setup.sh      # Runs on session start (installs tools, configures git)
+│   ├── pre-push-check.sh    # Runs before git push / gh pr (build, lint, typecheck)
+│   ├── verify_ci.py          # Runs on session stop (blocks if checks fail, max 3 retries)
+│   └── lib-checks.sh        # Shared bash helpers (exists, has_script)
 └── skills/
     └── pr-creation/       # PR creation workflow with self-critique
         ├── SKILL.md       # Main skill entrypoint
@@ -27,7 +27,7 @@
 
 1. **Installs tools**: shfmt, gh (GitHub CLI), jq, shellcheck
 2. **Configures git hooks**: Sets `core.hooksPath` to `.hooks/`
-3. **Validates GitHub CLI auth**: Warns if `gh` or `GH_TOKEN` is missing
+3. **Validates GitHub CLI auth**: Fails fast if `GH_TOKEN` is missing
 4. **Detects GitHub repo**: Extracts `owner/repo` from proxy remotes in web sessions
 5. **Installs dependencies**: Node (pnpm/npm) and Python (uv) if applicable
 
@@ -44,11 +44,13 @@
 
 ### Stop Hook
 
-When Claude finishes a session, `verify-ci-on-stop.sh` blocks completion if any checks fail:
+When Claude finishes a session, `verify_ci.py` blocks completion if any checks fail:
 
 - Runs test, lint, and typecheck (superset of pre-push checks — adds tests)
 - Returns `decision: "block"` with failure details so Claude continues fixing issues
 - Returns `decision: "approve"` if all checks pass
+- **Retry limit**: After 3 failed attempts (configurable via `MAX_STOP_RETRIES`), approves anyway with a warning to prevent infinite token burn
+- Written in Python for reliability — reads `package.json` directly, no `jq` dependency
 
 ### Skills
 
```
</details>

### `.claude/hooks/verify_ci.py`

<details>
<summary>View conflict details</summary>

**Your current version:**
```
#!/usr/bin/env python3
"""Stop hook: verifies CI checks pass before allowing Claude to complete.

Outputs JSON to stdout:
  {"decision": "approve"}               — all checks passed (or retries exhausted)
  {"decision": "block", "reason": "…"}  — checks failed, Claude should keep fixing

Tracks retry attempts via a temp file keyed on the project directory hash.
Gives up after MAX_STOP_RETRIES (default 3) to prevent infinite token burn.
The retry counter is reset on each new session by session-setup.sh.
"""

from __future__ import annotations

import json
import os
import shutil
import subprocess
import sys
from hashlib import sha256
from pathlib import Path


def _get_max_retries() -> int:
    return int(os.environ.get("MAX_STOP_RETRIES", "3"))


def _retry_file(project_dir: str) -> Path:
    """Return a stable path for the retry counter, keyed on project dir."""
    dir_hash = sha256(project_dir.encode()).hexdigest()[:16]
    return Path(f"/tmp/claude-stop-attempts-{dir_hash}")


def _has_script(pkg: dict, name: str) -> bool:
    """Check if a package.json script exists and isn't a placeholder."""
    script = pkg.get("scripts", {}).get(name, "")
    return bool(script) and "ERROR: Configure" not in script


def _run_check(name: str, cmd: str) -> tuple[bool, str]:
    """Run a check command. Returns (passed, output)."""
    result = subprocess.run(cmd, shell=True, capture_output=True, text=True)
    if result.returncode == 0:
        return True, ""
    output = result.stdout + result.stderr
    return False, f"=== {name} FAILED ===\n{output}\n"


def _pluralize(n: int, word: str) -> str:
    return f"{n} {word}" if n == 1 else f"{n} {word}s"


def main() -> None:
    max_retries = _get_max_retries()
    project_dir = os.environ.get("CLAUDE_PROJECT_DIR", os.getcwd())
    os.chdir(project_dir)

    # --- Retry tracking ---
    retry_file = _retry_file(project_dir)
    attempt = 1
    if retry_file.exists():
        try:
            attempt = int(retry_file.read_text().strip()) + 1
        except (ValueError, OSError):
            attempt = 1
    retry_file.write_text(str(attempt))

    # --- Collect checks to run ---
    failures: list[str] = []
    outputs: list[str] = []

    def check(name: str, cmd: str) -> None:
        passed, output = _run_check(name, cmd)
        if not passed:
            failures.append(name)
            outputs.append(output)

    # Node.js checks
    pkg_path = Path("package.json")
    if pkg_path.exists():
        pkg = json.loads(pkg_path.read_text())
        checks = [("test", "tests"), ("lint", "lint"), ("check", "typecheck")]
        for script, label in checks:
            if _has_script(pkg, script):
                check(label, f"pnpm {script}")

    # Python checks
    has_pyproject = Path("pyproject.toml").exists()
    has_uvlock = Path("uv.lock").exists()
    if has_pyproject or has_uvlock:
        prefix = "uv run " if has_uvlock and shutil.which("uv") else ""
        if prefix or shutil.which("ruff"):
            check("ruff", f"{prefix}ruff check .")
        elif has_pyproject:
            print("Warning: ruff not found, skipping lint", file=sys.stderr)
        if Path("tests").is_dir() and (prefix or shutil.which("pytest")):
            check("pytest", f"{prefix}pytest")

    # --- Produce result ---
    if not failures:
... (truncated)
```

**Template version:**
```
#!/usr/bin/env python3
"""Stop hook: verifies CI checks pass before allowing Claude to complete.

Outputs JSON to stdout:
  {"decision": "approve"}               — all checks passed (or retries exhausted)
  {"decision": "block", "reason": "…"}  — checks failed, Claude should keep fixing

Tracks retry attempts via a temp file keyed on the project directory hash.
Gives up after MAX_STOP_RETRIES (default 3) to prevent infinite token burn.
The retry counter is reset on each new session by session-setup.sh.
"""

from __future__ import annotations

import json
import os
import shlex
import shutil
import subprocess
import sys
import tempfile
from hashlib import sha256
from pathlib import Path


def _get_max_retries() -> int:
    return int(os.environ.get("MAX_STOP_RETRIES", "3"))


def _retry_file(project_dir: str) -> Path:
    """Return a stable path for the retry counter, keyed on project dir."""
    dir_hash = sha256(project_dir.encode()).hexdigest()[:16]
    return Path(tempfile.gettempdir()) / f"claude-stop-attempts-{dir_hash}"


def _has_script(pkg: dict, name: str) -> bool:
    """Check if a package.json script exists and isn't a placeholder."""
    script = pkg.get("scripts", {}).get(name, "")
    return bool(script) and "ERROR: Configure" not in script


def _run_check(name: str, cmd: str) -> tuple[bool, str]:
    """Run a check command. Returns (passed, output)."""
    result = subprocess.run(
        shlex.split(cmd), capture_output=True, text=True, check=False
    )
    if result.returncode == 0:
        return True, ""
    output = result.stdout + result.stderr
    return False, f"=== {name} FAILED ===\n{output}\n"


def _pluralize(n: int, word: str) -> str:
    return f"{n} {word}" if n == 1 else f"{n} {word}s"


def _check_nodejs(check_fn) -> None:
    """Run Node.js checks (test, lint, typecheck)."""
    pkg_path = Path("package.json")
    if not pkg_path.exists():
        return
    pkg = json.loads(pkg_path.read_text())
    checks = [("test", "tests"), ("lint", "lint"), ("check", "typecheck")]
    for script, label in checks:
        if _has_script(pkg, script):
            check_fn(label, f"pnpm {script}")


def _check_python(check_fn) -> None:
    """Run Python checks (ruff, pytest)."""
    has_pyproject = Path("pyproject.toml").exists()
    has_uvlock = Path("uv.lock").exists()
    if not (has_pyproject or has_uvlock):
        return

    prefix = "uv run " if has_uvlock and shutil.which("uv") else ""
    if prefix or shutil.which("ruff"):
        check_fn("ruff", f"{prefix}ruff check .")
    elif has_pyproject:
        print("Warning: ruff not found, skipping lint", file=sys.stderr)

    if Path("tests").is_dir() and (prefix or shutil.which("pytest")):
        check_fn("pytest", f"{prefix}pytest")


def main() -> None:
    max_retries = _get_max_retries()
    project_dir = os.environ.get("CLAUDE_PROJECT_DIR", os.getcwd())
    os.chdir(project_dir)

    # --- Retry tracking ---
    retry_file = _retry_file(project_dir)
    attempt = 1
    if retry_file.exists():
        try:
            attempt = int(retry_file.read_text().strip()) + 1
        except (ValueError, OSError):
            attempt = 1
    retry_file.write_text(str(attempt))

... (truncated)
```

**Diff (your version → template):**
```diff
--- .claude/hooks/verify_ci.py	2026-02-21 09:05:21.916121873 +0000
+++ _template/.claude/hooks/verify_ci.py	2026-02-21 09:05:23.057119887 +0000
@@ -14,9 +14,11 @@
 
 import json
 import os
+import shlex
 import shutil
 import subprocess
 import sys
+import tempfile
 from hashlib import sha256
 from pathlib import Path
 
@@ -28,7 +30,7 @@
 def _retry_file(project_dir: str) -> Path:
     """Return a stable path for the retry counter, keyed on project dir."""
     dir_hash = sha256(project_dir.encode()).hexdigest()[:16]
-    return Path(f"/tmp/claude-stop-attempts-{dir_hash}")
+    return Path(tempfile.gettempdir()) / f"claude-stop-attempts-{dir_hash}"
 
 
 def _has_script(pkg: dict, name: str) -> bool:
@@ -39,7 +41,9 @@
 
 def _run_check(name: str, cmd: str) -> tuple[bool, str]:
     """Run a check command. Returns (passed, output)."""
-    result = subprocess.run(cmd, shell=True, capture_output=True, text=True)
+    result = subprocess.run(
+        shlex.split(cmd), capture_output=True, text=True, check=False
+    )
     if result.returncode == 0:
         return True, ""
     output = result.stdout + result.stderr
@@ -50,6 +54,35 @@
     return f"{n} {word}" if n == 1 else f"{n} {word}s"
 
 
+def _check_nodejs(check_fn) -> None:
+    """Run Node.js checks (test, lint, typecheck)."""
+    pkg_path = Path("package.json")
+    if not pkg_path.exists():
+        return
+    pkg = json.loads(pkg_path.read_text())
+    checks = [("test", "tests"), ("lint", "lint"), ("check", "typecheck")]
+    for script, label in checks:
+        if _has_script(pkg, script):
+            check_fn(label, f"pnpm {script}")
+
+
+def _check_python(check_fn) -> None:
+    """Run Python checks (ruff, pytest)."""
+    has_pyproject = Path("pyproject.toml").exists()
+    has_uvlock = Path("uv.lock").exists()
+    if not (has_pyproject or has_uvlock):
+        return
+
+    prefix = "uv run " if has_uvlock and shutil.which("uv") else ""
+    if prefix or shutil.which("ruff"):
+        check_fn("ruff", f"{prefix}ruff check .")
+    elif has_pyproject:
+        print("Warning: ruff not found, skipping lint", file=sys.stderr)
+
+    if Path("tests").is_dir() and (prefix or shutil.which("pytest")):
+        check_fn("pytest", f"{prefix}pytest")
+
+
 def main() -> None:
     max_retries = _get_max_retries()
     project_dir = os.environ.get("CLAUDE_PROJECT_DIR", os.getcwd())
@@ -75,26 +108,8 @@
             failures.append(name)
             outputs.append(output)
 
-    # Node.js checks
-    pkg_path = Path("package.json")
-    if pkg_path.exists():
-        pkg = json.loads(pkg_path.read_text())
-        checks = [("test", "tests"), ("lint", "lint"), ("check", "typecheck")]
-        for script, label in checks:
```
</details>

### `.claude/hooks/pre-push-check.sh`

<details>
<summary>View conflict details</summary>

**Your current version:**
```
#!/bin/bash
# Pre-push/PR hook: Runs configured checks before pushing or creating PRs
# Only runs scripts that exist and are properly configured in package.json

set -uo pipefail

HOOK_DIR="$(cd "$(dirname "$0")" && pwd)"
# shellcheck source=lib-checks.sh
source "$HOOK_DIR/lib-checks.sh"

FAILED=0

run_check() {
  local name="$1" cmd="$2"
  echo "=== $name ===" >&2
  if ! $cmd 2>&1; then
    echo "$name FAILED" >&2
    FAILED=1
  fi
}

echo "=== PRE-PR CHECKS ===" >&2

# Node.js checks (tests intentionally omitted — they run in CI and the stop hook)
has_script build && run_check "build" "pnpm build"
has_script lint && run_check "lint" "pnpm lint"
has_script check && run_check "typecheck" "pnpm check"

# Python checks
if [[ -f pyproject.toml ]] || [[ -f uv.lock ]]; then
  PREFIX=""
  [[ -f uv.lock ]] && exists uv && PREFIX="uv run "

  { exists ruff || [[ -n "$PREFIX" ]]; } && run_check "ruff" "${PREFIX}ruff check ."
fi

exit $FAILED
```

**Template version:**
```
#!/bin/bash
# Pre-push/PR hook: Runs configured checks before pushing or creating PRs
# Only runs scripts that exist and are properly configured in package.json

set -uo pipefail

HOOK_DIR="$(cd "$(dirname "$0")" && pwd)"
# shellcheck source=lib-checks.sh
source "$HOOK_DIR/lib-checks.sh"

FAILED=0

run_check() {
  local name="$1" cmd="$2"
  local output
  if ! output=$($cmd 2>&1); then
    echo "=== $name FAILED ===" >&2
    echo "$output" >&2
    FAILED=1
  fi
}

# Node.js checks (tests intentionally omitted — they run in CI and the stop hook)
has_script build && run_check "build" "pnpm build"
has_script lint && run_check "lint" "pnpm lint"
has_script check && run_check "typecheck" "pnpm check"

# Python checks
if [[ -f pyproject.toml ]] || [[ -f uv.lock ]]; then
  PREFIX=""
  [[ -f uv.lock ]] && exists uv && PREFIX="uv run "

  { exists ruff || [[ -n "$PREFIX" ]]; } && run_check "ruff" "${PREFIX}ruff check ."
fi

exit $FAILED
```

**Diff (your version → template):**
```diff
--- .claude/hooks/pre-push-check.sh	2026-02-21 09:05:21.916121873 +0000
+++ _template/.claude/hooks/pre-push-check.sh	2026-02-21 09:05:23.057119887 +0000
@@ -12,15 +12,14 @@
 
 run_check() {
   local name="$1" cmd="$2"
-  echo "=== $name ===" >&2
-  if ! $cmd 2>&1; then
-    echo "$name FAILED" >&2
+  local output
+  if ! output=$($cmd 2>&1); then
+    echo "=== $name FAILED ===" >&2
+    echo "$output" >&2
     FAILED=1
   fi
 }
 
-echo "=== PRE-PR CHECKS ===" >&2
-
 # Node.js checks (tests intentionally omitted — they run in CI and the stop hook)
 has_script build && run_check "build" "pnpm build"
 has_script lint && run_check "lint" "pnpm lint"
```
</details>

### `.claude/hooks/session-setup.sh`

<details>
<summary>View conflict details</summary>

**Your current version:**
```
#!/bin/bash
# Session setup script for Claude Code
# Installs dependencies and configures environment for git hooks

set -uo pipefail

PROJECT_DIR="$(cd "$(dirname "$0")/../.." && pwd)"

#######################################
# Helpers
#######################################

SETUP_WARNINGS=0
warn() {
	echo "WARNING: $1" >&2
	SETUP_WARNINGS=$((SETUP_WARNINGS + 1))
}
is_root() { [ "$(id -u)" = "0" ]; }

# Install a command via uv if missing
uv_install_if_missing() {
	local cmd="$1" pkg="${2:-$1}"
	if ! command -v "$cmd" &>/dev/null; then
		uv tool install --quiet "$pkg" || warn "Failed to install $pkg"
	fi
}

# Install a command via webi if missing
webi_install_if_missing() {
	local cmd="$1"
	if ! command -v "$cmd" &>/dev/null; then
		curl -sS "https://webi.sh/$cmd" | sh >/dev/null 2>&1 || warn "Failed to install $cmd"
	fi
}

#######################################
# PATH setup
#######################################

export PATH="$HOME/.local/bin:$PATH"
if [ -n "${CLAUDE_ENV_FILE:-}" ]; then
	echo "export PATH=\"\$HOME/.local/bin:\$PATH\"" >>"$CLAUDE_ENV_FILE"
fi

#######################################
# Tool installation (optional - warn on failure)
#######################################

# Install tools quietly — only warn on failure
webi_install_if_missing shfmt
webi_install_if_missing gh
webi_install_if_missing jq
if ! command -v shellcheck &>/dev/null && is_root; then
	{ apt-get update -qq && apt-get install -y -qq shellcheck; } || warn "Failed to install shellcheck"
fi

#######################################
# Clean up stale state from previous sessions
#######################################

# Remove stop-hook retry counter for THIS project so a new session starts fresh
# (keyed on project dir hash, matching verify_ci.py's _retry_file)
PROJ_HASH=$(printf '%s' "$PROJECT_DIR" | sha256sum | cut -c1-16)
rm -f "/tmp/claude-stop-attempts-${PROJ_HASH}"

#######################################
# Git setup
#######################################

cd "$PROJECT_DIR" || exit 1
git config core.hooksPath .hooks

#######################################
# GitHub CLI auth
#######################################

if ! command -v gh &>/dev/null; then
	warn "gh CLI not found"
elif [ -z "${GH_TOKEN:-}" ]; then
	warn "GH_TOKEN is not set — GitHub CLI requires authentication"
fi

#######################################
# GitHub repo detection for proxy environments
#######################################

# In Claude Code web sessions, git remotes use a local proxy URL like:
#   http://local_proxy@127.0.0.1:18393/git/owner/repo
# The gh CLI can't detect the GitHub repo from this, so we extract
# owner/repo and export GH_REPO to make all gh commands work.

if [ -z "${GH_REPO:-}" ]; then
	remote_url=$(git -C "$PROJECT_DIR" remote get-url origin 2>/dev/null || true)
	if [[ "$remote_url" =~ /git/([^/]+/[^/]+)$ ]]; then
		GH_REPO="${BASH_REMATCH[1]}"
		GH_REPO="${GH_REPO%.git}"
		export GH_REPO
		if [ -n "${CLAUDE_ENV_FILE:-}" ]; then
			echo "export GH_REPO=\"$GH_REPO\"" >>"$CLAUDE_ENV_FILE"
		fi
... (truncated)
```

**Template version:**
```
#!/bin/bash
# Session setup script for Claude Code
# Installs dependencies and configures environment for git hooks

set -uo pipefail

PROJECT_DIR="$(cd "$(dirname "$0")/../.." && pwd)"

#######################################
# Helpers
#######################################

SETUP_WARNINGS=0
warn() {
	echo "WARNING: $1" >&2
	SETUP_WARNINGS=$((SETUP_WARNINGS + 1))
}
is_root() { [ "$(id -u)" = "0" ]; }

# Install a command via uv if missing
uv_install_if_missing() {
	local cmd="$1" pkg="${2:-$1}"
	if ! command -v "$cmd" &>/dev/null; then
		uv tool install --quiet "$pkg" || warn "Failed to install $pkg"
	fi
}

# Install a command via webi if missing
webi_install_if_missing() {
	local cmd="$1"
	if ! command -v "$cmd" &>/dev/null; then
		curl -sS "https://webi.sh/$cmd" | sh >/dev/null 2>&1 || warn "Failed to install $cmd"
	fi
}

#######################################
# PATH setup
#######################################

export PATH="$HOME/.local/bin:$PATH"
if [ -n "${CLAUDE_ENV_FILE:-}" ]; then
	echo "export PATH=\"\$HOME/.local/bin:\$PATH\"" >>"$CLAUDE_ENV_FILE"
fi

#######################################
# Tool installation (optional - warn on failure)
#######################################

# Install tools quietly — only warn on failure
webi_install_if_missing shfmt
webi_install_if_missing gh
webi_install_if_missing jq
if ! command -v shellcheck &>/dev/null && is_root; then
	{ apt-get update -qq && apt-get install -y -qq shellcheck; } || warn "Failed to install shellcheck"
fi

#######################################
# Clean up stale state from previous sessions
#######################################

# Remove stop-hook retry counter for THIS project so a new session starts fresh
# (keyed on project dir hash, matching verify_ci.py's _retry_file)
PROJ_HASH=$(printf '%s' "$PROJECT_DIR" | sha256sum | cut -c1-16)
rm -f "/tmp/claude-stop-attempts-${PROJ_HASH}"

#######################################
# Git setup
#######################################

cd "$PROJECT_DIR" || exit 1
git config core.hooksPath .hooks

#######################################
# GitHub CLI auth
#######################################

if ! command -v gh &>/dev/null; then
	warn "gh CLI not found"
elif [ -z "${GH_TOKEN:-}" ]; then
	warn "GH_TOKEN is not set — GitHub CLI requires authentication"
fi

#######################################
# GitHub repo detection for proxy environments
#######################################

# In Claude Code web sessions, git remotes use a local proxy URL like:
#   http://local_proxy@127.0.0.1:18393/git/owner/repo
# The gh CLI can't detect the GitHub repo from this, so we extract
# owner/repo and export GH_REPO to make all gh commands work.

if [ -z "${GH_REPO:-}" ]; then
	remote_url=$(git -C "$PROJECT_DIR" remote get-url origin 2>/dev/null || true)
	if [[ "$remote_url" =~ /git/([^/]+/[^/]+)$ ]]; then
		GH_REPO="${BASH_REMATCH[1]}"
		GH_REPO="${GH_REPO%.git}"
		export GH_REPO
		if [ -n "${CLAUDE_ENV_FILE:-}" ]; then
			echo "export GH_REPO=\"$GH_REPO\"" >>"$CLAUDE_ENV_FILE"
		fi
... (truncated)
```

**Diff (your version → template):**
```diff
--- .claude/hooks/session-setup.sh	2026-02-21 09:05:21.916121873 +0000
+++ _template/.claude/hooks/session-setup.sh	2026-02-21 09:05:23.057119887 +0000
@@ -112,6 +112,7 @@
 #######################################
 
 if [ -f "$PROJECT_DIR/package.json" ]; then
+	# Always run install (git hooks are configured in package.json postinstall)
 	if command -v pnpm &>/dev/null; then
 		pnpm install --silent || warn "Failed to install Node dependencies"
 	elif command -v npm &>/dev/null; then
@@ -121,6 +122,7 @@
 
 if [ -f "$PROJECT_DIR/uv.lock" ] && command -v uv &>/dev/null; then
 	uv sync --quiet || warn "Failed to sync Python dependencies"
+	# Add .venv/bin to PATH so Python tools are available to hooks
 	if [ -d "$PROJECT_DIR/.venv/bin" ]; then
 		export PATH="$PROJECT_DIR/.venv/bin:$PATH"
 		if [ -n "${CLAUDE_ENV_FILE:-}" ]; then
```
</details>

### `.claude/skills/pr-creation/pr-templates.md`

<details>
<summary>View conflict details</summary>

**Your current version:**
```
# PR Templates and Formatting Reference

## PR Creation Command

```bash
gh pr create --title "<type>: <description>" --body "$(cat <<'EOF'
## Summary
<1-3 bullet points describing what changed and why>

## Changes
<List of specific changes made>

## Testing
<How the changes were tested>

https://claude.ai/code/session_...
EOF
)"
```

## Title Format

Use imperative mood with a Conventional Commits type prefix:

- `fix:` Bug fixes
- `feat:` New features
- `refactor:` Code refactoring
- `docs:` Documentation
- `test:` Test changes
- `chore:` Maintenance

## Body Guidelines

- Focus the summary on the "why", not the "what"
- List concrete changes
- Note any breaking changes
- Include the Claude session URL at the end

## Updating PR Description After Additional Commits

```bash
gh pr edit --body "$(cat <<'EOF'
## Summary
<Updated summary reflecting all changes>

## Changes
<Updated list of all changes, including new commits>

## Testing
<Updated testing information>

https://claude.ai/code/session_...
EOF
)"
```

## Validation Commands

**TypeScript/JavaScript:**

```bash
pnpm check        # Type checking (if applicable)
pnpm test         # Run tests
pnpm lint         # Run linter
```

**Python:**

```bash
mypy <changed_files>
pylint <changed_files>
ruff check <changed_files>
pytest <test_files>
```

Customize these commands based on your project's tooling.
```

**Template version:**
```
# PR Templates and Formatting Reference

## PR Creation Command

First, check if a PR already exists for the current branch:

```bash
EXISTING_PR=$(gh pr list --head "$(git branch --show-current)" --json number --jq '.[0].number' 2>/dev/null)
```

If `EXISTING_PR` is non-empty, update the existing PR with `gh pr edit` instead of creating a new one.

```bash
gh pr create --title "<type>: <description>" --body "$(cat <<'EOF'
## Summary
<1-3 bullet points describing what changed and why>

## Changes
<List of specific changes made>

## Testing
<How the changes were tested>

## Lessons Learned
<Optional: generalizable insights that could improve the template for all projects>
<Leave this section empty or omit it if there are no lessons worth sharing>
<Examples: "CLAUDE.md should mention X", "The pre-push hook should also check Y",
 "Template sync should handle Z edge case">

https://claude.ai/code/session_...
EOF
)"
```

## Title Format

Use imperative mood with a Conventional Commits type prefix:

- `fix:` Bug fixes
- `feat:` New features
- `refactor:` Code refactoring
- `docs:` Documentation
- `test:` Test changes
- `chore:` Maintenance

## Body Guidelines

- Focus the summary on the "why", not the "what"
- List concrete changes
- Note any breaking changes
- Include a "Lessons Learned" section if you discovered generalizable insights that could improve the template (this triggers the phone-home workflow to suggest improvements to the template repo)
- Include the Claude session URL at the end

## Updating PR Description After Additional Commits

```bash
gh pr edit --body "$(cat <<'EOF'
## Summary
<Updated summary reflecting all changes>

## Changes
<Updated list of all changes, including new commits>

## Testing
<Updated testing information>

## Lessons Learned
<Optional: generalizable insights from this session>

https://claude.ai/code/session_...
EOF
)"
```

## Validation Commands

**TypeScript/JavaScript:**

```bash
pnpm check        # Type checking (if applicable)
pnpm test         # Run tests
pnpm lint         # Run linter
```

**Python:**

```bash
mypy <changed_files>
pylint <changed_files>
ruff check <changed_files>
pytest <test_files>
```

Customize these commands based on your project's tooling.
```

**Diff (your version → template):**
```diff
--- .claude/skills/pr-creation/pr-templates.md	2026-02-21 09:05:21.916121873 +0000
+++ _template/.claude/skills/pr-creation/pr-templates.md	2026-02-21 09:05:23.058119886 +0000
@@ -2,6 +2,14 @@
 
 ## PR Creation Command
 
+First, check if a PR already exists for the current branch:
+
+```bash
+EXISTING_PR=$(gh pr list --head "$(git branch --show-current)" --json number --jq '.[0].number' 2>/dev/null)
+```
+
+If `EXISTING_PR` is non-empty, update the existing PR with `gh pr edit` instead of creating a new one.
+
 ```bash
 gh pr create --title "<type>: <description>" --body "$(cat <<'EOF'
 ## Summary
@@ -13,6 +21,12 @@
 ## Testing
 <How the changes were tested>
 
+## Lessons Learned
+<Optional: generalizable insights that could improve the template for all projects>
+<Leave this section empty or omit it if there are no lessons worth sharing>
+<Examples: "CLAUDE.md should mention X", "The pre-push hook should also check Y",
+ "Template sync should handle Z edge case">
+
 https://claude.ai/code/session_...
 EOF
 )"
@@ -34,6 +48,7 @@
 - Focus the summary on the "why", not the "what"
 - List concrete changes
 - Note any breaking changes
+- Include a "Lessons Learned" section if you discovered generalizable insights that could improve the template (this triggers the phone-home workflow to suggest improvements to the template repo)
 - Include the Claude session URL at the end
 
 ## Updating PR Description After Additional Commits
@@ -49,6 +64,9 @@
 ## Testing
 <Updated testing information>
 
+## Lessons Learned
+<Optional: generalizable insights from this session>
+
 https://claude.ai/code/session_...
 EOF
 )"
```
</details>

### `.claude/skills/pr-creation/SKILL.md`

<details>
<summary>View conflict details</summary>

**Your current version:**
```
---
# prettier-ignore
name: pr-creation
description: >
  Creates high-quality pull requests with mandatory self-critique before submission.
  Activate this skill whenever you are asked to create, open, submit, or push a pull request.
  Also activate when the user says "make a PR", "open a PR", "submit this for review",
  "push and create a PR", "I'm done, create the PR", or any variation of requesting a pull request.
  Always activate before running `gh pr create`.
---

# Pull Request Creation Skill

**IMPORTANT: Always follow this skill before creating any PR.** Do not skip steps, especially the self-critique.

## When to Use

Activate this skill when the user says any of the following (or similar):

- "Create a PR" / "Create a pull request"
- "Open a PR" / "Open a pull request"
- "Make a PR for this"
- "Submit this for review"
- "Push and create a PR"
- "I'm done, create the PR"
- "Can you PR this?"
- "Send this up for review"

Also activate when:

- You have completed a task and the user asks you to submit it
- CLAUDE.md or task instructions say to create a PR when done

Do **NOT** use this skill for:

- Reviewing an existing PR (use `gh pr view` or `gh pr diff` instead)
- Merging a PR (`gh pr merge`)
- Updating a PR description only (just run `gh pr edit`)

## Prerequisites

- GitHub CLI (`gh`) must be authenticated
- All changes must be committed to a feature branch (not `main`/`master`)

## Updating an Existing PR

Before updating an existing PR (pushing new commits, editing the description, etc.), you MUST check its current status:

1. Run `gh pr view <pr-number> --json state` to check the PR state
2. Based on the result:
   - **Open**: Proceed with the update normally
   - **Merged**: Do NOT update it. Create a new PR instead with the additional changes
   - **Closed** (not merged): Ask the user what they'd like to do, if not already clarified

## Workflow

### Step 1: Gather Context

1. Identify the base branch (typically `main` or `master`)
2. Run `git diff <base-branch>...HEAD` to see all changes
3. Run `git log <base-branch>..HEAD --oneline` to see all commits
4. Review the changed files to understand the scope

### Step 2: Self-Critique (Required)

**Before creating the PR**, you MUST read [critique-prompt.md](critique-prompt.md) and launch a critique sub-agent using the Task tool:

- `subagent_type`: "general-purpose"
- `description`: "Critique code changes"
- `prompt`: Include the full diff output and the critique prompt from that file

Do NOT skip reading the resource file — it contains the detailed checklist the sub-agent needs.

### Step 3: Address Critique

1. For each issue raised, determine if it's valid
2. Make necessary fixes and commit them
3. If you fixed more than 3 issues or made structural changes, re-run the critique

### Step 4: Run Validation

Run the project's test/lint/typecheck commands (see [pr-templates.md](pr-templates.md) for common commands per language). Fix any failures before proceeding.

### Step 5: Push and Create the Pull Request

You MUST read [pr-templates.md](pr-templates.md) for the PR template and formatting guidelines before this step.

1. Push the branch: `git push -u origin HEAD`
2. Create the PR using `gh pr create` with the template from the resource file

After creating the PR, and after any subsequent fix commits, update the PR description with `gh pr edit --body "..."` to reflect the current state of all changes.

### Step 6: Wait for CI Checks

1. Run `gh pr checks <pr-number> --watch` to monitor
2. If any checks fail, investigate and fix the issues
3. Push fixes and wait again
4. Only proceed once all checks are green

### Step 7: Report Result
... (truncated)
```

**Template version:**
```
---
# prettier-ignore
name: pr-creation
description: >
  Creates high-quality pull requests with mandatory self-critique before submission.
  Activate this skill whenever you are asked to create, open, submit, or push a pull request.
  Also activate when the user says "make a PR", "open a PR", "submit this for review",
  "push and create a PR", "I'm done, create the PR", or any variation of requesting a pull request.
  Always activate before running `gh pr create`.
---

# Pull Request Creation Skill

**IMPORTANT: Always follow this skill before creating any PR.** Do not skip steps, especially the self-critique.

## When to Use

Activate this skill when the user says any of the following (or similar):

- "Create a PR" / "Create a pull request"
- "Open a PR" / "Open a pull request"
- "Make a PR for this"
- "Submit this for review"
- "Push and create a PR"
- "I'm done, create the PR"
- "Can you PR this?"
- "Send this up for review"

Also activate when:

- You have completed a task and the user asks you to submit it
- CLAUDE.md or task instructions say to create a PR when done

Do **NOT** use this skill for:

- Reviewing an existing PR (use `gh pr view` or `gh pr diff` instead)
- Merging a PR (`gh pr merge`)
- Updating a PR description only (just run `gh pr edit`)

## Prerequisites

- GitHub CLI (`gh`) must be authenticated
- All changes must be committed to a feature branch (not `$CLAUDE_CODE_BASE_REF`/`master`)

## Updating an Existing PR

Before updating an existing PR (pushing new commits, editing the description, etc.), you MUST check its current status:

1. Run `gh pr view <pr-number> --json state` to check the PR state
2. Based on the result:
   - **Open**: Proceed with the update normally
   - **Merged**: Do NOT update it. Create a new PR instead with the additional changes
   - **Closed** (not merged): Ask the user what they'd like to do, if not already clarified

## Workflow

### Step 1: Gather Context

1. The base branch is in the env variable `$CLAUDE_CODE_BASE_REF` 
2. Run `git diff <base-branch>...HEAD` to see all changes
3. Run `git log <base-branch>..HEAD --oneline` to see all commits
4. Review the changed files to understand the scope

### Step 2: Self-Critique

**Before creating the PR**, you MUST read [critique-prompt.md](critique-prompt.md) and launch a critique sub-agent using the Task tool:

- `subagent_type`: "general-purpose"
- `description`: "Critique code changes"
- `prompt`: Include the full diff output and the critique prompt from that file

Do NOT skip reading the resource file — it contains the detailed checklist the sub-agent needs.

### Step 3: Address Critique

1. For each issue raised, determine if it's valid
2. Make necessary fixes and commit them
3. If you fixed more than 3 issues or made structural changes, re-run the critique (max 2 re-runs total — if issues persist after 2 rounds of critique, proceed to validation rather than looping indefinitely)

### Step 4: Run Validation

Run the project's test/lint/typecheck commands (see [pr-templates.md](pr-templates.md) for common commands per language). Fix any failures before proceeding.

### Step 5: Push and Create the Pull Request

You MUST read [pr-templates.md](pr-templates.md) for the PR template and formatting guidelines before this step.

1. Push the branch: `git push -u origin HEAD`
2. Check if a PR already exists for the current branch:
   ```bash
   EXISTING_PR=$(gh pr list --head "$(git branch --show-current)" --json number --jq '.[0].number' 2>/dev/null)
   ```
   If a PR already exists, update it with `gh pr edit` instead of creating a new one.
3. Create the PR using `gh pr create` with the template from the resource file. Make sure that you use the target branch

After creating the PR, and after any subsequent fix commits, update the PR description with `gh pr edit --body "..."` to reflect the current state of all changes.

### Step 6: Wait for CI Checks (MANDATORY)

1. Run `gh pr checks <pr-number> --watch` to monitor
... (truncated)
```

**Diff (your version → template):**
```diff
--- .claude/skills/pr-creation/SKILL.md	2026-02-21 09:05:21.916121873 +0000
+++ _template/.claude/skills/pr-creation/SKILL.md	2026-02-21 09:05:23.058119886 +0000
@@ -40,7 +40,7 @@
 ## Prerequisites
 
 - GitHub CLI (`gh`) must be authenticated
-- All changes must be committed to a feature branch (not `main`/`master`)
+- All changes must be committed to a feature branch (not `$CLAUDE_CODE_BASE_REF`/`master`)
 
 ## Updating an Existing PR
 
@@ -56,12 +56,12 @@
 
 ### Step 1: Gather Context
 
-1. Identify the base branch (typically `main` or `master`)
+1. The base branch is in the env variable `$CLAUDE_CODE_BASE_REF` 
 2. Run `git diff <base-branch>...HEAD` to see all changes
 3. Run `git log <base-branch>..HEAD --oneline` to see all commits
 4. Review the changed files to understand the scope
 
-### Step 2: Self-Critique (Required)
+### Step 2: Self-Critique
 
 **Before creating the PR**, you MUST read [critique-prompt.md](critique-prompt.md) and launch a critique sub-agent using the Task tool:
 
@@ -75,7 +75,7 @@
 
 1. For each issue raised, determine if it's valid
 2. Make necessary fixes and commit them
-3. If you fixed more than 3 issues or made structural changes, re-run the critique
+3. If you fixed more than 3 issues or made structural changes, re-run the critique (max 2 re-runs total — if issues persist after 2 rounds of critique, proceed to validation rather than looping indefinitely)
 
 ### Step 4: Run Validation
 
@@ -86,11 +86,16 @@
 You MUST read [pr-templates.md](pr-templates.md) for the PR template and formatting guidelines before this step.
 
 1. Push the branch: `git push -u origin HEAD`
-2. Create the PR using `gh pr create` with the template from the resource file
+2. Check if a PR already exists for the current branch:
+   ```bash
+   EXISTING_PR=$(gh pr list --head "$(git branch --show-current)" --json number --jq '.[0].number' 2>/dev/null)
+   ```
+   If a PR already exists, update it with `gh pr edit` instead of creating a new one.
+3. Create the PR using `gh pr create` with the template from the resource file. Make sure that you use the target branch
 
 After creating the PR, and after any subsequent fix commits, update the PR description with `gh pr edit --body "..."` to reflect the current state of all changes.
 
-### Step 6: Wait for CI Checks
+### Step 6: Wait for CI Checks (MANDATORY)
 
 1. Run `gh pr checks <pr-number> --watch` to monitor
 2. If any checks fail, investigate and fix the issues
@@ -109,8 +114,8 @@
 
 **Claude's actions:**
 
-1. Runs `git diff main...HEAD` — sees changes in `src/auth/login.ts` and `tests/auth/login.test.ts`
-2. Runs `git log main..HEAD --oneline` — sees 2 commits
+1. Runs `git diff $CLAUDE_CODE_BASE_REF...HEAD` — sees changes in `src/auth/login.ts` and `tests/auth/login.test.ts`
+2. Runs `git log $CLAUDE_CODE_BASE_REF..HEAD --oneline` — sees 2 commits
 3. Launches critique sub-agent with the diff
 4. Critique returns: "Looks good, minor suggestion to add null check on line 42"
 5. Fixes the null check, commits: `fix: add null check for empty session token`
@@ -128,8 +133,8 @@
 
 **Claude's actions:**
 
-1. Runs `git diff main...HEAD` — sees changes across 8 files including new components, tests, and API routes
-2. Runs `git log main..HEAD --oneline` — sees 5 commits
+1. Runs `git diff $CLAUDE_CODE_BASE_REF...HEAD` — sees changes across 8 files including new components, tests, and API routes
+2. Runs `git log $CLAUDE_CODE_BASE_REF..HEAD --oneline` — sees 5 commits
 3. Launches critique sub-agent with the full diff
 4. Critique returns 4 issues: unused import, missing error boundary, test not covering edge case, over-engineered helper
 5. Fixes all 4 issues across 2 additional commits
@@ -144,7 +149,7 @@
 
 **User says:** "Push this up"
 
```
</details>

### `.hooks/commit-msg`

<details>
<summary>View conflict details</summary>

**Your current version:**
```
#!/bin/sh
# Commit message hook: Validate conventional commit format
# Uses commitlint with @commitlint/config-conventional

git_root="$(git rev-parse --show-toplevel)"

# Run commitlint if available via pnpm or npm
if command -v pnpm >/dev/null 2>&1 && [ -f "$git_root/node_modules/.bin/commitlint" ]; then
  pnpm exec commitlint --edit "$1" --config config/javascript/commitlint.config.js
elif command -v npm >/dev/null 2>&1 && [ -f "$git_root/node_modules/.bin/commitlint" ]; then
  npx commitlint --edit "$1" --config config/javascript/commitlint.config.js
fi
```

**Template version:**
```
#!/bin/bash
# Commit message hook: Validate conventional commit format
# Uses commitlint with @commitlint/config-conventional

set -euo pipefail

git_root="$(git rev-parse --show-toplevel)"

# Git hooks run in a separate shell and don't inherit CLAUDE_ENV_FILE modifications.
# Explicitly add .venv/bin to PATH so Python tools from uv are available.
if [ -d "$git_root/.venv/bin" ]; then
  export PATH="$git_root/.venv/bin:$PATH"
fi

# Run commitlint if available via pnpm or npm
if command -v pnpm >/dev/null 2>&1 && [ -f "$git_root/node_modules/.bin/commitlint" ]; then
  pnpm exec commitlint --edit "$1" --config config/javascript/commitlint.config.js
elif command -v npm >/dev/null 2>&1 && [ -f "$git_root/node_modules/.bin/commitlint" ]; then
  npx commitlint --edit "$1" --config config/javascript/commitlint.config.js
fi
```

**Diff (your version → template):**
```diff
--- .hooks/commit-msg	2026-02-21 09:05:21.917121871 +0000
+++ _template/.hooks/commit-msg	2026-02-21 09:05:23.059119884 +0000
@@ -1,9 +1,17 @@
-#!/bin/sh
+#!/bin/bash
 # Commit message hook: Validate conventional commit format
 # Uses commitlint with @commitlint/config-conventional
 
+set -euo pipefail
+
 git_root="$(git rev-parse --show-toplevel)"
 
+# Git hooks run in a separate shell and don't inherit CLAUDE_ENV_FILE modifications.
+# Explicitly add .venv/bin to PATH so Python tools from uv are available.
+if [ -d "$git_root/.venv/bin" ]; then
+  export PATH="$git_root/.venv/bin:$PATH"
+fi
+
 # Run commitlint if available via pnpm or npm
 if command -v pnpm >/dev/null 2>&1 && [ -f "$git_root/node_modules/.bin/commitlint" ]; then
   pnpm exec commitlint --edit "$1" --config config/javascript/commitlint.config.js
```
</details>

### `.hooks/pre-commit`

<details>
<summary>View conflict details</summary>

**Your current version:**
```
#!/bin/bash
# Pre-commit hook: Format and lint staged files
# Customize the lint-staged configuration in package.json

GIT_ROOT=$(git rev-parse --show-toplevel)

# Check if lint-staged is installed
if [ ! -f "$GIT_ROOT/node_modules/.bin/lint-staged" ]; then
  echo "Warning: lint-staged not found. Run 'pnpm install' to enable pre-commit formatting." >&2
  exit 0
fi

# Run lint-staged (via pnpm or npm)
if command -v pnpm >/dev/null 2>&1; then
  pnpm exec lint-staged --allow-empty
elif command -v npm >/dev/null 2>&1; then
  npx lint-staged --allow-empty
else
  echo "Warning: Neither pnpm nor npm found. Skipping lint-staged." >&2
fi
```

**Template version:**
```
#!/bin/bash
# Pre-commit hook: Format and lint staged files
# Customize the lint-staged configuration in package.json

set -euo pipefail

git_root=$(git rev-parse --show-toplevel)

# Git hooks run in a separate shell and don't inherit CLAUDE_ENV_FILE modifications.
# Explicitly add .venv/bin to PATH so Python tools from uv are available.
if [ -d "$git_root/.venv/bin" ]; then
  export PATH="$git_root/.venv/bin:$PATH"
fi

# Check if lint-staged is installed
if [ ! -f "$git_root/node_modules/.bin/lint-staged" ]; then
  echo "Warning: lint-staged not found. Run 'pnpm install' to enable pre-commit formatting." >&2
  exit 0
fi

# Run lint-staged (via pnpm or npm)
if command -v pnpm >/dev/null 2>&1; then
  pnpm exec lint-staged --allow-empty
elif command -v npm >/dev/null 2>&1; then
  npx lint-staged --allow-empty
else
  echo "Warning: Neither pnpm nor npm found. Skipping lint-staged." >&2
fi
```

**Diff (your version → template):**
```diff
--- .hooks/pre-commit	2026-02-21 09:05:21.917121871 +0000
+++ _template/.hooks/pre-commit	2026-02-21 09:05:23.059119884 +0000
@@ -2,10 +2,18 @@
 # Pre-commit hook: Format and lint staged files
 # Customize the lint-staged configuration in package.json
 
-GIT_ROOT=$(git rev-parse --show-toplevel)
+set -euo pipefail
+
+git_root=$(git rev-parse --show-toplevel)
+
+# Git hooks run in a separate shell and don't inherit CLAUDE_ENV_FILE modifications.
+# Explicitly add .venv/bin to PATH so Python tools from uv are available.
+if [ -d "$git_root/.venv/bin" ]; then
+  export PATH="$git_root/.venv/bin:$PATH"
+fi
 
 # Check if lint-staged is installed
-if [ ! -f "$GIT_ROOT/node_modules/.bin/lint-staged" ]; then
+if [ ! -f "$git_root/node_modules/.bin/lint-staged" ]; then
   echo "Warning: lint-staged not found. Run 'pnpm install' to enable pre-commit formatting." >&2
   exit 0
 fi
```
</details>

### `.github/workflows/template-sync.yaml`

<details>
<summary>View conflict details</summary>

**Your current version:**
```
name: Sync from Template

# Syncs updates from the template repository automatically.
# Runs daily or manually via "Run workflow" button.
# No setup required - works out of the box.
#
# When conflicts are detected (local customizations vs template updates),
# the PR will include detailed conflict information for Claude to help resolve.

on:
  workflow_dispatch:
    inputs:
      dry-run:
        description: "Show what would be synced without making changes"
        required: false
        default: "false"
        type: boolean
  schedule:
    # Run daily at 9am UTC
    - cron: "0 9 * * *"

env:
  TEMPLATE_REPO: "alexander-turner/claude-automation-template"
  # Only sync core automation files that don't need customization
  SYNC_PATHS: ".claude .hooks .github/workflows/template-sync.yaml .github/workflows/dependabot-auto-merge.yaml"
  # These are excluded because they require project-specific customization
  # (comment-on-failed-checks needs workflow names, lint/test need project scripts)
  EXCLUDE_PATHS: ""

permissions:
  contents: write
  pull-requests: write

jobs:
  sync:
    runs-on: ubuntu-latest
    steps:
      - name: Checkout child repository
        uses: actions/checkout@v4
        with:
          fetch-depth: 0

      - name: Checkout template repository
        uses: actions/checkout@v4
        with:
          repository: ${{ env.TEMPLATE_REPO }}
          path: _template
          token: ${{ secrets.TEMPLATE_SYNC_TOKEN || secrets.GITHUB_TOKEN }}

      - name: Sync template files with conflict detection
        id: sync
        run: |
          set -e

          # Initialize tracking files
          : > /tmp/conflict_files.txt
          : > /tmp/conflict_report.md

          # Function to process a single file
          process_file() {
            local rel_path="$1"
            local template_file="_template/$rel_path"

            # Create parent directory if needed
            local parent_dir=$(dirname "$rel_path")
            [ "$parent_dir" != "." ] && mkdir -p "$parent_dir"

            if [ ! -f "$rel_path" ]; then
              # New file from template - no conflict
              cp "$template_file" "$rel_path"
              echo "Added: $rel_path"
              return
            fi

            # File exists locally - check if it differs from template
            if diff -q "$rel_path" "$template_file" > /dev/null 2>&1; then
              # Files are identical - no action needed
              return
            fi

            # Files differ - this is a potential conflict
            # The local version may have customizations we want to preserve
            echo "CONFLICT: $rel_path (local differs from template)"
            echo "$rel_path" >> /tmp/conflict_files.txt

            # Generate conflict report showing both versions
            {
              echo "### \`$rel_path\`"
              echo ""
              echo "<details>"
              echo "<summary>View conflict details</summary>"
              echo ""
              echo "**Your current version:**"
              echo "\`\`\`"
              head -100 "$rel_path"
              [ "$(wc -l < "$rel_path")" -gt 100 ] && echo "... (truncated)"
              echo "\`\`\`"
              echo ""
              echo "**Template version:**"
              echo "\`\`\`"
... (truncated)
```

**Template version:**
```
name: Sync from Template

# Syncs updates from the template repository automatically.
# Runs daily or manually via "Run workflow" button.
# No setup required - works out of the box.
#
# Features:
# - Detects new files, changed files, and deleted files from the template
# - Preserves local customizations (reports conflicts instead of overwriting)
# - Tracks which template version the repo is synced to (.template-version)
# - Requests @claude review for conflict resolution
#
# =============================================================================
# HANDLING CUSTOMIZATIONS DURING SYNC
# =============================================================================
# Projects may have local customizations in synced files (e.g., project-specific
# tools in session-setup.sh, custom pre-commit checks). When resolving conflicts:
#
# 1. Look for header comments like "IMPORTANT: This file has project-specific
#    customizations" or "Future Claudes: Leave these customizations as-is"
# 2. Preserve local customizations while adopting new template features
# 3. When in doubt, keep local changes - they exist for a reason
# =============================================================================

on:
  workflow_dispatch:
    inputs:
      dry-run:
        description: "Show what would be synced without making changes"
        required: false
        default: "false"
        type: boolean
  schedule:
    # Run daily at 9am UTC
    - cron: "0 9 * * *"

env:
  TEMPLATE_REPO: "alexander-turner/claude-automation-template"
  # Only sync core automation files that don't need customization
  SYNC_PATHS: ".claude .hooks .github/scripts .github/workflows/template-sync.yaml .github/workflows/dependabot-auto-merge.yaml .github/workflows/claude.yaml .github/workflows/phone-home.yaml"
  # These are excluded because they require project-specific customization
  # (comment-on-failed-checks needs workflow names, lint/test need project scripts)
  EXCLUDE_PATHS: ""

permissions:
  contents: write
  pull-requests: write

jobs:
  sync:
    runs-on: ubuntu-latest
    steps:
      - name: Checkout child repository
        uses: actions/checkout@v6
        with:
          fetch-depth: 0

      - name: Checkout template repository
        uses: actions/checkout@v6
        with:
          repository: ${{ env.TEMPLATE_REPO }}
          path: _template
          token: ${{ secrets.TEMPLATE_SYNC_TOKEN || secrets.GITHUB_TOKEN }}

      - name: Check token workflow scope
        env:
          TOKEN: ${{ secrets.TEMPLATE_SYNC_TOKEN || secrets.GITHUB_TOKEN }}
        run: |
          # GitHub requires 'workflow' scope on PATs to push .github/workflows/ changes.
          # Check the x-oauth-scopes response header from the GitHub API.
          SCOPES=$(curl -sS -I -H "Authorization: token $TOKEN" \
            https://api.github.com/user 2>/dev/null \
            | grep -i '^x-oauth-scopes:' | sed 's/^[^:]*: //' | tr -d '\r\n' || true)

          if echo "$SCOPES" | tr ',' '\n' | sed 's/^ *//' | grep -qx 'workflow'; then
            echo "Token has 'workflow' scope."
          else
            echo "::error::TEMPLATE_SYNC_TOKEN lacks the 'workflow' scope, which GitHub requires to push changes to .github/workflows/ files. Add the 'workflow' scope to your PAT at https://github.com/settings/tokens and update the TEMPLATE_SYNC_TOKEN repository secret."
            exit 1
          fi

      - name: Sync template files with conflict detection
        id: sync
        run: |
          set -e

          # Initialize tracking files
          : > /tmp/conflict_files.txt
          : > /tmp/conflict_report.md
          : > /tmp/deleted_files.txt

          #############################################
          # Version tracking
          #############################################

          TEMPLATE_SHA=$(git -C _template rev-parse HEAD)
          TEMPLATE_SHA_SHORT=$(echo "$TEMPLATE_SHA" | head -c 7)
          echo "template_sha=$TEMPLATE_SHA" >> $GITHUB_OUTPUT
          echo "template_sha_short=$TEMPLATE_SHA_SHORT" >> $GITHUB_OUTPUT

... (truncated)
```

**Diff (your version → template):**
```diff
--- .github/workflows/template-sync.yaml	2026-02-21 09:05:21.917121871 +0000
+++ _template/.github/workflows/template-sync.yaml	2026-02-21 09:05:23.059119884 +0000
@@ -4,8 +4,23 @@
 # Runs daily or manually via "Run workflow" button.
 # No setup required - works out of the box.
 #
-# When conflicts are detected (local customizations vs template updates),
-# the PR will include detailed conflict information for Claude to help resolve.
+# Features:
+# - Detects new files, changed files, and deleted files from the template
+# - Preserves local customizations (reports conflicts instead of overwriting)
+# - Tracks which template version the repo is synced to (.template-version)
+# - Requests @claude review for conflict resolution
+#
+# =============================================================================
+# HANDLING CUSTOMIZATIONS DURING SYNC
+# =============================================================================
+# Projects may have local customizations in synced files (e.g., project-specific
+# tools in session-setup.sh, custom pre-commit checks). When resolving conflicts:
+#
+# 1. Look for header comments like "IMPORTANT: This file has project-specific
+#    customizations" or "Future Claudes: Leave these customizations as-is"
+# 2. Preserve local customizations while adopting new template features
+# 3. When in doubt, keep local changes - they exist for a reason
+# =============================================================================
 
 on:
   workflow_dispatch:
@@ -22,7 +37,7 @@
 env:
   TEMPLATE_REPO: "alexander-turner/claude-automation-template"
   # Only sync core automation files that don't need customization
-  SYNC_PATHS: ".claude .hooks .github/workflows/template-sync.yaml .github/workflows/dependabot-auto-merge.yaml"
+  SYNC_PATHS: ".claude .hooks .github/scripts .github/workflows/template-sync.yaml .github/workflows/dependabot-auto-merge.yaml .github/workflows/claude.yaml .github/workflows/phone-home.yaml"
   # These are excluded because they require project-specific customization
   # (comment-on-failed-checks needs workflow names, lint/test need project scripts)
   EXCLUDE_PATHS: ""
@@ -36,17 +51,34 @@
     runs-on: ubuntu-latest
     steps:
       - name: Checkout child repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Checkout template repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: ${{ env.TEMPLATE_REPO }}
           path: _template
           token: ${{ secrets.TEMPLATE_SYNC_TOKEN || secrets.GITHUB_TOKEN }}
 
+      - name: Check token workflow scope
+        env:
+          TOKEN: ${{ secrets.TEMPLATE_SYNC_TOKEN || secrets.GITHUB_TOKEN }}
+        run: |
+          # GitHub requires 'workflow' scope on PATs to push .github/workflows/ changes.
+          # Check the x-oauth-scopes response header from the GitHub API.
+          SCOPES=$(curl -sS -I -H "Authorization: token $TOKEN" \
+            https://api.github.com/user 2>/dev/null \
+            | grep -i '^x-oauth-scopes:' | sed 's/^[^:]*: //' | tr -d '\r\n' || true)
+
+          if echo "$SCOPES" | tr ',' '\n' | sed 's/^ *//' | grep -qx 'workflow'; then
+            echo "Token has 'workflow' scope."
+          else
+            echo "::error::TEMPLATE_SYNC_TOKEN lacks the 'workflow' scope, which GitHub requires to push changes to .github/workflows/ files. Add the 'workflow' scope to your PAT at https://github.com/settings/tokens and update the TEMPLATE_SYNC_TOKEN repository secret."
+            exit 1
+          fi
+
       - name: Sync template files with conflict detection
         id: sync
         run: |
@@ -55,6 +87,42 @@
           # Initialize tracking files
           : > /tmp/conflict_files.txt
           : > /tmp/conflict_report.md
+          : > /tmp/deleted_files.txt
+
```
</details>


---
Please review the changes and merge if appropriate.