### PR TITLE
Improve .npmrc security configuration and clarity

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,8 +1,6 @@
-# Security hardening for npm
-# Note: This project uses pnpm (see package.json), but this config must be
-# npm-compatible to avoid warnings when npm is used in some environments.
-# pnpm-specific options (strict-peer-dependencies, use-lockfile-v6, shamefully-hoist)
-# have been removed as they are not recognized by npm.
+# Security hardening for npm/pnpm
+# Note: This project uses pnpm (see package.json "packageManager" field).
+# Some options below are pnpm-specific and will trigger harmless warnings in npm.
 
 # Enable automatic security auditing during install
 audit=true
@@ -15,3 +13,7 @@ save-exact=true
 
 # Prefer offline packages to reduce exposure to registry attacks
 prefer-offline=true
+
+# pnpm-specific: Enforce strict peer dependencies resolution
+# (npm will warn but ignore this option)
+strict-peer-dependencies=true

--- a/.npmrc
+++ b/.npmrc
@@ -17,3 +17,7 @@ prefer-offline=true
 # pnpm-specific: Enforce strict peer dependencies resolution
 # (npm will warn but ignore this option)
 strict-peer-dependencies=true
+
+# pnpm-specific: Delay installing packages published <24hrs ago (supply chain protection)
+# Gives time for malicious releases to be detected and removed from registry
+minimum-release-age=1440

--- a/.npmrc
+++ b/.npmrc
@@ -1,5 +1,8 @@
-# Security hardening for pnpm/npm
-# See: https://pnpm.io/npmrc
+# Security hardening for npm
+# Note: This project uses pnpm (see package.json), but this config must be
+# npm-compatible to avoid warnings when npm is used in some environments.
+# pnpm-specific options (strict-peer-dependencies, use-lockfile-v6, shamefully-hoist)
+# have been removed as they are not recognized by npm.
 
 # Enable automatic security auditing during install
 audit=true
@@ -7,17 +10,8 @@ audit=true
 # Fail on high severity vulnerabilities during audit
 audit-level=high
 
-# Enforce strict peer dependencies resolution
-strict-peer-dependencies=true
-
 # Use exact versions for reproducible builds
 save-exact=true
 
 # Prefer offline packages to reduce exposure to registry attacks
 prefer-offline=true
-
-# Verify package integrity using lockfile checksums
-use-lockfile-v6=true
-
-# Disable package modifications in node_modules
-shamefully-hoist=false


### PR DESCRIPTION
## Summary
Updated `.npmrc` configuration to improve security posture, clarify pnpm-specific options, and add supply chain protection measures.

## Key Changes
- **Reorganized comments** to clarify that the project uses pnpm as the primary package manager, with notes about pnpm-specific options that may trigger harmless warnings in npm
- **Removed `use-lockfile-v6=true`** - this option is no longer necessary as v6 is now the default lockfile format
- **Removed `shamefully-hoist=false`** - simplified configuration by removing this non-essential option
- **Added `minimum-release-age=1440`** - new supply chain protection measure that delays installation of packages published less than 24 hours ago, providing time for malicious releases to be detected and removed from the registry
- **Reorganized pnpm-specific options** with inline comments explaining their pnpm-specific nature and impact on npm

## Notable Details
- The `strict-peer-dependencies=true` option is now clearly marked as pnpm-specific with a note that npm will warn but ignore it
- The new `minimum-release-age` setting adds an important security layer against supply chain attacks by preventing installation of very recently published packages
- Configuration remains backward compatible while improving clarity for developers using different package managers

https://claude.ai/code/session_01TZfMZ13LdF6CPyTRF988Dd