### PR TITLE
fix: tilde, separator opts, (r) context, quote matching

### DIFF
--- a/src/dashes.ts
+++ b/src/dashes.ts
@@ -26,7 +26,7 @@ export const numberRangeDisallowedPrefixes = ["-", EN_DASH, EM_DASH, MINUS] as c
 export const months = [
   "January", "February", "March", "April", "May", "June",
   "July", "August", "September", "October", "November", "December",
-  "Jan", "Feb", "Mar", "Apr", "May", "Jun",
+  "Jan", "Feb", "Mar", "Apr", "Jun",
   "Jul", "Aug", "Sep", "Oct", "Nov", "Dec",
 ].join("|")
 
@@ -155,7 +155,7 @@ function convertParentheticalDashes(text: string, sep: string, style: DashStyle)
   // Convert spaced dashes: "word - word" or "word — word"
   // When a separator follows the dash, preserve trailing spaces (they belong to the next text segment).
   const spacedDashPattern = new RegExp(
-    `(?<=[^\\s]|^)(?<sepBefore>${escapedSep}?)[ ]+[~${EN_DASH}${EM_DASH}-]+(?!-*>)[ ]*(?<sepAfter>${escapedSep}?)(?<trailing>[ ]*)(?=\\S|$)`, "g"
+    `(?<=[^\\s]|^)(?<sepBefore>${escapedSep}?)[ ]+[${EN_DASH}${EM_DASH}-]+(?!-*>)[ ]*(?<sepAfter>${escapedSep}?)(?<trailing>[ ]*)(?=\\S|$)`, "g"
   )
   text = text.replace(spacedDashPattern, (_match, sepBefore, sepAfter, trailing) => {
     // For British style (spaced en-dash), preserve trailing spaces after separator
@@ -166,13 +166,13 @@ function convertParentheticalDashes(text: string, sep: string, style: DashStyle)
   // Convert dashes at text node boundaries: separator alone precedes dash (e.g., "word{sep}– rest")
   // Requires space after the dash to avoid matching number ranges like "1{sep}-{sep}5"
   text = text.replace(
-    new RegExp(`(?<=[^\\s])(?<sepBefore>${escapedSep})[~${EN_DASH}${EM_DASH}-]+[ ]+(?<sepAfter>${escapedSep}?)`, "g"),
+    new RegExp(`(?<=[^\\s])(?<sepBefore>${escapedSep})[${EN_DASH}${EM_DASH}-]+[ ]+(?<sepAfter>${escapedSep}?)`, "g"),
     `$<sepBefore>${maybeSpace}${localizedDash}${maybeSpace}$<sepAfter>`
   )
   // Convert multiple dashes: "word--word" or "word---word" or "quote"--"quote"
   const quoteChars = `"'${LEFT_DOUBLE_QUOTE}${RIGHT_DOUBLE_QUOTE}${LEFT_SINGLE_QUOTE}${RIGHT_SINGLE_QUOTE}`
   text = text.replace(
-    new RegExp(`(?<=[${LATIN_LETTERS}\\d${quoteChars}])(?<sepBefore>${escapedSep}?)[~${EN_DASH}${EM_DASH}-]{2,}(?<sepAfter>${escapedSep}?)(?=[${LATIN_LETTERS}${quoteChars} ])`, "g"),
+    new RegExp(`(?<=[${LATIN_LETTERS}\\d${quoteChars}])(?<sepBefore>${escapedSep}?)[${EN_DASH}${EM_DASH}-]{2,}(?<sepAfter>${escapedSep}?)(?=[${LATIN_LETTERS}${quoteChars} ])`, "g"),
     `$<sepBefore>${maybeSpace}${localizedDash}${maybeSpace}$<sepAfter>`
   )
   // Convert dashes at start of line

--- a/src/index.ts
+++ b/src/index.ts
@@ -240,11 +240,11 @@ export function transform(text: string, options: TransformOptions = {}): string 
   }
 
   if (fractions) {
-    text = fractionsTransform(text)
+    text = fractionsTransform(text, separatorOpts)
   }
 
   if (degrees) {
-    text = degreesTransform(text)
+    text = degreesTransform(text, separatorOpts)
   }
 
   if (superscript) {

--- a/src/rehype.ts
+++ b/src/rehype.ts
@@ -183,15 +183,19 @@ export function getFirstTextNode(
 export function assertSmartQuotesMatch(input: string): void {
   if (!input) return
 
-  const quoteMap: Record<string, string> = { "\u201C": "\u201D", "\u201D": "\u201C" }
+  const openers = new Set(["\u201C"])   // left double quote opens
+  const closerToOpener: Record<string, string> = { "\u201D": "\u201C" }  // right closes left
   const stack: string[] = []
 
   for (const char of input) {
-    if (char in quoteMap) {
-      if (stack.length > 0 && quoteMap[stack[stack.length - 1]] === char) {
+    if (openers.has(char)) {
+      stack.push(char)
+    } else if (char in closerToOpener) {
+      if (stack.length > 0 && stack[stack.length - 1] === closerToOpener[char]) {
         stack.pop()
       } else {
-        stack.push(char)
+        // Unmatched closer
+        throw new Error(`Mismatched quotes in ${input}`)
       }
     }
   }

--- a/src/symbols.ts
+++ b/src/symbols.ts
@@ -142,7 +142,7 @@ export function legalSymbols(text: string): string {
 
   // (r) → ® unless in enumeration "(q), (r)" or legal citation "(r)(1)" context
   text = contextAwareLegalReplace(text, /\(r\)/gi, REGISTERED, (before, after) =>
-    !/\([a-zA-Z]\)[,;]\s*$/.test(before) && !/^\(\d/.test(after)
+    !/\([a-z]\)[,;]\s*$/i.test(before) && !/^\(\d/.test(after)
   )
 
   // (tm) → ™ unconditionally

--- a/src/symbols.ts
+++ b/src/symbols.ts
@@ -116,32 +116,38 @@ export function mathSymbols(text: string): string {
   return text
 }
 
-/** Legal symbol replacement map: ASCII → Unicode */
-const LEGAL_SYMBOL_MAP: [RegExp, string][] = [
-  [/\(r\)/gi, REGISTERED],
-  [/\(tm\)/gi, TRADEMARK],
-]
+/**
+ * Context-aware replacement for legal symbols like (c), (r), (tm).
+ * Extracts surrounding text and delegates the convert/skip decision to a predicate.
+ */
+function contextAwareLegalReplace(
+  text: string,
+  pattern: RegExp,
+  replacement: string,
+  shouldConvert: (before: string, after: string) => boolean,
+): string {
+  return text.replace(pattern, (match: string, offset: number, str: string) => {
+    const before = str.slice(Math.max(0, offset - 25), offset)
+    const after = str.slice(offset + match.length, offset + match.length + 25)
+    return shouldConvert(before, after) ? replacement : match
+  })
+}
 
 /** Convert (c), (r), (tm) to ©, ®, ™. */
 export function legalSymbols(text: string): string {
-  // (c) needs context-aware replacement to avoid false positives in essays,
-  // enumerations like "(a), (b), (c)", and legal citations like "(c)(2)(A)".
-  // Only convert when there's positive copyright evidence:
-  //   - Followed by a 4-digit year (19xx/20xx) within a short window
-  //   - Preceded by the word "copyright"
-  text = text.replace(/\(c\)/gi, (match, offset, str) => {
-    const after = str.slice(offset + 3, offset + 25)
-    if (/^\s*(?:19|20)\d{2}\b/.test(after)) return COPYRIGHT
+  // (c) → © only with positive copyright evidence (year or "copyright" keyword)
+  text = contextAwareLegalReplace(text, /\(c\)/gi, COPYRIGHT, (before, after) =>
+    /^\s*(?:19|20)\d{2}\b/.test(after) || /\bcopyright\s*$/i.test(before)
+  )
 
-    const before = str.slice(Math.max(0, offset - 20), offset)
-    if (/\bcopyright\s*$/i.test(before)) return COPYRIGHT
+  // (r) → ® unless in enumeration "(q), (r)" or legal citation "(r)(1)" context
+  text = contextAwareLegalReplace(text, /\(r\)/gi, REGISTERED, (before, after) =>
+    !/\([a-zA-Z]\)[,;]\s*$/.test(before) && !/^\(\d/.test(after)
+  )
 
-    return match
-  })
+  // (tm) → ™ unconditionally
+  text = text.replace(/\(tm\)/gi, TRADEMARK)
 
-  for (const [pattern, replacement] of LEGAL_SYMBOL_MAP) {
-    text = text.replace(pattern, replacement)
-  }
   return text
 }
 

--- a/src/tests/dashes.test.ts
+++ b/src/tests/dashes.test.ts
@@ -124,6 +124,17 @@ describe("hyphenReplace", () => {
     })
   })
 
+  describe("tilde preservation", () => {
+    it.each([
+      ["word ~ word", "word ~ word"],
+      ["word ~~ word", "word ~~ word"],
+      ["the ~5% range", "the ~5% range"],
+      ["~approximately", "~approximately"],
+    ])('preserves tilde in "%s"', (input) => {
+      expect(hyphenReplace(input)).toBe(input)
+    })
+  })
+
   describe("with separator character", () => {
     const sep = "\uE000"
     it.each([

--- a/src/tests/index.test.ts
+++ b/src/tests/index.test.ts
@@ -11,6 +11,9 @@ const {
   ELLIPSIS,
   MULTIPLICATION,
   NOT_EQUAL,
+  PLUS_MINUS,
+  LESS_EQUAL,
+  GREATER_EQUAL,
   COPYRIGHT,
   NBSP,
   PRIME,
@@ -18,6 +21,7 @@ const {
   TRADEMARK,
   REGISTERED,
   DEGREE,
+  MINUS,
   FRACTION_1_2,
   SUPERSCRIPT_ST,
 } = UNICODE_SYMBOLS
@@ -183,11 +187,11 @@ describe("transform", () => {
         // Date ranges - all competitors fail
         ["January-March", `January${EN_DASH}March`],
         // Minus signs - most competitors fail
-        ["-5", `−5`],
-        ["(-5)", `(−5)`],
+        ["-5", `${MINUS}5`],
+        ["(-5)", `(${MINUS}5)`],
         // Prime marks - smartypants/typograf fail
-        ['5\'10"', `5′10″`],
-        ['He is 6\'2" tall', `He is 6′2″ tall`],
+        ['5\'10"', `5${PRIME}10${DOUBLE_PRIME}`],
+        ['He is 6\'2" tall', `He is 6${PRIME}2${DOUBLE_PRIME} tall`],
       ])('correctly transforms: "%s"', (input, expected) => {
         expect(transform(input, { symbols: true, degrees: true, nbsp: false })).toBe(expected)
       })
@@ -229,7 +233,7 @@ describe("transform", () => {
 
     it("handles technical documentation", () => {
       const input = 'The API returns x != y when a <= b and c >= d. Error tolerance: +-5%.'
-      const expected = `The API returns x ${NOT_EQUAL} y when a ≤ b and c ≥ d. Error tolerance: ±5%.`
+      const expected = `The API returns x ${NOT_EQUAL} y when a ${LESS_EQUAL} b and c ${GREATER_EQUAL} d. Error tolerance: ${PLUS_MINUS}5%.`
       expect(transform(input, { nbsp: false })).toBe(expected)
     })
 
@@ -262,11 +266,11 @@ describe("transform", () => {
     it.each([
       [
         '"Wait..." she said - "it\'s pages 1-5."',
-        `${LEFT_DOUBLE_QUOTE}Wait…${RIGHT_DOUBLE_QUOTE} she said${EM_DASH}${LEFT_DOUBLE_QUOTE}it${RIGHT_SINGLE_QUOTE}s pages 1–5.${RIGHT_DOUBLE_QUOTE}`,
+        `${LEFT_DOUBLE_QUOTE}Wait${ELLIPSIS}${RIGHT_DOUBLE_QUOTE} she said${EM_DASH}${LEFT_DOUBLE_QUOTE}it${RIGHT_SINGLE_QUOTE}s pages 1${EN_DASH}5.${RIGHT_DOUBLE_QUOTE}`,
       ],
       [
         "(c) 2024 - Room is 10x12, set to 72 F",
-        `${COPYRIGHT} 2024${EM_DASH}Room is 10×12, set to 72 °F`,
+        `${COPYRIGHT} 2024${EM_DASH}Room is 10${MULTIPLICATION}12, set to 72 ${DEGREE}F`,
       ],
     ])('handles complex transform: "%s"', (input, expected) => {
       expect(transform(input, { degrees: true, nbsp: false })).toBe(expected)
@@ -312,7 +316,7 @@ describe("transform", () => {
       const count = 50
       const input = "pages 1-5 ".repeat(count)
       const result = transform(input, { nbsp: false })
-      const enDashCount = (result.match(/–/g) || []).length
+      const enDashCount = (result.match(new RegExp(EN_DASH, "g")) || []).length
       expect(enDashCount).toBe(count)
     })
 
@@ -320,7 +324,7 @@ describe("transform", () => {
       const count = 50
       const input = "Wait... ".repeat(count)
       const result = transform(input, { nbsp: false })
-      const ellipsisCount = (result.match(/…/g) || []).length
+      const ellipsisCount = (result.match(new RegExp(ELLIPSIS, "g")) || []).length
       expect(ellipsisCount).toBe(count)
     })
   })
@@ -372,7 +376,7 @@ describe("transform", () => {
 
     it.each([
       [`word${sep} - ${sep}word`, `word${sep}${EM_DASH}${sep}word`],
-      [`1${sep}-${sep}5`, `1${sep}–${sep}5`],
+      [`1${sep}-${sep}5`, `1${sep}${EN_DASH}${sep}5`],
     ])('handles separator in dashes', (input, expected) => {
       expect(transform(input, { separator: sep, nbsp: false })).toBe(expected)
     })
@@ -416,10 +420,10 @@ describe("transform", () => {
     it.each([
       `${LEFT_DOUBLE_QUOTE}Hello${RIGHT_DOUBLE_QUOTE}`,
       `word${EM_DASH}word`,
-      `1–5`,
-      `Wait…`,
-      `5×5`,
-      `20${NBSP}°C`,
+      `1${EN_DASH}5`,
+      `Wait${ELLIPSIS}`,
+      `5${MULTIPLICATION}5`,
+      `20${NBSP}${DEGREE}C`,
       `${COPYRIGHT}${NBSP}2024`,
     ])('stable for: "%s"', (input) => {
       expect(transform(input)).toBe(input)
@@ -515,12 +519,12 @@ describe("transform", () => {
     it.each([
       ['"start', `${LEFT_DOUBLE_QUOTE}start`],
       ["'start", `${RIGHT_SINGLE_QUOTE}start`],
-      ["-5 start", `−5 start`],
-      ["...start", `… start`],
+      ["-5 start", `${MINUS}5 start`],
+      ["...start", `${ELLIPSIS} start`],
       ['end"', `end${RIGHT_DOUBLE_QUOTE}`],
       ["end'", `end${RIGHT_SINGLE_QUOTE}`],
-      ["end...", `end…`],
-      ["5x", `5×`],
+      ["end...", `end${ELLIPSIS}`],
+      ["5x", `5${MULTIPLICATION}`],
     ])('handles boundary: "%s"', (input, expected) => {
       expect(transform(input, { nbsp: false })).toBe(expected)
     })

--- a/src/tests/index.test.ts
+++ b/src/tests/index.test.ts
@@ -389,6 +389,16 @@ describe("transform", () => {
       const input = `Text with ${sep} in it`
       expect(() => transform(input, { separator: sep, nbsp: false })).not.toThrow()
     })
+
+    it("handles separator in fractions", () => {
+      const input = `1${sep}/2`
+      expect(transform(input, { separator: sep, fractions: true, nbsp: false })).toBe(`${sep}${FRACTION_1_2}`)
+    })
+
+    it("handles separator in degrees", () => {
+      const input = `72${sep} F`
+      expect(transform(input, { separator: sep, degrees: true, nbsp: false })).toBe(`72${sep} ${DEGREE}F`)
+    })
   })
 
   describe("additional idempotency", () => {

--- a/src/tests/nbsp.test.ts
+++ b/src/tests/nbsp.test.ts
@@ -15,7 +15,7 @@ import {
 } from "../nbsp.js"
 import { UNICODE_SYMBOLS, DEFAULT_SEPARATOR } from "../constants.js"
 
-const NBSP = UNICODE_SYMBOLS.NBSP
+const { NBSP, COPYRIGHT, REGISTERED, TRADEMARK } = UNICODE_SYMBOLS
 const SEP = DEFAULT_SEPARATOR
 
 /** Calls fn with separator option, checking all cases produce correct nbsp. */
@@ -183,18 +183,18 @@ describe("nbspAfterHonorifics", () => {
 
 describe("nbspAfterCopyrightSymbols", () => {
   it.each([
-    ["© 2024", `©${NBSP}2024`],
-    ["® Brand", `®${NBSP}Brand`],
-    ["™ Product", `™${NBSP}Product`],
-    ["© 2024 Company", `©${NBSP}2024 Company`],
-    ["© company", "© company"],
+    [`${COPYRIGHT} 2024`, `${COPYRIGHT}${NBSP}2024`],
+    [`${REGISTERED} Brand`, `${REGISTERED}${NBSP}Brand`],
+    [`${TRADEMARK} Product`, `${TRADEMARK}${NBSP}Product`],
+    [`${COPYRIGHT} 2024 Company`, `${COPYRIGHT}${NBSP}2024 Company`],
+    [`${COPYRIGHT} company`, `${COPYRIGHT} company`],
   ])('"%s" → "%s"', (input, expected) => {
     expect(nbspAfterCopyrightSymbols(input)).toBe(expected)
   })
 
   it("preserves separator after symbol", () => {
     expectSep(nbspAfterCopyrightSymbols, [
-      [`©${SEP} 2024`, `©${SEP}${NBSP}2024`],
+      [`${COPYRIGHT}${SEP} 2024`, `${COPYRIGHT}${SEP}${NBSP}2024`],
     ])
   })
 })
@@ -224,8 +224,8 @@ describe("nbspTransform", () => {
   })
 
   it("handles multiple rules on the same text", () => {
-    expect(nbspTransform("© 2024 by J. K. Rowling"))
-      .toBe(`©${NBSP}2024 by${NBSP}J.${NBSP}K.${NBSP}Rowling`)
+    expect(nbspTransform(`${COPYRIGHT} 2024 by J. K. Rowling`))
+      .toBe(`${COPYRIGHT}${NBSP}2024 by${NBSP}J.${NBSP}K.${NBSP}Rowling`)
   })
 
   it("nbspBeforeLastWord fires on plain text", () => {

--- a/src/tests/rehype.test.ts
+++ b/src/tests/rehype.test.ts
@@ -363,6 +363,7 @@ describe("rehypePunctilio", () => {
         ["unmatched opening", "\u201CHello"],
         ["unmatched closing", "Hello\u201D"],
         ["extra opening", "\u201C\u201CHello\u201D"],
+        ["reversed quotes", "\u201DHello\u201C"],
       ])("throws for %s", (_name, input) => {
         expect(() => assertSmartQuotesMatch(input)).toThrow("Mismatched quotes")
       })

--- a/src/tests/rehype.test.ts
+++ b/src/tests/rehype.test.ts
@@ -69,7 +69,7 @@ describe("rehypePunctilio", () => {
       ["multi-segment number preserved", "<p>1-<em>2</em>-3</p>", "<p>1-<em>2</em>-3</p>"],
       ["model name preserved", "<p><em>GPT</em>-3</p>", "<p><em>GPT</em>-3</p>"],
       ["simple range still converts", "<p>pages <em>1</em>-5</p>", `<p>pages <em>1</em>${EN_DASH}5</p>`],
-      ["genuine negative at element start", "<p><em>-5</em> degrees</p>", "<p><em>\u22125</em> degrees</p>"],
+      ["genuine negative at element start", "<p><em>-5</em> degrees</p>", `<p><em>${UNICODE_SYMBOLS.MINUS}5</em> degrees</p>`],
     ])("%s", async (_name, html, expected) => {
       expect(await processHtml(html, { nbsp: false })).toEqual(expected)
     })
@@ -259,8 +259,8 @@ describe("rehypePunctilio", () => {
 
       it("applies custom transforms", () => {
         const element = h("p", "pages 1-5") as Element
-        transformElement(element, (s) => s.replace(/-/g, "–"), ignoreNone, DEFAULT_SEPARATOR)
-        expect((element.children[0] as Text).value).toBe("pages 1–5")
+        transformElement(element, (s) => s.replace(/-/g, EN_DASH), ignoreNone, DEFAULT_SEPARATOR)
+        expect((element.children[0] as Text).value).toBe(`pages 1${EN_DASH}5`)
       })
 
       it("handles missing children gracefully", () => {
@@ -351,8 +351,8 @@ describe("rehypePunctilio", () => {
 
     describe("assertSmartQuotesMatch", () => {
       it.each([
-        ["matched double quotes", "\u201CHello\u201D"],
-        ["nested quotes", "\u201COuter \u201Cinner\u201D outer\u201D"],
+        ["matched double quotes", `${LDQ}Hello${RDQ}`],
+        ["nested quotes", `${LDQ}Outer ${LDQ}inner${RDQ} outer${RDQ}`],
         ["empty string", ""],
         ["no quotes", "Hello, world!"],
       ])("passes for %s", (_name, input) => {
@@ -360,10 +360,10 @@ describe("rehypePunctilio", () => {
       })
 
       it.each([
-        ["unmatched opening", "\u201CHello"],
-        ["unmatched closing", "Hello\u201D"],
-        ["extra opening", "\u201C\u201CHello\u201D"],
-        ["reversed quotes", "\u201DHello\u201C"],
+        ["unmatched opening", `${LDQ}Hello`],
+        ["unmatched closing", `Hello${RDQ}`],
+        ["extra opening", `${LDQ}${LDQ}Hello${RDQ}`],
+        ["reversed quotes", `${RDQ}Hello${LDQ}`],
       ])("throws for %s", (_name, input) => {
         expect(() => assertSmartQuotesMatch(input)).toThrow("Mismatched quotes")
       })

--- a/src/tests/symbols.test.ts
+++ b/src/tests/symbols.test.ts
@@ -129,7 +129,7 @@ describe("legalSymbols", () => {
     // (c) preceded by "copyright" → copyright
     ["Copyright (c) Company", `Copyright ${UNICODE_SYMBOLS.COPYRIGHT} Company`],
     ["copyright (C) by Author", `copyright ${UNICODE_SYMBOLS.COPYRIGHT} by Author`],
-    // (r) and (tm) always convert
+    // (r) converts in trademark context
     ["Brand(r)", `Brand${UNICODE_SYMBOLS.REGISTERED}`],
     ["Product (R)", `Product ${UNICODE_SYMBOLS.REGISTERED}`],
     ["Name(tm)", `Name${UNICODE_SYMBOLS.TRADEMARK}`],
@@ -152,6 +152,16 @@ describe("legalSymbols", () => {
     ["discussed in (c) above", "discussed in (c) above"],
     ["(C) Acme Inc", "(C) Acme Inc"],
   ])('preserves (c) in non-copyright context "%s"', (input, expected) => {
+    expect(legalSymbols(input)).toBe(expected)
+  })
+
+  it.each([
+    // (r) in enumerations
+    ["(p), (q), (r), (s)", "(p), (q), (r), (s)"],
+    ["(Q); (R); (S)", "(Q); (R); (S)"],
+    // (r) in legal citations
+    ["See (r)(1)(A)", "See (r)(1)(A)"],
+  ])('preserves (r) in non-trademark context "%s"', (input, expected) => {
     expect(legalSymbols(input)).toBe(expected)
   })
 })

--- a/src/tests/symbols.test.ts
+++ b/src/tests/symbols.test.ts
@@ -237,14 +237,14 @@ describe("primeMarks", () => {
     ['He is 6\'2" tall', `He is 6${UNICODE_SYMBOLS.PRIME}2${UNICODE_SYMBOLS.DOUBLE_PRIME} tall`],
     ["The board is 8' long", `The board is 8${UNICODE_SYMBOLS.PRIME} long`],
     ['12"', `12${UNICODE_SYMBOLS.DOUBLE_PRIME}`],
-    ["Location: 45° 30' 15\"", `Location: 45° 30${UNICODE_SYMBOLS.PRIME} 15${UNICODE_SYMBOLS.DOUBLE_PRIME}`],
+    [`Location: 45${UNICODE_SYMBOLS.DEGREE} 30' 15"`, `Location: 45${UNICODE_SYMBOLS.DEGREE} 30${UNICODE_SYMBOLS.PRIME} 15${UNICODE_SYMBOLS.DOUBLE_PRIME}`],
     ["don't", "don't"],
     ["it's", "it's"],
     ["'Twas the night", "'Twas the night"],
     ["'hello'", "'hello'"],
     ['"test"', '"test"'],
     ['The ceiling is 9\'6" high', `The ceiling is 9${UNICODE_SYMBOLS.PRIME}6${UNICODE_SYMBOLS.DOUBLE_PRIME} high`],
-    ["40° 44' 54\" N", `40° 44${UNICODE_SYMBOLS.PRIME} 54${UNICODE_SYMBOLS.DOUBLE_PRIME} N`],
+    [`40${UNICODE_SYMBOLS.DEGREE} 44' 54" N`, `40${UNICODE_SYMBOLS.DEGREE} 44${UNICODE_SYMBOLS.PRIME} 54${UNICODE_SYMBOLS.DOUBLE_PRIME} N`],
     ['The board is 12" wide', `The board is 12${UNICODE_SYMBOLS.DOUBLE_PRIME} wide`],
     ['12" long', `12${UNICODE_SYMBOLS.DOUBLE_PRIME} long`],
     // Multiple primes in one string
@@ -544,9 +544,9 @@ describe("competitor-derived edge cases", () => {
   // From Standard Ebooks: coordinates
   describe("coordinate notation", () => {
     it.each([
-      ["40° 44' 54\" N", `40° 44${UNICODE_SYMBOLS.PRIME} 54${UNICODE_SYMBOLS.DOUBLE_PRIME} N`],
-      ["74° 0' 21\" W", `74° 0${UNICODE_SYMBOLS.PRIME} 21${UNICODE_SYMBOLS.DOUBLE_PRIME} W`],
-      ["51° 30' N", `51° 30${UNICODE_SYMBOLS.PRIME} N`],
+      [`40${UNICODE_SYMBOLS.DEGREE} 44' 54" N`, `40${UNICODE_SYMBOLS.DEGREE} 44${UNICODE_SYMBOLS.PRIME} 54${UNICODE_SYMBOLS.DOUBLE_PRIME} N`],
+      [`74${UNICODE_SYMBOLS.DEGREE} 0' 21" W`, `74${UNICODE_SYMBOLS.DEGREE} 0${UNICODE_SYMBOLS.PRIME} 21${UNICODE_SYMBOLS.DOUBLE_PRIME} W`],
+      [`51${UNICODE_SYMBOLS.DEGREE} 30' N`, `51${UNICODE_SYMBOLS.DEGREE} 30${UNICODE_SYMBOLS.PRIME} N`],
     ])('converts coordinates: "%s"', (input, expected) => {
       expect(primeMarks(input)).toBe(expected)
     })


### PR DESCRIPTION
## Summary
- **Tilde in dash character classes**: Removed `~` from 3 regex character classes in `convertParentheticalDashes()` that incorrectly matched tildes and converted them to em/en dashes (e.g., `word ~ word` became `word—word`)
- **Missing separatorOpts**: `fractions()` and `degrees()` transforms in the `transform()` pipeline were called without separator options, causing separator-aware patterns to fail when processing text across HTML element boundaries
- **`(r)` false positives**: Added context guards to `(r)` → ® conversion to prevent false positives in enumerations like `(p), (q), (r), (s)` and legal citations like `(r)(1)(A)`. Now skips conversion when preceded by a single-letter parenthesized item or followed by a parenthesized number
- **`assertSmartQuotesMatch` false negative**: Fixed bidirectional quote map that allowed reversed quotes to pass validation. Now enforces directional semantics: only left double quote opens, only right double quote closes
- **Duplicate "May"**: Removed duplicate "May" entry from abbreviated months in the `months` regex alternation

## Test plan
- [x] Added tilde preservation tests (4 cases: spaced, doubled, prefixed number, prefixed word)
- [x] Added (r) enumeration/citation preservation tests (3 cases)
- [x] Added reversed quotes test for assertSmartQuotesMatch
- [x] Added separator robustness tests for fractions and degrees in transform()
- [x] All 1264 tests pass with 100% coverage

https://claude.ai/code/session_01QoWLS5eMFR9FrtaJRCCSFF