### PR TITLE
fix: replace literal Unicode with UNICODE_SYMBOLS constants

### DIFF
--- a/src/tests/index.test.ts
+++ b/src/tests/index.test.ts
@@ -11,6 +11,9 @@ const {
   ELLIPSIS,
   MULTIPLICATION,
   NOT_EQUAL,
+  PLUS_MINUS,
+  LESS_EQUAL,
+  GREATER_EQUAL,
   COPYRIGHT,
   NBSP,
   PRIME,
@@ -18,6 +21,7 @@ const {
   TRADEMARK,
   REGISTERED,
   DEGREE,
+  MINUS,
   FRACTION_1_2,
   SUPERSCRIPT_ST,
 } = UNICODE_SYMBOLS
@@ -183,11 +187,11 @@ describe("transform", () => {
         // Date ranges - all competitors fail
         ["January-March", `January${EN_DASH}March`],
         // Minus signs - most competitors fail
-        ["-5", `−5`],
-        ["(-5)", `(−5)`],
+        ["-5", `${MINUS}5`],
+        ["(-5)", `(${MINUS}5)`],
         // Prime marks - smartypants/typograf fail
-        ['5\'10"', `5′10″`],
-        ['He is 6\'2" tall', `He is 6′2″ tall`],
+        ['5\'10"', `5${PRIME}10${DOUBLE_PRIME}`],
+        ['He is 6\'2" tall', `He is 6${PRIME}2${DOUBLE_PRIME} tall`],
       ])('correctly transforms: "%s"', (input, expected) => {
         expect(transform(input, { symbols: true, degrees: true, nbsp: false })).toBe(expected)
       })
@@ -229,7 +233,7 @@ describe("transform", () => {
 
     it("handles technical documentation", () => {
       const input = 'The API returns x != y when a <= b and c >= d. Error tolerance: +-5%.'
-      const expected = `The API returns x ${NOT_EQUAL} y when a ≤ b and c ≥ d. Error tolerance: ±5%.`
+      const expected = `The API returns x ${NOT_EQUAL} y when a ${LESS_EQUAL} b and c ${GREATER_EQUAL} d. Error tolerance: ${PLUS_MINUS}5%.`
       expect(transform(input, { nbsp: false })).toBe(expected)
     })
 
@@ -262,11 +266,11 @@ describe("transform", () => {
     it.each([
       [
         '"Wait..." she said - "it\'s pages 1-5."',
-        `${LEFT_DOUBLE_QUOTE}Wait…${RIGHT_DOUBLE_QUOTE} she said${EM_DASH}${LEFT_DOUBLE_QUOTE}it${RIGHT_SINGLE_QUOTE}s pages 1–5.${RIGHT_DOUBLE_QUOTE}`,
+        `${LEFT_DOUBLE_QUOTE}Wait${ELLIPSIS}${RIGHT_DOUBLE_QUOTE} she said${EM_DASH}${LEFT_DOUBLE_QUOTE}it${RIGHT_SINGLE_QUOTE}s pages 1${EN_DASH}5.${RIGHT_DOUBLE_QUOTE}`,
       ],
       [
         "(c) 2024 - Room is 10x12, set to 72 F",
-        `${COPYRIGHT} 2024${EM_DASH}Room is 10×12, set to 72 °F`,
+        `${COPYRIGHT} 2024${EM_DASH}Room is 10${MULTIPLICATION}12, set to 72 ${DEGREE}F`,
       ],
     ])('handles complex transform: "%s"', (input, expected) => {
       expect(transform(input, { degrees: true, nbsp: false })).toBe(expected)
@@ -312,7 +316,7 @@ describe("transform", () => {
       const count = 50
       const input = "pages 1-5 ".repeat(count)
       const result = transform(input, { nbsp: false })
-      const enDashCount = (result.match(/–/g) || []).length
+      const enDashCount = (result.match(new RegExp(EN_DASH, "g")) || []).length
       expect(enDashCount).toBe(count)
     })
 
@@ -320,7 +324,7 @@ describe("transform", () => {
       const count = 50
       const input = "Wait... ".repeat(count)
       const result = transform(input, { nbsp: false })
-      const ellipsisCount = (result.match(/…/g) || []).length
+      const ellipsisCount = (result.match(new RegExp(ELLIPSIS, "g")) || []).length
       expect(ellipsisCount).toBe(count)
     })
   })
@@ -372,7 +376,7 @@ describe("transform", () => {
 
     it.each([
       [`word${sep} - ${sep}word`, `word${sep}${EM_DASH}${sep}word`],
-      [`1${sep}-${sep}5`, `1${sep}–${sep}5`],
+      [`1${sep}-${sep}5`, `1${sep}${EN_DASH}${sep}5`],
     ])('handles separator in dashes', (input, expected) => {
       expect(transform(input, { separator: sep, nbsp: false })).toBe(expected)
     })
@@ -416,10 +420,10 @@ describe("transform", () => {
     it.each([
       `${LEFT_DOUBLE_QUOTE}Hello${RIGHT_DOUBLE_QUOTE}`,
       `word${EM_DASH}word`,
-      `1–5`,
-      `Wait…`,
-      `5×5`,
-      `20${NBSP}°C`,
+      `1${EN_DASH}5`,
+      `Wait${ELLIPSIS}`,
+      `5${MULTIPLICATION}5`,
+      `20${NBSP}${DEGREE}C`,
       `${COPYRIGHT}${NBSP}2024`,
     ])('stable for: "%s"', (input) => {
       expect(transform(input)).toBe(input)
@@ -515,12 +519,12 @@ describe("transform", () => {
     it.each([
       ['"start', `${LEFT_DOUBLE_QUOTE}start`],
       ["'start", `${RIGHT_SINGLE_QUOTE}start`],
-      ["-5 start", `−5 start`],
-      ["...start", `… start`],
+      ["-5 start", `${MINUS}5 start`],
+      ["...start", `${ELLIPSIS} start`],
       ['end"', `end${RIGHT_DOUBLE_QUOTE}`],
       ["end'", `end${RIGHT_SINGLE_QUOTE}`],
-      ["end...", `end…`],
-      ["5x", `5×`],
+      ["end...", `end${ELLIPSIS}`],
+      ["5x", `5${MULTIPLICATION}`],
     ])('handles boundary: "%s"', (input, expected) => {
       expect(transform(input, { nbsp: false })).toBe(expected)
     })

--- a/src/tests/nbsp.test.ts
+++ b/src/tests/nbsp.test.ts
@@ -15,7 +15,7 @@ import {
 } from "../nbsp.js"
 import { UNICODE_SYMBOLS, DEFAULT_SEPARATOR } from "../constants.js"
 
-const NBSP = UNICODE_SYMBOLS.NBSP
+const { NBSP, COPYRIGHT, REGISTERED, TRADEMARK } = UNICODE_SYMBOLS
 const SEP = DEFAULT_SEPARATOR
 
 /** Calls fn with separator option, checking all cases produce correct nbsp. */
@@ -183,18 +183,18 @@ describe("nbspAfterHonorifics", () => {
 
 describe("nbspAfterCopyrightSymbols", () => {
   it.each([
-    ["© 2024", `©${NBSP}2024`],
-    ["® Brand", `®${NBSP}Brand`],
-    ["™ Product", `™${NBSP}Product`],
-    ["© 2024 Company", `©${NBSP}2024 Company`],
-    ["© company", "© company"],
+    [`${COPYRIGHT} 2024`, `${COPYRIGHT}${NBSP}2024`],
+    [`${REGISTERED} Brand`, `${REGISTERED}${NBSP}Brand`],
+    [`${TRADEMARK} Product`, `${TRADEMARK}${NBSP}Product`],
+    [`${COPYRIGHT} 2024 Company`, `${COPYRIGHT}${NBSP}2024 Company`],
+    [`${COPYRIGHT} company`, `${COPYRIGHT} company`],
   ])('"%s" → "%s"', (input, expected) => {
     expect(nbspAfterCopyrightSymbols(input)).toBe(expected)
   })
 
   it("preserves separator after symbol", () => {
     expectSep(nbspAfterCopyrightSymbols, [
-      [`©${SEP} 2024`, `©${SEP}${NBSP}2024`],
+      [`${COPYRIGHT}${SEP} 2024`, `${COPYRIGHT}${SEP}${NBSP}2024`],
     ])
   })
 })
@@ -224,8 +224,8 @@ describe("nbspTransform", () => {
   })
 
   it("handles multiple rules on the same text", () => {
-    expect(nbspTransform("© 2024 by J. K. Rowling"))
-      .toBe(`©${NBSP}2024 by${NBSP}J.${NBSP}K.${NBSP}Rowling`)
+    expect(nbspTransform(`${COPYRIGHT} 2024 by J. K. Rowling`))
+      .toBe(`${COPYRIGHT}${NBSP}2024 by${NBSP}J.${NBSP}K.${NBSP}Rowling`)
   })
 
   it("nbspBeforeLastWord fires on plain text", () => {

--- a/src/tests/rehype.test.ts
+++ b/src/tests/rehype.test.ts
@@ -69,7 +69,7 @@ describe("rehypePunctilio", () => {
       ["multi-segment number preserved", "<p>1-<em>2</em>-3</p>", "<p>1-<em>2</em>-3</p>"],
       ["model name preserved", "<p><em>GPT</em>-3</p>", "<p><em>GPT</em>-3</p>"],
       ["simple range still converts", "<p>pages <em>1</em>-5</p>", `<p>pages <em>1</em>${EN_DASH}5</p>`],
-      ["genuine negative at element start", "<p><em>-5</em> degrees</p>", "<p><em>\u22125</em> degrees</p>"],
+      ["genuine negative at element start", "<p><em>-5</em> degrees</p>", `<p><em>${UNICODE_SYMBOLS.MINUS}5</em> degrees</p>`],
     ])("%s", async (_name, html, expected) => {
       expect(await processHtml(html, { nbsp: false })).toEqual(expected)
     })
@@ -259,8 +259,8 @@ describe("rehypePunctilio", () => {
 
       it("applies custom transforms", () => {
         const element = h("p", "pages 1-5") as Element
-        transformElement(element, (s) => s.replace(/-/g, "–"), ignoreNone, DEFAULT_SEPARATOR)
-        expect((element.children[0] as Text).value).toBe("pages 1–5")
+        transformElement(element, (s) => s.replace(/-/g, EN_DASH), ignoreNone, DEFAULT_SEPARATOR)
+        expect((element.children[0] as Text).value).toBe(`pages 1${EN_DASH}5`)
       })
 
       it("handles missing children gracefully", () => {
@@ -351,8 +351,8 @@ describe("rehypePunctilio", () => {
 
     describe("assertSmartQuotesMatch", () => {
       it.each([
-        ["matched double quotes", "\u201CHello\u201D"],
-        ["nested quotes", "\u201COuter \u201Cinner\u201D outer\u201D"],
+        ["matched double quotes", `${LDQ}Hello${RDQ}`],
+        ["nested quotes", `${LDQ}Outer ${LDQ}inner${RDQ} outer${RDQ}`],
         ["empty string", ""],
         ["no quotes", "Hello, world!"],
       ])("passes for %s", (_name, input) => {
@@ -360,10 +360,10 @@ describe("rehypePunctilio", () => {
       })
 
       it.each([
-        ["unmatched opening", "\u201CHello"],
-        ["unmatched closing", "Hello\u201D"],
-        ["extra opening", "\u201C\u201CHello\u201D"],
-        ["reversed quotes", "\u201DHello\u201C"],
+        ["unmatched opening", `${LDQ}Hello`],
+        ["unmatched closing", `Hello${RDQ}`],
+        ["extra opening", `${LDQ}${LDQ}Hello${RDQ}`],
+        ["reversed quotes", `${RDQ}Hello${LDQ}`],
       ])("throws for %s", (_name, input) => {
         expect(() => assertSmartQuotesMatch(input)).toThrow("Mismatched quotes")
       })

--- a/src/tests/symbols.test.ts
+++ b/src/tests/symbols.test.ts
@@ -237,14 +237,14 @@ describe("primeMarks", () => {
     ['He is 6\'2" tall', `He is 6${UNICODE_SYMBOLS.PRIME}2${UNICODE_SYMBOLS.DOUBLE_PRIME} tall`],
     ["The board is 8' long", `The board is 8${UNICODE_SYMBOLS.PRIME} long`],
     ['12"', `12${UNICODE_SYMBOLS.DOUBLE_PRIME}`],
-    ["Location: 45° 30' 15\"", `Location: 45° 30${UNICODE_SYMBOLS.PRIME} 15${UNICODE_SYMBOLS.DOUBLE_PRIME}`],
+    [`Location: 45${UNICODE_SYMBOLS.DEGREE} 30' 15"`, `Location: 45${UNICODE_SYMBOLS.DEGREE} 30${UNICODE_SYMBOLS.PRIME} 15${UNICODE_SYMBOLS.DOUBLE_PRIME}`],
     ["don't", "don't"],
     ["it's", "it's"],
     ["'Twas the night", "'Twas the night"],
     ["'hello'", "'hello'"],
     ['"test"', '"test"'],
     ['The ceiling is 9\'6" high', `The ceiling is 9${UNICODE_SYMBOLS.PRIME}6${UNICODE_SYMBOLS.DOUBLE_PRIME} high`],
-    ["40° 44' 54\" N", `40° 44${UNICODE_SYMBOLS.PRIME} 54${UNICODE_SYMBOLS.DOUBLE_PRIME} N`],
+    [`40${UNICODE_SYMBOLS.DEGREE} 44' 54" N`, `40${UNICODE_SYMBOLS.DEGREE} 44${UNICODE_SYMBOLS.PRIME} 54${UNICODE_SYMBOLS.DOUBLE_PRIME} N`],
     ['The board is 12" wide', `The board is 12${UNICODE_SYMBOLS.DOUBLE_PRIME} wide`],
     ['12" long', `12${UNICODE_SYMBOLS.DOUBLE_PRIME} long`],
     // Multiple primes in one string
@@ -544,9 +544,9 @@ describe("competitor-derived edge cases", () => {
   // From Standard Ebooks: coordinates
   describe("coordinate notation", () => {
     it.each([
-      ["40° 44' 54\" N", `40° 44${UNICODE_SYMBOLS.PRIME} 54${UNICODE_SYMBOLS.DOUBLE_PRIME} N`],
-      ["74° 0' 21\" W", `74° 0${UNICODE_SYMBOLS.PRIME} 21${UNICODE_SYMBOLS.DOUBLE_PRIME} W`],
-      ["51° 30' N", `51° 30${UNICODE_SYMBOLS.PRIME} N`],
+      [`40${UNICODE_SYMBOLS.DEGREE} 44' 54" N`, `40${UNICODE_SYMBOLS.DEGREE} 44${UNICODE_SYMBOLS.PRIME} 54${UNICODE_SYMBOLS.DOUBLE_PRIME} N`],
+      [`74${UNICODE_SYMBOLS.DEGREE} 0' 21" W`, `74${UNICODE_SYMBOLS.DEGREE} 0${UNICODE_SYMBOLS.PRIME} 21${UNICODE_SYMBOLS.DOUBLE_PRIME} W`],
+      [`51${UNICODE_SYMBOLS.DEGREE} 30' N`, `51${UNICODE_SYMBOLS.DEGREE} 30${UNICODE_SYMBOLS.PRIME} N`],
     ])('converts coordinates: "%s"', (input, expected) => {
       expect(primeMarks(input)).toBe(expected)
     })


### PR DESCRIPTION
## Summary
- Replaces all literal/escaped Unicode characters in test files with their named `UNICODE_SYMBOLS` constants for consistency and readability
- Characters like `−` (minus) vs `-` (hyphen) are visually indistinguishable in most editors; using `MINUS` makes intent explicit

## Changes
- **src/tests/index.test.ts**: Added `MINUS`, `PLUS_MINUS`, `LESS_EQUAL`, `GREATER_EQUAL` imports; replaced ~18 literal Unicode chars with constants
- **src/tests/nbsp.test.ts**: Added `COPYRIGHT`, `REGISTERED`, `TRADEMARK` imports; replaced ~12 literal ©, ®, ™ with constants
- **src/tests/rehype.test.ts**: Replaced literal en-dash, minus, and smart quote escapes with named constants
- **src/tests/symbols.test.ts**: Replaced literal ° (degree) in coordinate test data with `UNICODE_SYMBOLS.DEGREE`

## Testing
All 1264 tests pass with 100% coverage across all files.

https://claude.ai/code/session_01WXsdKRUj7FBQnePdnGRWAe