### PR TITLE
Fix month range dash conversion order in hyphenReplace

### DIFF
--- a/src/dashes.ts
+++ b/src/dashes.ts
@@ -218,9 +218,9 @@ export function hyphenReplace(text: string, options: DashOptions = {}): string {
   const style = options.dashStyle ?? "american"
   if (style === "none") return text
   text = minusReplace(text, options)
+  text = enDashDateRange(text, options)
   text = convertParentheticalDashes(text, sep, style)
   if (style === "american") text = normalizeEmDashSpacing(text, sep)
   text = enDashNumberRange(text, options)
-  text = enDashDateRange(text, options)
   return text
 }

--- a/src/tests/dashes.test.ts
+++ b/src/tests/dashes.test.ts
@@ -111,6 +111,19 @@ describe("hyphenReplace", () => {
     })
   })
 
+  describe("month ranges to en dashes", () => {
+    it.each([
+      ["Jan-Mar", `Jan${EN_DASH}Mar`],
+      ["Mar - Nov", `Mar${EN_DASH}Nov`],
+      ["January - March", `January${EN_DASH}March`],
+      ["October 2012 - December 2014", `October 2012${EN_DASH}December 2014`],
+      ["Jan 2000 - Feb", `Jan 2000${EN_DASH}Feb`],
+      ["March - April 2025", `March${EN_DASH}April 2025`],
+    ])('converts "%s"', (input, expected) => {
+      expect(hyphenReplace(input)).toBe(expected)
+    })
+  })
+
   describe("with separator character", () => {
     const sep = "\uE000"
     it.each([


### PR DESCRIPTION
## Summary
Reordered the dash conversion pipeline in `hyphenReplace()` to process date ranges before number ranges, ensuring month range patterns are correctly converted to en dashes.

## Changes
- Moved `enDashDateRange()` call to execute before `enDashNumberRange()` in the conversion pipeline
- Added comprehensive test cases for month range conversions covering:
  - Abbreviated months (Jan-Mar)
  - Full month names (January - March)
  - Months with years (October 2012 - December 2014)
  - Mixed formats (Jan 2000 - Feb, March - April 2025)
  - Various spacing around hyphens

## Details
The order of operations matters because `enDashNumberRange()` may match patterns that could also be valid date ranges. By processing date ranges first, we ensure month-based ranges are converted to en dashes before the number range logic runs, preventing incorrect conversions or missed opportunities to apply the proper dash style.

https://claude.ai/code/session_01UNH5paYwywFvUgda95bjad