### PR TITLE
fix: log API response in version-bump for diagnosability

### DIFF
--- a/scripts/version-bump.sh
+++ b/scripts/version-bump.sh
@@ -90,6 +90,7 @@ RESPONSE=$(curl -s https://api.anthropic.com/v1/messages \
     }')")
 
 # Extract the bump level from Claude's structured tool use response
+echo "API response: $RESPONSE"
 BUMP=$(echo "$RESPONSE" | jq -r '.content[] | select(.type == "tool_use") | .input.bump_type')
 
 # Validate response - fail if Claude couldn't determine bump type


### PR DESCRIPTION
## Summary
- The auto-version workflow ([run #22013828241](https://github.com/alexander-turner/punctilio/actions/runs/22013828241)) failed with an unhelpful `jq: Cannot iterate over null` error because the Claude API returned an error response
- Add logging of the raw API response before `jq` parsing so the actual failure reason is visible in CI logs

## Changes
- `scripts/version-bump.sh`: Print the API response before extracting the bump type with `jq`

## Testing
- Existing tests pass (1248/1248), lint clean
- Change is purely diagnostic output in a CI script; no logic affected

https://claude.ai/code/session_01K3HWSRak4VoyqigR8sNUK1