### PR TITLE
Clear version field in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "punctilio",
-  "version": "1.4.1",
+  "version": "",
   "description": "Smart typography transformations: curly quotes, em-dashes, en-dashes, and more",
   "type": "module",
   "main": "./dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "punctilio",
-  "version": "",
+  "version": "", // Tracked via git tags and npmjs.com
   "description": "Smart typography transformations: curly quotes, em-dashes, en-dashes, and more",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
This change clears the version field in package.json, setting it to an empty string instead of the previous "1.4.1" value.

## Summary
The version number has been removed from the package.json manifest file.

## Changes
- Set `version` field to empty string in package.json

## Notes
This appears to be a preparation for automated version management, possibly for a build process or release workflow that will populate the version field dynamically.

https://claude.ai/code/session_01LmocnKubDpCpWfxkxu5qgp