### PR TITLE
feat: re-apply remark plugin and Markdown module (PR #84)

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,8 @@ unified()
 //  are both resolved correctly across the element boundary.
 ```
 
+For Markdown ASTs via `remark`, use `remarkPunctilio` which applies the same separator technique to preserve inline element boundaries, or use `transformMarkdown` for a simpler Markdown-to-Markdown pipeline.
+
 For manual DOM walking or custom transforms, use `transformElement` from `punctilio/rehype`. 
 
 ## Options

--- a/package.json
+++ b/package.json
@@ -13,6 +13,14 @@
     "./rehype": {
       "types": "./dist/rehype.d.ts",
       "import": "./dist/rehype.js"
+    },
+    "./remark": {
+      "types": "./dist/remark.d.ts",
+      "import": "./dist/remark.js"
+    },
+    "./markdown": {
+      "types": "./dist/markdown.d.ts",
+      "import": "./dist/markdown.js"
     }
   },
   "files": [
@@ -40,6 +48,8 @@
     "text-formatting",
     "rehype",
     "rehype-plugin",
+    "remark",
+    "remark-plugin",
     "unified",
     "markdown",
     "html"
@@ -62,6 +72,7 @@
     "@eslint/js": "^9.39.2",
     "@types/hast": "^3.0.4",
     "@types/jest": "^29.5.12",
+    "@types/mdast": "4.0.4",
     "@types/node": "^20.11.0",
     "eslint": "^9.39.2",
     "eslint-plugin-regexp": "^3.0.0",
@@ -69,6 +80,9 @@
     "jest": "^29.7.0",
     "rehype-parse": "9.0.1",
     "rehype-stringify": "10.0.1",
+    "remark-gfm": "^4.0.1",
+    "remark-parse": "11.0.0",
+    "remark-stringify": "11.0.0",
     "retext": "9.0.0",
     "retext-smartypants": "6.2.0",
     "smartquotes": "2.3.2",
@@ -81,10 +95,18 @@
     "unified": "11.0.5"
   },
   "peerDependencies": {
+    "remark-parse": "^11.0.0",
+    "remark-stringify": "^11.0.0",
     "unified": "^11.0.0"
   },
   "peerDependenciesMeta": {
     "unified": {
+      "optional": true
+    },
+    "remark-parse": {
+      "optional": true
+    },
+    "remark-stringify": {
       "optional": true
     }
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,6 +24,9 @@ importers:
       '@types/jest':
         specifier: ^29.5.12
         version: 29.5.14
+      '@types/mdast':
+        specifier: 4.0.4
+        version: 4.0.4
       '@types/node':
         specifier: ^20.11.0
         version: 20.19.30
@@ -45,6 +48,15 @@ importers:
       rehype-stringify:
         specifier: 10.0.1
         version: 10.0.1
+      remark-gfm:
+        specifier: ^4.0.1
+        version: 4.0.1
+      remark-parse:
+        specifier: 11.0.0
+        version: 11.0.0
+      remark-stringify:
+        specifier: 11.0.0
+        version: 11.0.0
       retext:
         specifier: 9.0.0
         version: 9.0.0
@@ -408,6 +420,9 @@ packages:
   '@types/babel__traverse@7.28.0':
     resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
 
+  '@types/debug@4.1.12':
+    resolution: {integrity: sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==}
+
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
@@ -434,6 +449,9 @@ packages:
 
   '@types/mdast@4.0.4':
     resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
+
+  '@types/ms@2.1.0':
+    resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
 
   '@types/nlcst@2.0.3':
     resolution: {integrity: sha512-vSYNSDe6Ix3q+6Z7ri9lyWqgGhJTmzRjZRqyq15N0Z/1/UnVsno9G/N40NBijoYx2seFDIl0+B2mgAb9mezUCA==}
@@ -649,6 +667,9 @@ packages:
   character-entities-legacy@3.0.0:
     resolution: {integrity: sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==}
 
+  character-entities@2.0.2:
+    resolution: {integrity: sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==}
+
   ci-info@3.9.0:
     resolution: {integrity: sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==}
     engines: {node: '>=8'}
@@ -711,6 +732,9 @@ packages:
   decamelize@1.2.0:
     resolution: {integrity: sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==}
     engines: {node: '>=0.10.0'}
+
+  decode-named-character-reference@1.3.0:
+    resolution: {integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==}
 
   dedent@1.7.1:
     resolution: {integrity: sha512-9JmrhGZpOlEgOLdQgSm0zxFaYoQon408V1v49aqTWuXENVlnCuY9JBZcXZiCsZQWDjTm5Qf/nIvAy77mXDAjEg==}
@@ -1258,6 +1282,9 @@ packages:
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
 
+  longest-streak@3.1.0:
+    resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
+
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
@@ -1271,26 +1298,131 @@ packages:
   makeerror@1.0.12:
     resolution: {integrity: sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==}
 
+  markdown-table@3.0.4:
+    resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
+
+  mdast-util-find-and-replace@3.0.2:
+    resolution: {integrity: sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==}
+
+  mdast-util-from-markdown@2.0.2:
+    resolution: {integrity: sha512-uZhTV/8NBuw0WHkPTrCqDOl0zVe1BIng5ZtHoDk49ME1qqcjYmmLmOf0gELgcRMxN4w2iuIeVso5/6QymSrgmA==}
+
+  mdast-util-gfm-autolink-literal@2.0.1:
+    resolution: {integrity: sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==}
+
+  mdast-util-gfm-footnote@2.1.0:
+    resolution: {integrity: sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==}
+
+  mdast-util-gfm-strikethrough@2.0.0:
+    resolution: {integrity: sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==}
+
+  mdast-util-gfm-table@2.0.0:
+    resolution: {integrity: sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==}
+
+  mdast-util-gfm-task-list-item@2.0.0:
+    resolution: {integrity: sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==}
+
+  mdast-util-gfm@3.1.0:
+    resolution: {integrity: sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==}
+
+  mdast-util-phrasing@4.1.0:
+    resolution: {integrity: sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==}
+
   mdast-util-to-hast@13.2.1:
     resolution: {integrity: sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==}
+
+  mdast-util-to-markdown@2.1.2:
+    resolution: {integrity: sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==}
+
+  mdast-util-to-string@4.0.0:
+    resolution: {integrity: sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==}
 
   merge-stream@2.0.0:
     resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
 
+  micromark-core-commonmark@2.0.3:
+    resolution: {integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==}
+
+  micromark-extension-gfm-autolink-literal@2.1.0:
+    resolution: {integrity: sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==}
+
+  micromark-extension-gfm-footnote@2.1.0:
+    resolution: {integrity: sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==}
+
+  micromark-extension-gfm-strikethrough@2.1.0:
+    resolution: {integrity: sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==}
+
+  micromark-extension-gfm-table@2.1.1:
+    resolution: {integrity: sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==}
+
+  micromark-extension-gfm-tagfilter@2.0.0:
+    resolution: {integrity: sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==}
+
+  micromark-extension-gfm-task-list-item@2.1.0:
+    resolution: {integrity: sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==}
+
+  micromark-extension-gfm@3.0.0:
+    resolution: {integrity: sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==}
+
+  micromark-factory-destination@2.0.1:
+    resolution: {integrity: sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==}
+
+  micromark-factory-label@2.0.1:
+    resolution: {integrity: sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==}
+
+  micromark-factory-space@2.0.1:
+    resolution: {integrity: sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==}
+
+  micromark-factory-title@2.0.1:
+    resolution: {integrity: sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==}
+
+  micromark-factory-whitespace@2.0.1:
+    resolution: {integrity: sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==}
+
   micromark-util-character@2.1.1:
     resolution: {integrity: sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==}
+
+  micromark-util-chunked@2.0.1:
+    resolution: {integrity: sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==}
+
+  micromark-util-classify-character@2.0.1:
+    resolution: {integrity: sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==}
+
+  micromark-util-combine-extensions@2.0.1:
+    resolution: {integrity: sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==}
+
+  micromark-util-decode-numeric-character-reference@2.0.2:
+    resolution: {integrity: sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==}
+
+  micromark-util-decode-string@2.0.1:
+    resolution: {integrity: sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==}
 
   micromark-util-encode@2.0.1:
     resolution: {integrity: sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==}
 
+  micromark-util-html-tag-name@2.0.1:
+    resolution: {integrity: sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==}
+
+  micromark-util-normalize-identifier@2.0.1:
+    resolution: {integrity: sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==}
+
+  micromark-util-resolve-all@2.0.1:
+    resolution: {integrity: sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==}
+
   micromark-util-sanitize-uri@2.0.1:
     resolution: {integrity: sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==}
+
+  micromark-util-subtokenize@2.1.0:
+    resolution: {integrity: sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==}
 
   micromark-util-symbol@2.0.1:
     resolution: {integrity: sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==}
 
   micromark-util-types@2.0.2:
     resolution: {integrity: sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==}
+
+  micromark@4.0.2:
+    resolution: {integrity: sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==}
 
   micromatch@4.0.8:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
@@ -1453,6 +1585,15 @@ packages:
 
   rehype-stringify@10.0.1:
     resolution: {integrity: sha512-k9ecfXHmIPuFVI61B9DeLPN0qFHfawM6RsuX48hoqlaKSF61RskNjSm1lI8PhBEM0MRdLxVVm4WmTqJQccH9mA==}
+
+  remark-gfm@4.0.1:
+    resolution: {integrity: sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==}
+
+  remark-parse@11.0.0:
+    resolution: {integrity: sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==}
+
+  remark-stringify@11.0.0:
+    resolution: {integrity: sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==}
 
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
@@ -2275,6 +2416,10 @@ snapshots:
     dependencies:
       '@babel/types': 7.28.6
 
+  '@types/debug@4.1.12':
+    dependencies:
+      '@types/ms': 2.1.0
+
   '@types/estree@1.0.8': {}
 
   '@types/graceful-fs@4.1.9':
@@ -2305,6 +2450,8 @@ snapshots:
   '@types/mdast@4.0.4':
     dependencies:
       '@types/unist': 3.0.3
+
+  '@types/ms@2.1.0': {}
 
   '@types/nlcst@2.0.3':
     dependencies:
@@ -2568,6 +2715,8 @@ snapshots:
 
   character-entities-legacy@3.0.0: {}
 
+  character-entities@2.0.2: {}
+
   ci-info@3.9.0: {}
 
   cjs-module-lexer@1.4.3: {}
@@ -2628,6 +2777,10 @@ snapshots:
       ms: 2.1.3
 
   decamelize@1.2.0: {}
+
+  decode-named-character-reference@1.3.0:
+    dependencies:
+      character-entities: 2.0.2
 
   dedent@1.7.1: {}
 
@@ -3358,6 +3511,8 @@ snapshots:
 
   lodash.merge@4.6.2: {}
 
+  longest-streak@3.1.0: {}
+
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
@@ -3372,6 +3527,94 @@ snapshots:
     dependencies:
       tmpl: 1.0.5
 
+  markdown-table@3.0.4: {}
+
+  mdast-util-find-and-replace@3.0.2:
+    dependencies:
+      '@types/mdast': 4.0.4
+      escape-string-regexp: 5.0.0
+      unist-util-is: 6.0.1
+      unist-util-visit-parents: 6.0.2
+
+  mdast-util-from-markdown@2.0.2:
+    dependencies:
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      mdast-util-to-string: 4.0.0
+      micromark: 4.0.2
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-decode-string: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+      unist-util-stringify-position: 4.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-autolink-literal@2.0.1:
+    dependencies:
+      '@types/mdast': 4.0.4
+      ccount: 2.0.1
+      devlop: 1.1.0
+      mdast-util-find-and-replace: 3.0.2
+      micromark-util-character: 2.1.1
+
+  mdast-util-gfm-footnote@2.1.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.2
+      mdast-util-to-markdown: 2.1.2
+      micromark-util-normalize-identifier: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-strikethrough@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-from-markdown: 2.0.2
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-table@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      markdown-table: 3.0.4
+      mdast-util-from-markdown: 2.0.2
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-task-list-item@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.2
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm@3.1.0:
+    dependencies:
+      mdast-util-from-markdown: 2.0.2
+      mdast-util-gfm-autolink-literal: 2.0.1
+      mdast-util-gfm-footnote: 2.1.0
+      mdast-util-gfm-strikethrough: 2.0.0
+      mdast-util-gfm-table: 2.0.0
+      mdast-util-gfm-task-list-item: 2.0.0
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-phrasing@4.1.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      unist-util-is: 6.0.1
+
   mdast-util-to-hast@13.2.1:
     dependencies:
       '@types/hast': 3.0.4
@@ -3384,14 +3627,175 @@ snapshots:
       unist-util-visit: 5.1.0
       vfile: 6.0.3
 
+  mdast-util-to-markdown@2.1.2:
+    dependencies:
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      longest-streak: 3.1.0
+      mdast-util-phrasing: 4.1.0
+      mdast-util-to-string: 4.0.0
+      micromark-util-classify-character: 2.0.1
+      micromark-util-decode-string: 2.0.1
+      unist-util-visit: 5.1.0
+      zwitch: 2.0.4
+
+  mdast-util-to-string@4.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+
   merge-stream@2.0.0: {}
+
+  micromark-core-commonmark@2.0.3:
+    dependencies:
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      micromark-factory-destination: 2.0.1
+      micromark-factory-label: 2.0.1
+      micromark-factory-space: 2.0.1
+      micromark-factory-title: 2.0.1
+      micromark-factory-whitespace: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-chunked: 2.0.1
+      micromark-util-classify-character: 2.0.1
+      micromark-util-html-tag-name: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-subtokenize: 2.1.0
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-autolink-literal@2.1.0:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-footnote@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-core-commonmark: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-strikethrough@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-chunked: 2.0.1
+      micromark-util-classify-character: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-table@2.1.1:
+    dependencies:
+      devlop: 1.1.0
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-tagfilter@2.0.0:
+    dependencies:
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-task-list-item@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm@3.0.0:
+    dependencies:
+      micromark-extension-gfm-autolink-literal: 2.1.0
+      micromark-extension-gfm-footnote: 2.1.0
+      micromark-extension-gfm-strikethrough: 2.1.0
+      micromark-extension-gfm-table: 2.1.1
+      micromark-extension-gfm-tagfilter: 2.0.0
+      micromark-extension-gfm-task-list-item: 2.1.0
+      micromark-util-combine-extensions: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-destination@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-label@2.0.1:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-space@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-title@2.0.1:
+    dependencies:
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-whitespace@2.0.1:
+    dependencies:
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
 
   micromark-util-character@2.1.1:
     dependencies:
       micromark-util-symbol: 2.0.1
       micromark-util-types: 2.0.2
 
+  micromark-util-chunked@2.0.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-classify-character@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-combine-extensions@2.0.1:
+    dependencies:
+      micromark-util-chunked: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-decode-numeric-character-reference@2.0.2:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-decode-string@2.0.1:
+    dependencies:
+      decode-named-character-reference: 1.3.0
+      micromark-util-character: 2.1.1
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-symbol: 2.0.1
+
   micromark-util-encode@2.0.1: {}
+
+  micromark-util-html-tag-name@2.0.1: {}
+
+  micromark-util-normalize-identifier@2.0.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-resolve-all@2.0.1:
+    dependencies:
+      micromark-util-types: 2.0.2
 
   micromark-util-sanitize-uri@2.0.1:
     dependencies:
@@ -3399,9 +3803,38 @@ snapshots:
       micromark-util-encode: 2.0.1
       micromark-util-symbol: 2.0.1
 
+  micromark-util-subtokenize@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-chunked: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
   micromark-util-symbol@2.0.1: {}
 
   micromark-util-types@2.0.2: {}
+
+  micromark@4.0.2:
+    dependencies:
+      '@types/debug': 4.1.12
+      debug: 4.4.3
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      micromark-core-commonmark: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-chunked: 2.0.1
+      micromark-util-combine-extensions: 2.0.1
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-encode: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-subtokenize: 2.1.0
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
 
   micromatch@4.0.8:
     dependencies:
@@ -3559,6 +3992,32 @@ snapshots:
     dependencies:
       '@types/hast': 3.0.4
       hast-util-to-html: 9.0.5
+      unified: 11.0.5
+
+  remark-gfm@4.0.1:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-gfm: 3.1.0
+      micromark-extension-gfm: 3.0.0
+      remark-parse: 11.0.0
+      remark-stringify: 11.0.0
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
+
+  remark-parse@11.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-from-markdown: 2.0.2
+      micromark-util-types: 2.0.2
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
+
+  remark-stringify@11.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-to-markdown: 2.1.2
       unified: 11.0.5
 
   require-directory@2.1.1: {}

--- a/src/markdown.ts
+++ b/src/markdown.ts
@@ -1,0 +1,84 @@
+/**
+ * Convenience module for Markdown-to-Markdown typography transformations.
+ *
+ * Provides a single function that takes Markdown input and returns
+ * typographically improved Markdown output.
+ *
+ * Requires `unified`, `remark-parse`, and `remark-stringify` to be installed.
+ *
+ * @packageDocumentation
+ */
+
+import { unified } from "unified"
+import remarkParse from "remark-parse"
+import remarkStringify from "remark-stringify"
+
+import { remarkPunctilio, type RemarkPunctilioOptions } from "./remark.js"
+
+/**
+ * Options for the Markdown transform pipeline.
+ */
+export interface MarkdownOptions extends RemarkPunctilioOptions {
+  /**
+   * Character for emphasis (`*text*` vs `_text_`) and strong (`**text**` vs `__text__`).
+   * Default: "*"
+   */
+  emphasisMarker?: "*" | "_"
+
+  /**
+   * Character for strong emphasis (`**text**` vs `__text__`). Must match emphasisMarker.
+   * Default: "*"
+   */
+  strongMarker?: "*" | "_"
+
+  /** Bullet marker for output consistency. Default: "-" */
+  bulletMarker?: "-" | "*" | "+"
+
+  /** Thematic break marker. Default: "-" */
+  ruleMarker?: "-" | "*" | "_"
+}
+
+/**
+ * Transforms Markdown text with typographic improvements.
+ *
+ * Parses the input as Markdown, applies punctilio typography transformations
+ * (smart quotes, em-dashes, ellipses, etc.), and serializes back to Markdown.
+ *
+ * @param input - The Markdown text to transform
+ * @param options - Configuration options for both the transform and serializer
+ * @returns The typographically improved Markdown text
+ *
+ * @example
+ * ```ts
+ * import { transformMarkdown } from 'punctilio/markdown'
+ *
+ * await transformMarkdown('"Hello" -- world')
+ * // → '\u201CHello\u201D\u2014world'
+ * ```
+ */
+export async function transformMarkdown(
+  input: string,
+  options: MarkdownOptions = {}
+): Promise<string> {
+  const {
+    emphasisMarker,
+    strongMarker,
+    bulletMarker,
+    ruleMarker,
+    ...punctilioOptions
+  } = options
+
+  const processor = unified()
+    .use(remarkParse)
+    .use(remarkPunctilio, punctilioOptions)
+    .use(remarkStringify, {
+      emphasis: emphasisMarker ?? "*",
+      strong: strongMarker ?? "*",
+      bullet: bulletMarker ?? "-",
+      rule: ruleMarker ?? "-",
+      ...(ruleMarker === "-" || ruleMarker === undefined ? { ruleRepetition: 4 } : {}),
+    })
+
+  const result = await processor.process(input)
+  return String(result)
+}

--- a/src/remark.ts
+++ b/src/remark.ts
@@ -1,0 +1,152 @@
+/**
+ * Remark plugin for applying punctilio typography transformations to Markdown.
+ *
+ * This plugin integrates punctilio with the unified/remark ecosystem,
+ * allowing you to apply smart typography transformations to Markdown ASTs.
+ *
+ * @packageDocumentation
+ */
+
+import type { Root, PhrasingContent, Text } from "mdast"
+import type { Transformer } from "unified"
+
+import { visitParents } from "unist-util-visit-parents"
+
+import { transform, type TransformOptions } from "./index.js"
+import { DEFAULT_SEPARATOR } from "./constants.js"
+import { formatErrorString } from "./utils.js"
+
+export type RemarkPunctilioOptions = TransformOptions
+
+/**
+ * Maximum recursion depth for tree traversal functions.
+ * Prevents stack overflow from maliciously deep Markdown nesting.
+ */
+const MAX_RECURSION_DEPTH = 1000
+
+/**
+ * MDAST node types that contain phrasing (inline) content and should
+ * have their text transformed as a single unit.
+ */
+const PHRASING_CONTAINERS = new Set(["paragraph", "heading", "tableCell"])
+
+/**
+ * MDAST node types whose text content should not be transformed.
+ */
+const SKIP_TYPES = new Set(["inlineCode", "html"])
+
+/**
+ * Recursively collects text nodes from a phrasing content tree,
+ * skipping code and HTML nodes.
+ *
+ * @param node - The phrasing content node to collect from
+ * @param depth - Current recursion depth (internal use)
+ * @returns Array of Text nodes
+ */
+function flattenTextNodes(
+  node: PhrasingContent,
+  depth: number = 0
+): Text[] {
+  /* istanbul ignore if -- defensive: prevents stack overflow from malicious nesting */
+  if (depth > MAX_RECURSION_DEPTH) {
+    return []
+  }
+
+  if (SKIP_TYPES.has(node.type)) {
+    return []
+  }
+
+  if (node.type === "text") {
+    return [node]
+  }
+
+  if ("children" in node) {
+    return (node.children as PhrasingContent[]).flatMap((child) =>
+      flattenTextNodes(child, depth + 1)
+    )
+  }
+
+  return []
+}
+
+/**
+ * Remark plugin that applies punctilio typography transformations to Markdown.
+ *
+ * @param options - Plugin configuration options
+ * @returns Unified transformer function
+ *
+ * @example
+ * ```ts
+ * import { unified } from 'unified'
+ * import remarkParse from 'remark-parse'
+ * import remarkStringify from 'remark-stringify'
+ * import remarkPunctilio from 'punctilio/remark'
+ *
+ * const result = await unified()
+ *   .use(remarkParse)
+ *   .use(remarkPunctilio, {
+ *     punctuationStyle: 'american',
+ *     dashStyle: 'american',
+ *   })
+ *   .use(remarkStringify)
+ *   .process('"Hello," she said -- "it\'s nice."')
+ *
+ * // Output Markdown will have smart quotes and em-dashes
+ * ```
+ */
+export function remarkPunctilio(
+  options: RemarkPunctilioOptions = {}
+): Transformer<Root, Root> {
+  const separator = options.separator ?? DEFAULT_SEPARATOR
+
+  const transformFn = (text: string): string => {
+    return transform(text, { ...options, separator })
+  }
+
+  return (tree: Root) => {
+    visitParents(tree, (node, ancestors) => {
+      if (!PHRASING_CONTAINERS.has(node.type)) {
+        return
+      }
+
+      /* istanbul ignore if -- defensive: standard MDAST never nests phrasing containers */
+      if (ancestors.some((a) => PHRASING_CONTAINERS.has(a.type))) {
+        return
+      }
+
+      /* istanbul ignore if -- defensive: phrasing containers always have children */
+      if (!("children" in node)) {
+        return
+      }
+
+      const textNodes = (node.children as PhrasingContent[]).flatMap((child) =>
+        flattenTextNodes(child)
+      )
+
+      if (textNodes.length === 0) {
+        return
+      }
+
+      // Same separator technique as the rehype plugin:
+      // append marker to each text node, concatenate, transform, split back
+      const markedContent = textNodes.map((n) => n.value + separator).join("")
+      const transformedContent = transformFn(markedContent)
+      const transformedFragments = transformedContent.split(separator).slice(0, -1)
+
+      /* istanbul ignore if -- defensive: transform should never consume separator chars */
+      if (transformedFragments.length !== textNodes.length) {
+        throw new Error(
+          `Transformation altered the number of text nodes. ` +
+            `Expected ${textNodes.length}, got ${transformedFragments.length}. ` +
+            `Input: ${formatErrorString(markedContent, "input")}`
+        )
+      }
+
+      textNodes.forEach((n, index) => {
+        n.value = transformedFragments[index]
+      })
+    })
+  }
+}
+
+export default remarkPunctilio

--- a/src/tests/markdown.test.ts
+++ b/src/tests/markdown.test.ts
@@ -1,0 +1,71 @@
+import { transformMarkdown } from "../markdown.js"
+import { UNICODE_SYMBOLS } from "../constants.js"
+
+const {
+  LEFT_DOUBLE_QUOTE: LDQ,
+  RIGHT_DOUBLE_QUOTE: RDQ,
+  RIGHT_SINGLE_QUOTE: RSQ,
+  EM_DASH,
+  ELLIPSIS,
+} = UNICODE_SYMBOLS
+
+describe("transformMarkdown", () => {
+  it("transforms basic typography", async () => {
+    const result = await transformMarkdown('"Hello," she said.', { nbsp: false })
+    expect(result.trimEnd()).toEqual(`${LDQ}Hello,${RDQ} she said.`)
+  })
+
+  it("preserves code blocks", async () => {
+    const input = '```\n"untouched"\n```'
+    const result = await transformMarkdown(input, { nbsp: false })
+    expect(result.trimEnd()).toEqual(input)
+  })
+
+  it("handles complex documents", async () => {
+    const input = [
+      '# "Welcome"',
+      "",
+      "It's great -- isn't it?",
+      "",
+      "Wait...",
+    ].join("\n")
+
+    const expected = [
+      `# ${LDQ}Welcome${RDQ}`,
+      "",
+      `It${RSQ}s great${EM_DASH}isn${RSQ}t it?`,
+      "",
+      `Wait${ELLIPSIS}`,
+      "", // remark-stringify adds trailing newline
+    ].join("\n")
+
+    expect(await transformMarkdown(input, { nbsp: false })).toEqual(expected)
+  })
+
+  it("passes through punctuationStyle option", async () => {
+    const american = await transformMarkdown('"Hello."', {
+      punctuationStyle: "american",
+      nbsp: false,
+    })
+    const british = await transformMarkdown('"Hello."', {
+      punctuationStyle: "british",
+      nbsp: false,
+    })
+    expect(american.trimEnd()).toEqual(`${LDQ}Hello.${RDQ}`)
+    expect(british.trimEnd()).toEqual(`${LDQ}Hello${RDQ}.`)
+  })
+
+  it.each([
+    ["bulletMarker", "- item", { bulletMarker: "+" as const }, "+ item"],
+    ["emphasisMarker", "*italic*", { emphasisMarker: "_" as const }, "_italic_"],
+    ["strongMarker", "**bold**", { strongMarker: "_" as const }, "__bold__"],
+    ["ruleMarker", "---", { ruleMarker: "*" as const }, "***"],
+  ])("passes through %s option", async (_name, input, options, expected) => {
+    expect((await transformMarkdown(input, { ...options, nbsp: false })).trimEnd()).toEqual(expected)
+  })
+
+  it("uses default options when none provided", async () => {
+    const result = await transformMarkdown('"Hello"')
+    expect(result.trimEnd()).toEqual(`${LDQ}Hello${RDQ}`)
+  })
+})

--- a/src/tests/remark.test.ts
+++ b/src/tests/remark.test.ts
@@ -1,0 +1,173 @@
+import { unified } from "unified"
+import remarkParse from "remark-parse"
+import remarkGfm from "remark-gfm"
+import remarkStringify from "remark-stringify"
+import { remarkPunctilio, type RemarkPunctilioOptions } from "../remark.js"
+import { UNICODE_SYMBOLS } from "../constants.js"
+
+const {
+  LEFT_DOUBLE_QUOTE: LDQ,
+  RIGHT_DOUBLE_QUOTE: RDQ,
+  RIGHT_SINGLE_QUOTE: RSQ,
+  EM_DASH,
+  EN_DASH,
+  ELLIPSIS,
+  MULTIPLICATION,
+  NOT_EQUAL,
+  COPYRIGHT,
+  NBSP,
+  FRACTION_1_2,
+} = UNICODE_SYMBOLS
+
+async function processMarkdown(
+  markdown: string,
+  options?: RemarkPunctilioOptions
+): Promise<string> {
+  const result = await unified()
+    .use(remarkParse)
+    .use(remarkPunctilio, options)
+    .use(remarkStringify)
+    .process(markdown)
+  return String(result).trimEnd()
+}
+
+async function processGfmMarkdown(
+  markdown: string,
+  options?: RemarkPunctilioOptions
+): Promise<string> {
+  const result = await unified()
+    .use(remarkParse)
+    .use(remarkGfm)
+    .use(remarkPunctilio, options)
+    .use(remarkStringify)
+    .process(markdown)
+  return String(result).trimEnd()
+}
+
+describe("remarkPunctilio", () => {
+  describe("basic transformations (nbsp enabled)", () => {
+    it.each([
+      ["quotes", '"Hello," she said.', `${LDQ}Hello,${RDQ} she${NBSP}said.`],
+      ["apostrophes", "It's a test.", `It${RSQ}s${NBSP}a${NBSP}test.`],
+      ["em dashes", "Wait -- here it comes.", `Wait${EM_DASH}here it${NBSP}comes.`],
+      ["en dashes (number range)", "Pages 1-5", `Pages${NBSP}1${EN_DASH}5`],
+      ["ellipses", "Wait...", `Wait${ELLIPSIS}`],
+      ["multiplication", "5x5", `5${MULTIPLICATION}5`],
+      ["math symbols", "x != y", `x${NBSP}${NOT_EQUAL} y`],
+      ["legal symbols", "(c) 2024", `${COPYRIGHT}${NBSP}2024`],
+    ])("transforms %s", async (_name, input, expected) => {
+      expect(await processMarkdown(input)).toEqual(expected)
+    })
+  })
+
+  describe("basic transformations (nbsp disabled)", () => {
+    it.each([
+      ["quotes", '"Hello," she said.', `${LDQ}Hello,${RDQ} she said.`],
+      ["apostrophes", "It's a test.", `It${RSQ}s a test.`],
+      ["em dashes", "Wait -- here it comes.", `Wait${EM_DASH}here it comes.`],
+      ["ellipses", "Wait...", `Wait${ELLIPSIS}`],
+      ["multiplication", "5x5", `5${MULTIPLICATION}5`],
+      ["math symbols", "x != y", `x ${NOT_EQUAL} y`],
+      ["legal symbols", "(c) 2024", `${COPYRIGHT} 2024`],
+    ])("transforms %s", async (_name, input, expected) => {
+      expect(await processMarkdown(input, { nbsp: false })).toEqual(expected)
+    })
+  })
+
+  describe("inline element boundaries", () => {
+    it.each([
+      ["quotes spanning emphasis", '"Hello," *she* said.', `${LDQ}Hello,${RDQ} *she* said.`],
+      ["quotes inside emphasis", '*"Hello,"* she said.', `*${LDQ}Hello,${RDQ}* she said.`],
+      ["apostrophe in strong", "**It's** fine.", `**It${RSQ}s** fine.`],
+      ["dash between elements", "word *one* -- *two* word", `word *one*${EM_DASH}*two* word`],
+      ["deeply nested elements", '*"Hello **beautiful** world"*', `*${LDQ}Hello **beautiful** world${RDQ}*`],
+    ])("handles %s", async (_name, input, expected) => {
+      expect(await processMarkdown(input, { nbsp: false })).toEqual(expected)
+    })
+  })
+
+  describe("code preservation", () => {
+    it.each([
+      ["inline code", '`"Hello" -- test...`'],
+      ["fenced code blocks", '```\n"Hello" -- test...\n```'],
+      ["indented code blocks", '    "Hello" -- test...'],
+    ])("does not transform %s", async (_name, input) => {
+      const result = await processMarkdown(input, { nbsp: false })
+      expect(result).toContain('"Hello" -- test...')
+      expect(result).not.toContain(LDQ)
+      expect(result).not.toContain(EM_DASH)
+      expect(result).not.toContain(ELLIPSIS)
+    })
+
+    it("transforms text alongside inline code", async () => {
+      expect(await processMarkdown('`code` "Hello"', { nbsp: false }))
+        .toEqual(`\`code\` ${LDQ}Hello${RDQ}`)
+    })
+  })
+
+  describe("element types", () => {
+    it.each([
+      ["h1", '# "Hello"', `# ${LDQ}Hello${RDQ}`],
+      ["h2", '## It\'s nice', `## It${RSQ}s nice`],
+      ["h3", "### Wait -- really?", `### Wait${EM_DASH}really?`],
+      ["list items", '- "Hello" -- world', `* ${LDQ}Hello${RDQ}${EM_DASH}world`],
+      ["blockquotes", '> "Hello," she said.', `> ${LDQ}Hello,${RDQ} she said.`],
+    ])("transforms %s", async (_name, input, expected) => {
+      expect(await processMarkdown(input, { nbsp: false })).toEqual(expected)
+    })
+
+    it.each([
+      ["nested list items", '- outer "quote"\n  - inner "quote"', `* outer ${LDQ}quote${RDQ}\n  * inner ${LDQ}quote${RDQ}`],
+      ["link text", '["Hello," she said.](https://example.com)', `[${LDQ}Hello,${RDQ} she said.](https://example.com)`],
+      ["text around links", '"Hello" [link](url) "world"', `${LDQ}Hello${RDQ} [link](url) ${LDQ}world${RDQ}`],
+      ["text around images", '"Hello" ![img](url) "world"', `${LDQ}Hello${RDQ} ![img](url) ${LDQ}world${RDQ}`],
+      ["inline HTML boundaries", '"Hello"<br>"world"', `${LDQ}Hello${RDQ}<br>${LDQ}world${RDQ}`],
+      ["hard line breaks", '"Hello"  \n"world"', `${LDQ}Hello${RDQ}\\\n${LDQ}world${RDQ}`],
+    ])("transforms text in %s", async (_name, input, expected) => {
+      expect(await processMarkdown(input, { nbsp: false })).toEqual(expected)
+    })
+  })
+
+  describe("GFM extensions", () => {
+    it.each([
+      ["table cells", '| "Hello" | world |\n| --- | --- |\n| "test" | data |', `| ${LDQ}Hello${RDQ} | world |\n| ------- | ----- |\n| ${LDQ}test${RDQ}  | data  |`],
+      ["strikethrough", '~~"Hello" -- world~~', `~~${LDQ}Hello${RDQ}${EM_DASH}world~~`],
+    ])("transforms %s", async (_name, input, expected) => {
+      expect(await processGfmMarkdown(input, { nbsp: false })).toEqual(expected)
+    })
+  })
+
+  describe("transform options passthrough", () => {
+    it.each([
+      ["punctuationStyle american", '"Hello."', { punctuationStyle: "american" as const, nbsp: false as const }, `${LDQ}Hello.${RDQ}`],
+      ["punctuationStyle british", '"Hello."', { punctuationStyle: "british" as const, nbsp: false as const }, `${LDQ}Hello${RDQ}.`],
+      ["dashStyle american", "word - word", { dashStyle: "american" as const, nbsp: false as const }, `word${EM_DASH}word`],
+      ["dashStyle british", "word - word", { dashStyle: "british" as const, nbsp: false as const }, `word ${EN_DASH} word`],
+      ["symbols disabled", "5x5", { symbols: false, nbsp: false as const }, "5x5"],
+      ["fractions enabled", "1/2 cup", { fractions: true, nbsp: false as const }, `${FRACTION_1_2} cup`],
+      ["fractions disabled", "1/2 cup", { fractions: false, nbsp: false as const }, "1/2 cup"],
+      ["custom separator", '"Hello"', { separator: "\uE001", nbsp: false as const }, `${LDQ}Hello${RDQ}`],
+    ])("respects %s", async (_name, input, options, expected) => {
+      expect(await processMarkdown(input, options)).toEqual(expected)
+    })
+  })
+
+  describe("complex documents", () => {
+    it("transforms a multi-paragraph document", async () => {
+      const input = '"Hello," she said.\n\nIt\'s a nice day -- isn\'t it?\n\nWait...'
+      const expected = `${LDQ}Hello,${RDQ} she said.\n\nIt${RSQ}s a nice day${EM_DASH}isn${RSQ}t it?\n\nWait${ELLIPSIS}`
+      expect(await processMarkdown(input, { nbsp: false })).toEqual(expected)
+    })
+
+    it("preserves code blocks among transformed paragraphs", async () => {
+      const input = '"Transform this"\n\n```\n"Leave this alone"\n```\n\n"Transform this too"'
+      const expected = `${LDQ}Transform this${RDQ}\n\n\`\`\`\n"Leave this alone"\n\`\`\`\n\n${LDQ}Transform this too${RDQ}`
+      expect(await processMarkdown(input, { nbsp: false })).toEqual(expected)
+    })
+  })
+
+  it("is idempotent", async () => {
+    const first = await processMarkdown('"Hello," she said -- "it\'s pages 1-5."', { nbsp: false })
+    expect(await processMarkdown(first, { nbsp: false })).toEqual(first)
+  })
+})


### PR DESCRIPTION
## Summary
- Re-applies the changes from PR #84 ("Add remark plugin and Markdown convenience module") that were temporarily reverted in PR #87
- This re-merge triggers the auto-version workflow with the fixed `version-bump.sh` (from PR #86) so the version bump succeeds this time

## Changes
Re-introduces:
- `src/remark.ts`: Remark plugin for Markdown-to-Markdown pipeline
- `src/markdown.ts`: Markdown convenience module
- `src/tests/remark.test.ts` and `src/tests/markdown.test.ts`: Tests
- README updates for the new feature

## Context
- Original PR #84 merged but the auto-version [workflow failed](https://github.com/alexander-turner/punctilio/actions/runs/22013828241)
- PR #86 fixed the version-bump script to log API responses
- PR #87 reverted PR #84 so this re-merge triggers auto-version with the fix

https://claude.ai/code/session_01K3HWSRak4VoyqigR8sNUK1