### PR TITLE
Set placeholder version for git-based distribution

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "punctilio",
-  "version": "", // Tracked via git tags and npmjs.com
+  "version": "0.0.0-git",
   "description": "Smart typography transformations: curly quotes, em-dashes, en-dashes, and more",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Summary
Updated the package version field to use a placeholder value that indicates this is a git-based distribution, rather than leaving it empty.

## Changes
- Changed `package.json` version from an empty string to `"0.0.0-git"`
- This allows the package to have a valid version identifier while being distributed via git, with the actual version still tracked through git tags and npmjs.com as noted in the comment

## Details
The version field is now set to a semantic versioning-compliant placeholder (`0.0.0-git`) that clearly indicates this is a development/git distribution. This ensures the package has a valid version string for tooling and package managers while maintaining the existing version management strategy via git tags.

https://claude.ai/code/session_01UL1Pz3WavtURAZoaXraBdq