### PR TITLE
feat: prevent em dashes from wrapping to start of new line

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -54,6 +54,7 @@ export const UNICODE_SYMBOLS = {
   RIGHT_SINGLE_QUOTE: "\u2019",
   MODIFIER_LETTER_APOSTROPHE: "\u02BC",
   NBSP: "\u00A0",
+  WORD_JOINER: "\u2060",
   // Superscript ordinal suffixes
   SUPERSCRIPT_ST: "\u02E2\u1D57", // ˢᵗ
   SUPERSCRIPT_ND: "\u207F\u1D48", // ⁿᵈ

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -68,6 +68,11 @@ export const UNICODE_SYMBOLS = {
 } as const
 
 /**
+ * Em dash preceded by a word joiner to prevent line-break before the dash.
+ */
+export const NOWRAP_EM_DASH = `${UNICODE_SYMBOLS.WORD_JOINER}${UNICODE_SYMBOLS.EM_DASH}`
+
+/**
  * Character class pattern for Latin letters including European accented characters.
  * Use inside regex character classes: `[${LATIN_LETTERS}]`
  *

--- a/src/dashes.ts
+++ b/src/dashes.ts
@@ -233,6 +233,9 @@ export function hyphenReplace(text: string, options: DashOptions = {}): string {
   const sep = options.separator ?? DEFAULT_SEPARATOR
   const style = options.dashStyle ?? "american"
   if (style === "none") return text
+  // Strip word joiners before em dashes so internal regex patterns match correctly.
+  // preventEmDashLineBreak() at the end re-adds them.
+  text = text.replaceAll(wordJoinerEmDash, EM_DASH)
   text = minusReplace(text, options)
   text = enDashDateRange(text, options)
   text = convertParentheticalDashes(text, sep, style)

--- a/src/dashes.ts
+++ b/src/dashes.ts
@@ -14,7 +14,7 @@ export interface DashOptions {
   dashStyle?: DashStyle
 }
 
-const { EN_DASH, EM_DASH, MINUS, LEFT_DOUBLE_QUOTE, RIGHT_DOUBLE_QUOTE, LEFT_SINGLE_QUOTE, RIGHT_SINGLE_QUOTE } = UNICODE_SYMBOLS
+const { EN_DASH, EM_DASH, MINUS, WORD_JOINER, LEFT_DOUBLE_QUOTE, RIGHT_DOUBLE_QUOTE, LEFT_SINGLE_QUOTE, RIGHT_SINGLE_QUOTE } = UNICODE_SYMBOLS
 
 /**
  * Characters that, when preceding a number, prevent it from being
@@ -212,6 +212,22 @@ function normalizeEmDashSpacing(text: string, sep: string): string {
   return text
 }
 
+/**
+ * Prevent em dashes from wrapping to the start of a new line.
+ *
+ * Unicode classifies em dash (U+2014) with line break class B2, giving browsers
+ * a line break opportunity before it. This causes em dashes to appear orphaned at
+ * the start of a new line. Inserting a Word Joiner (U+2060) before each em dash
+ * suppresses that break opportunity, keeping the em dash attached to the preceding word.
+ *
+ * Uses idempotent string operations: strips any existing word joiners before em dashes
+ * first, then re-inserts them, so the function can be safely called multiple times.
+ */
+const wordJoinerEmDash = `${WORD_JOINER}${EM_DASH}`
+export function preventEmDashLineBreak(text: string): string {
+  return text.replaceAll(wordJoinerEmDash, EM_DASH).replaceAll(EM_DASH, wordJoinerEmDash)
+}
+
 /** Full dash transformation. */
 export function hyphenReplace(text: string, options: DashOptions = {}): string {
   const sep = options.separator ?? DEFAULT_SEPARATOR
@@ -222,5 +238,6 @@ export function hyphenReplace(text: string, options: DashOptions = {}): string {
   text = convertParentheticalDashes(text, sep, style)
   if (style === "american") text = normalizeEmDashSpacing(text, sep)
   text = enDashNumberRange(text, options)
+  text = preventEmDashLineBreak(text)
   return text
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ export {
   enDashNumberRange,
   enDashDateRange,
   minusReplace,
+  preventEmDashLineBreak,
   months,
   numberRangeDisallowedPrefixes,
   type DashOptions,

--- a/src/quotes.ts
+++ b/src/quotes.ts
@@ -13,6 +13,7 @@ const {
   RIGHT_SINGLE_QUOTE,
   MODIFIER_LETTER_APOSTROPHE,
   ELLIPSIS,
+  WORD_JOINER,
 } = UNICODE_SYMBOLS
 
 export type PunctuationStyle = "american" | "british" | "none"
@@ -35,7 +36,7 @@ function convertSingleQuotes(text: string, sep: string): string {
   text = text.replace(new RegExp(`(?<!${singleQuoteOrWord})''(?!${singleQuoteOrWord})`, "g"), `${LEFT_SINGLE_QUOTE}${RIGHT_SINGLE_QUOTE}`)
   text = text.replace(new RegExp(`(?<!${singleQuoteOrWord})'(\\s+)'(?!${singleQuoteOrWord})`, "g"), `${LEFT_SINGLE_QUOTE}$1${RIGHT_SINGLE_QUOTE}`)
 
-  const afterEndingSinglePatterns = `\\s\\.!?;,\\)${EM_DASH}\\-\\]"`
+  const afterEndingSinglePatterns = `\\s\\.!?;,\\)${EM_DASH}${WORD_JOINER}\\-\\]"`
   // Full pattern with optional 's' for lookahead detection in apostropheRegex
   const afterEndingSingle = `(?=${escapedSep}?(?:s${escapedSep}?)?(?:[${afterEndingSinglePatterns}]|$))`
 
@@ -114,14 +115,14 @@ function convertDoubleQuotes(text: string, sep: string): string {
   text = text.replace(/(?<=^|[\s([{])"(?<whitespace>\s+)"(?=$|[\s)\]}.!?,;:])/g, `${LEFT_DOUBLE_QUOTE}$<whitespace>${RIGHT_DOUBLE_QUOTE}`)
 
   const beginningDouble = new RegExp(
-    `(?<=^|[\\s\\(\\/\\[\\{\\-${EM_DASH}${escapedSep}])(?<beforeChr>${escapedSep}?)["](?<afterChr>(?<sepWithPunct>${escapedSep}[ .,])|(?=${escapedSep}?\\.{3}|${escapedSep}?[^\\s\\)\\${EM_DASH},!?${escapedSep};:.\\}]))`,
+    `(?<=^|[\\s\\(\\/\\[\\{\\-${EM_DASH}${escapedSep}])(?<beforeChr>${escapedSep}?)["](?<afterChr>(?<sepWithPunct>${escapedSep}[ .,])|(?=${escapedSep}?\\.{3}|${escapedSep}?[^\\s\\)\\${EM_DASH}${WORD_JOINER},!?${escapedSep};:.\\}]))`,
     "gm"
   )
   text = text.replace(beginningDouble, `$<beforeChr>${LEFT_DOUBLE_QUOTE}$<afterChr>`)
 
   text = text.replace(new RegExp(`(?<=\\{)(?<sepSpace>${escapedSep}? )?["]`, "g"), `$<sepSpace>${LEFT_DOUBLE_QUOTE}`)
 
-  const endingDouble = `(?<beforeQuote>[^\\s\\(])["]((?<sepAfter>${escapedSep})?)(?=${escapedSep}|[\\s/\\).,;${EM_DASH}:\\-\\}!?s]|$)`
+  const endingDouble = `(?<beforeQuote>[^\\s\\(])["]((?<sepAfter>${escapedSep})?)(?=${escapedSep}|[\\s/\\).,;${EM_DASH}${WORD_JOINER}:\\-\\}!?s]|$)`
   text = text.replace(new RegExp(endingDouble, "g"), `$<beforeQuote>${RIGHT_DOUBLE_QUOTE}$<sepAfter>`)
 
   text = text.replace(new RegExp(`["](?<sepEnd>${escapedSep}?)$`, "g"), `${RIGHT_DOUBLE_QUOTE}$<sepEnd>`)

--- a/src/tests/dashes.test.ts
+++ b/src/tests/dashes.test.ts
@@ -1,4 +1,4 @@
-import { hyphenReplace, enDashNumberRange, enDashDateRange, minusReplace, numberRangeDisallowedPrefixes } from "../dashes.js"
+import { hyphenReplace, enDashNumberRange, enDashDateRange, minusReplace, preventEmDashLineBreak, numberRangeDisallowedPrefixes } from "../dashes.js"
 import { DEFAULT_SEPARATOR, UNICODE_SYMBOLS } from "../constants.js"
 
 const {
@@ -6,11 +6,15 @@ const {
   RIGHT_DOUBLE_QUOTE,
   LEFT_SINGLE_QUOTE,
   RIGHT_SINGLE_QUOTE,
-  EM_DASH,
+  EM_DASH: RAW_EM_DASH,
   EN_DASH,
   MINUS,
   ELLIPSIS,
+  WORD_JOINER,
 } = UNICODE_SYMBOLS
+
+// hyphenReplace prepends a word joiner before em dashes to prevent line wrapping
+const EM_DASH = `${WORD_JOINER}${RAW_EM_DASH}`
 
 describe("hyphenReplace", () => {
   describe("em dashes from surrounded hyphens", () => {
@@ -18,23 +22,23 @@ describe("hyphenReplace", () => {
       ["This is a - hyphen.", `This is a${EM_DASH}hyphen.`],
       // Parenthetical dash before a digit (not math subtraction)
       ["Safari) - 9 combinations", `Safari)${EM_DASH}9 combinations`],
-      [`This is an ${EM_DASH} em dash.`, `This is an${EM_DASH}em dash.`],
-      [`word ${EM_DASH} word`, `word${EM_DASH}word`],
+      [`This is an ${RAW_EM_DASH} em dash.`, `This is an${EM_DASH}em dash.`],
+      [`word ${RAW_EM_DASH} word`, `word${EM_DASH}word`],
       ["word ---", `word${EM_DASH}`],
-      [`word${EM_DASH} word`, `word${EM_DASH}word`],
-      [`word ${EM_DASH}word`, `word${EM_DASH}word`],
+      [`word${RAW_EM_DASH} word`, `word${EM_DASH}word`],
+      [`word ${RAW_EM_DASH}word`, `word${EM_DASH}word`],
       ['"I love dogs." - Me', `"I love dogs."${EM_DASH}Me`],
       ["- Me", `${EM_DASH} Me`],
       ["-- Me", `${EM_DASH} Me`],
       ["Hi-- what do you think?", `Hi${EM_DASH}what do you think?`],
       [
-        `${EM_DASH}such behaviors still have to be retrodicted`,
+        `${RAW_EM_DASH}such behaviors still have to be retrodicted`,
         `${EM_DASH}such behaviors still have to be retrodicted`,
       ],
-      [`emphasis" ${EM_DASH}`, `emphasis"${EM_DASH}`],
+      [`emphasis" ${RAW_EM_DASH}`, `emphasis"${EM_DASH}`],
       ["- Intro text\n then more", `${EM_DASH} Intro text\n then more`],
       [
-        `reward${ELLIPSIS} ${EM_DASH} [Model-based RL, Desires, Brains, Wireheading](https://www.alignmentforum.org/posts/K5ikTdaNymfWXQHFb/model-based-rl-desires-brains-wireheading#Self_aware_desires_1__wireheading)`,
+        `reward${ELLIPSIS} ${RAW_EM_DASH} [Model-based RL, Desires, Brains, Wireheading](https://www.alignmentforum.org/posts/K5ikTdaNymfWXQHFb/model-based-rl-desires-brains-wireheading#Self_aware_desires_1__wireheading)`,
         `reward${ELLIPSIS}${EM_DASH}[Model-based RL, Desires, Brains, Wireheading](https://www.alignmentforum.org/posts/K5ikTdaNymfWXQHFb/model-based-rl-desires-brains-wireheading#Self_aware_desires_1__wireheading)`,
       ],
       ["a browser- or OS-specific fashion", "a browser- or OS-specific fashion"],
@@ -70,9 +74,9 @@ describe("hyphenReplace", () => {
 
   describe("spaces around em dashes", () => {
     it.each([
-      [`word ${EM_DASH} another`, `word${EM_DASH}another`],
-      [`word${EM_DASH}  another`, `word${EM_DASH}another`],
-      [`word  ${EM_DASH}another`, `word${EM_DASH}another`],
+      [`word ${RAW_EM_DASH} another`, `word${EM_DASH}another`],
+      [`word${RAW_EM_DASH}  another`, `word${EM_DASH}another`],
+      [`word  ${RAW_EM_DASH}another`, `word${EM_DASH}another`],
     ])('removes spaces in "%s"', (input, expected) => {
       expect(hyphenReplace(input)).toBe(expected)
     })
@@ -80,7 +84,6 @@ describe("hyphenReplace", () => {
 
   describe("quote-to-quote em dash (Chicago: no spaces)", () => {
     it.each([
-      // Chicago style: no spaces around em-dashes, even between quotes
       `"Hello."${EM_DASH}"World"`,
       `'Hi.'${EM_DASH}'There'`,
       `${LEFT_DOUBLE_QUOTE}Hello.${RIGHT_DOUBLE_QUOTE}${EM_DASH}${LEFT_DOUBLE_QUOTE}World${RIGHT_DOUBLE_QUOTE}`,
@@ -92,9 +95,9 @@ describe("hyphenReplace", () => {
 
   describe("em dashes at start of line", () => {
     it.each([
-      [`${EM_DASH}Start of line`, `${EM_DASH} Start of line`],
-      [`Line 1\n${EM_DASH}Line 2`, `Line 1\n${EM_DASH} Line 2`],
-      [`${EM_DASH} Already correct`, `${EM_DASH} Already correct`],
+      [`${RAW_EM_DASH}Start of line`, `${EM_DASH} Start of line`],
+      [`Line 1\n${RAW_EM_DASH}Line 2`, `Line 1\n${EM_DASH} Line 2`],
+      [`${RAW_EM_DASH} Already correct`, `${EM_DASH} Already correct`],
     ])('handles "%s"', (input, expected) => {
       expect(hyphenReplace(input)).toBe(expected)
     })
@@ -141,7 +144,7 @@ describe("hyphenReplace", () => {
       [`word${sep} - ${sep}another`, `word${sep}${EM_DASH}${sep}another`, "em dash context"],
       [`pages 1${sep}-${sep}5`, `pages 1${sep}${EN_DASH}${sep}5`, "number ranges"],
       // American em-dash (Chicago style) consumes surrounding spaces, even across separator boundaries
-      [`text ${EM_DASH} ${sep} more text`, `text${EM_DASH}${sep}more text`, "consumes space after separator for em-dash"],
+      [`text ${RAW_EM_DASH} ${sep} more text`, `text${EM_DASH}${sep}more text`, "consumes space after separator for em-dash"],
       [`text - ${sep} more`, `text${EM_DASH}${sep}more`, "consumes space after separator with hyphen"],
       // Separator-only before dash (no space between word and separator): e.g., link text followed by dash
       [`word${sep}${EN_DASH} rest`, `word${sep}${EM_DASH}rest`, "en-dash after separator without preceding space"],
@@ -505,7 +508,7 @@ describe("dashStyle option", () => {
 
     it("converts existing em-dashes to spaced en-dashes", () => {
       // Oxford style uses spaced en-dashes, so em-dashes get converted
-      expect(hyphenReplace(`word ${EM_DASH} word`, { dashStyle: "british" })).toBe(`word ${EN_DASH} word`)
+      expect(hyphenReplace(`word ${RAW_EM_DASH} word`, { dashStyle: "british" })).toBe(`word ${EN_DASH} word`)
     })
 
     it("converts date ranges with spaced en dash", () => {
@@ -531,8 +534,8 @@ describe("dashStyle option", () => {
       "word -- word",
       "since--as you know",
       "Hello. -- Author",
-      `word${EM_DASH}word`,
-      `"Quote."${EM_DASH}Author`,
+      `word${RAW_EM_DASH}word`,
+      `"Quote."${RAW_EM_DASH}Author`,
     ]
 
     it.each(testCases)(
@@ -620,8 +623,8 @@ describe("social media patterns", () => {
 describe("mixed dash types", () => {
   it.each([
     [`pages 1${EN_DASH}5`, `pages 1${EN_DASH}5`],
-    [`word${EM_DASH}word`, `word${EM_DASH}word`],
-    [`pages 1-5 and word${EM_DASH}word`, `pages 1${EN_DASH}5 and word${EM_DASH}word`],
+    [`word${RAW_EM_DASH}word`, `word${EM_DASH}word`],
+    [`pages 1-5 and word${RAW_EM_DASH}word`, `pages 1${EN_DASH}5 and word${EM_DASH}word`],
   ])('handles mixed dashes: "%s"', (input, expected) => {
     expect(hyphenReplace(input)).toBe(expected)
   })
@@ -696,5 +699,32 @@ describe("hyphenReplace preserves multi-segment numbers across separators", () =
     ["model name across elements", `${sep}GPT${sep}-3`],
   ])("%s", (_desc, input) => {
     expect(hyphenReplace(input, { separator: sep })).toBe(input)
+  })
+})
+
+describe("preventEmDashLineBreak", () => {
+  it("inserts word joiner before em dashes", () => {
+    expect(preventEmDashLineBreak(`word${RAW_EM_DASH}word`)).toBe(`word${WORD_JOINER}${RAW_EM_DASH}word`)
+  })
+
+  it("is idempotent", () => {
+    const input = `word${RAW_EM_DASH}word`
+    const once = preventEmDashLineBreak(input)
+    const twice = preventEmDashLineBreak(once)
+    expect(twice).toBe(once)
+  })
+
+  it("handles text with no em dashes", () => {
+    expect(preventEmDashLineBreak("no dashes here")).toBe("no dashes here")
+  })
+
+  it("handles multiple em dashes", () => {
+    const input = `a${RAW_EM_DASH}b${RAW_EM_DASH}c`
+    const expected = `a${WORD_JOINER}${RAW_EM_DASH}b${WORD_JOINER}${RAW_EM_DASH}c`
+    expect(preventEmDashLineBreak(input)).toBe(expected)
+  })
+
+  it("does not affect en dashes", () => {
+    expect(preventEmDashLineBreak(`1${EN_DASH}5`)).toBe(`1${EN_DASH}5`)
   })
 })

--- a/src/tests/dashes.test.ts
+++ b/src/tests/dashes.test.ts
@@ -1,48 +1,45 @@
 import { hyphenReplace, enDashNumberRange, enDashDateRange, minusReplace, preventEmDashLineBreak, numberRangeDisallowedPrefixes } from "../dashes.js"
-import { DEFAULT_SEPARATOR, UNICODE_SYMBOLS } from "../constants.js"
+import { DEFAULT_SEPARATOR, UNICODE_SYMBOLS, NOWRAP_EM_DASH } from "../constants.js"
 
 const {
   LEFT_DOUBLE_QUOTE,
   RIGHT_DOUBLE_QUOTE,
   LEFT_SINGLE_QUOTE,
   RIGHT_SINGLE_QUOTE,
-  EM_DASH: RAW_EM_DASH,
+  EM_DASH,
   EN_DASH,
   MINUS,
   ELLIPSIS,
   WORD_JOINER,
 } = UNICODE_SYMBOLS
 
-// hyphenReplace prepends a word joiner before em dashes to prevent line wrapping
-const EM_DASH = `${WORD_JOINER}${RAW_EM_DASH}`
-
 describe("hyphenReplace", () => {
   describe("em dashes from surrounded hyphens", () => {
     it.each([
-      ["This is a - hyphen.", `This is a${EM_DASH}hyphen.`],
+      ["This is a - hyphen.", `This is a${NOWRAP_EM_DASH}hyphen.`],
       // Parenthetical dash before a digit (not math subtraction)
-      ["Safari) - 9 combinations", `Safari)${EM_DASH}9 combinations`],
-      [`This is an ${RAW_EM_DASH} em dash.`, `This is an${EM_DASH}em dash.`],
-      [`word ${RAW_EM_DASH} word`, `word${EM_DASH}word`],
-      ["word ---", `word${EM_DASH}`],
-      [`word${RAW_EM_DASH} word`, `word${EM_DASH}word`],
-      [`word ${RAW_EM_DASH}word`, `word${EM_DASH}word`],
-      ['"I love dogs." - Me', `"I love dogs."${EM_DASH}Me`],
-      ["- Me", `${EM_DASH} Me`],
-      ["-- Me", `${EM_DASH} Me`],
-      ["Hi-- what do you think?", `Hi${EM_DASH}what do you think?`],
+      ["Safari) - 9 combinations", `Safari)${NOWRAP_EM_DASH}9 combinations`],
+      [`This is an ${EM_DASH} em dash.`, `This is an${NOWRAP_EM_DASH}em dash.`],
+      [`word ${EM_DASH} word`, `word${NOWRAP_EM_DASH}word`],
+      ["word ---", `word${NOWRAP_EM_DASH}`],
+      [`word${EM_DASH} word`, `word${NOWRAP_EM_DASH}word`],
+      [`word ${EM_DASH}word`, `word${NOWRAP_EM_DASH}word`],
+      ['"I love dogs." - Me', `"I love dogs."${NOWRAP_EM_DASH}Me`],
+      ["- Me", `${NOWRAP_EM_DASH} Me`],
+      ["-- Me", `${NOWRAP_EM_DASH} Me`],
+      ["Hi-- what do you think?", `Hi${NOWRAP_EM_DASH}what do you think?`],
       [
-        `${RAW_EM_DASH}such behaviors still have to be retrodicted`,
         `${EM_DASH}such behaviors still have to be retrodicted`,
+        `${NOWRAP_EM_DASH}such behaviors still have to be retrodicted`,
       ],
-      [`emphasis" ${RAW_EM_DASH}`, `emphasis"${EM_DASH}`],
-      ["- Intro text\n then more", `${EM_DASH} Intro text\n then more`],
+      [`emphasis" ${EM_DASH}`, `emphasis"${NOWRAP_EM_DASH}`],
+      ["- Intro text\n then more", `${NOWRAP_EM_DASH} Intro text\n then more`],
       [
-        `reward${ELLIPSIS} ${RAW_EM_DASH} [Model-based RL, Desires, Brains, Wireheading](https://www.alignmentforum.org/posts/K5ikTdaNymfWXQHFb/model-based-rl-desires-brains-wireheading#Self_aware_desires_1__wireheading)`,
-        `reward${ELLIPSIS}${EM_DASH}[Model-based RL, Desires, Brains, Wireheading](https://www.alignmentforum.org/posts/K5ikTdaNymfWXQHFb/model-based-rl-desires-brains-wireheading#Self_aware_desires_1__wireheading)`,
+        `reward${ELLIPSIS} ${EM_DASH} [Model-based RL, Desires, Brains, Wireheading](https://www.alignmentforum.org/posts/K5ikTdaNymfWXQHFb/model-based-rl-desires-brains-wireheading#Self_aware_desires_1__wireheading)`,
+        `reward${ELLIPSIS}${NOWRAP_EM_DASH}[Model-based RL, Desires, Brains, Wireheading](https://www.alignmentforum.org/posts/K5ikTdaNymfWXQHFb/model-based-rl-desires-brains-wireheading#Self_aware_desires_1__wireheading)`,
       ],
       ["a browser- or OS-specific fashion", "a browser- or OS-specific fashion"],
-      ["since--as you know", `since${EM_DASH}as you know`],
+      ["since--as you know", `since${NOWRAP_EM_DASH}as you know`],
       // Arrow patterns should be preserved (not converted to em-dashes)
       ["word -> arrow", "word -> arrow"],
       ["word --> arrow", "word --> arrow"],
@@ -55,8 +52,8 @@ describe("hyphenReplace", () => {
 
   describe("multiple dashes within words", () => {
     it.each([
-      ["Since--as you know", `Since${EM_DASH}as you know`, "double dashes"],
-      ["word---another", `word${EM_DASH}another`, "triple dashes"],
+      ["Since--as you know", `Since${NOWRAP_EM_DASH}as you know`, "double dashes"],
+      ["word---another", `word${NOWRAP_EM_DASH}another`, "triple dashes"],
     ])("%s → %s (%s)", (input, expected) => {
       expect(hyphenReplace(input)).toBe(expected)
     })
@@ -64,9 +61,9 @@ describe("hyphenReplace", () => {
 
   describe("dashes at start of line", () => {
     it.each([
-      ["- Author", `${EM_DASH} Author`],
-      ["--- Author attribution", `${EM_DASH} Author attribution`],
-      ["Quote\n- Author", `Quote\n${EM_DASH} Author`],
+      ["- Author", `${NOWRAP_EM_DASH} Author`],
+      ["--- Author attribution", `${NOWRAP_EM_DASH} Author attribution`],
+      ["Quote\n- Author", `Quote\n${NOWRAP_EM_DASH} Author`],
     ])('handles "%s"', (input, expected) => {
       expect(hyphenReplace(input)).toBe(expected)
     })
@@ -74,9 +71,9 @@ describe("hyphenReplace", () => {
 
   describe("spaces around em dashes", () => {
     it.each([
-      [`word ${RAW_EM_DASH} another`, `word${EM_DASH}another`],
-      [`word${RAW_EM_DASH}  another`, `word${EM_DASH}another`],
-      [`word  ${RAW_EM_DASH}another`, `word${EM_DASH}another`],
+      [`word ${EM_DASH} another`, `word${NOWRAP_EM_DASH}another`],
+      [`word${EM_DASH}  another`, `word${NOWRAP_EM_DASH}another`],
+      [`word  ${EM_DASH}another`, `word${NOWRAP_EM_DASH}another`],
     ])('removes spaces in "%s"', (input, expected) => {
       expect(hyphenReplace(input)).toBe(expected)
     })
@@ -84,10 +81,10 @@ describe("hyphenReplace", () => {
 
   describe("quote-to-quote em dash (Chicago: no spaces)", () => {
     it.each([
-      `"Hello."${EM_DASH}"World"`,
-      `'Hi.'${EM_DASH}'There'`,
-      `${LEFT_DOUBLE_QUOTE}Hello.${RIGHT_DOUBLE_QUOTE}${EM_DASH}${LEFT_DOUBLE_QUOTE}World${RIGHT_DOUBLE_QUOTE}`,
-      `${LEFT_SINGLE_QUOTE}Hi.${RIGHT_SINGLE_QUOTE}${EM_DASH}${LEFT_SINGLE_QUOTE}There${RIGHT_SINGLE_QUOTE}`,
+      `"Hello."${NOWRAP_EM_DASH}"World"`,
+      `'Hi.'${NOWRAP_EM_DASH}'There'`,
+      `${LEFT_DOUBLE_QUOTE}Hello.${RIGHT_DOUBLE_QUOTE}${NOWRAP_EM_DASH}${LEFT_DOUBLE_QUOTE}World${RIGHT_DOUBLE_QUOTE}`,
+      `${LEFT_SINGLE_QUOTE}Hi.${RIGHT_SINGLE_QUOTE}${NOWRAP_EM_DASH}${LEFT_SINGLE_QUOTE}There${RIGHT_SINGLE_QUOTE}`,
     ])('preserves unspaced em-dash in "%s"', (input) => {
       expect(hyphenReplace(input)).toBe(input)
     })
@@ -95,9 +92,9 @@ describe("hyphenReplace", () => {
 
   describe("em dashes at start of line", () => {
     it.each([
-      [`${RAW_EM_DASH}Start of line`, `${EM_DASH} Start of line`],
-      [`Line 1\n${RAW_EM_DASH}Line 2`, `Line 1\n${EM_DASH} Line 2`],
-      [`${RAW_EM_DASH} Already correct`, `${EM_DASH} Already correct`],
+      [`${EM_DASH}Start of line`, `${NOWRAP_EM_DASH} Start of line`],
+      [`Line 1\n${EM_DASH}Line 2`, `Line 1\n${NOWRAP_EM_DASH} Line 2`],
+      [`${EM_DASH} Already correct`, `${NOWRAP_EM_DASH} Already correct`],
     ])('handles "%s"', (input, expected) => {
       expect(hyphenReplace(input)).toBe(expected)
     })
@@ -141,14 +138,14 @@ describe("hyphenReplace", () => {
   describe("with separator character", () => {
     const sep = "\uE000"
     it.each([
-      [`word${sep} - ${sep}another`, `word${sep}${EM_DASH}${sep}another`, "em dash context"],
+      [`word${sep} - ${sep}another`, `word${sep}${NOWRAP_EM_DASH}${sep}another`, "em dash context"],
       [`pages 1${sep}-${sep}5`, `pages 1${sep}${EN_DASH}${sep}5`, "number ranges"],
       // American em-dash (Chicago style) consumes surrounding spaces, even across separator boundaries
-      [`text ${RAW_EM_DASH} ${sep} more text`, `text${EM_DASH}${sep}more text`, "consumes space after separator for em-dash"],
-      [`text - ${sep} more`, `text${EM_DASH}${sep}more`, "consumes space after separator with hyphen"],
+      [`text ${EM_DASH} ${sep} more text`, `text${NOWRAP_EM_DASH}${sep}more text`, "consumes space after separator for em-dash"],
+      [`text - ${sep} more`, `text${NOWRAP_EM_DASH}${sep}more`, "consumes space after separator with hyphen"],
       // Separator-only before dash (no space between word and separator): e.g., link text followed by dash
-      [`word${sep}${EN_DASH} rest`, `word${sep}${EM_DASH}rest`, "en-dash after separator without preceding space"],
-      [`word${sep}- rest`, `word${sep}${EM_DASH}rest`, "hyphen after separator without preceding space"],
+      [`word${sep}${EN_DASH} rest`, `word${sep}${NOWRAP_EM_DASH}rest`, "en-dash after separator without preceding space"],
+      [`word${sep}- rest`, `word${sep}${NOWRAP_EM_DASH}rest`, "hyphen after separator without preceding space"],
     ])("%s → %s (%s)", (input, expected) => {
       expect(hyphenReplace(input, { separator: sep })).toBe(expected)
     })
@@ -353,9 +350,9 @@ describe("competitor-derived edge cases", () => {
   describe("double/triple dash patterns", () => {
     it.each([
       // From retext-smartypants oldschool mode
-      ["word--word", `word${EM_DASH}word`],
-      ["word---word", `word${EM_DASH}word`],
-      ["start-- end", `start${EM_DASH}end`],
+      ["word--word", `word${NOWRAP_EM_DASH}word`],
+      ["word---word", `word${NOWRAP_EM_DASH}word`],
+      ["start-- end", `start${NOWRAP_EM_DASH}end`],
     ])('converts "%s"', (input, expected) => {
       expect(hyphenReplace(input)).toBe(expected)
     })
@@ -363,7 +360,7 @@ describe("competitor-derived edge cases", () => {
     it("handles double dash after quote", () => {
       const input = '"Hello"-- she said'
       const result = hyphenReplace(input)
-      expect(result).toBe(`"Hello"${EM_DASH}she said`)
+      expect(result).toBe(`"Hello"${NOWRAP_EM_DASH}she said`)
     })
   })
 
@@ -384,8 +381,8 @@ describe("competitor-derived edge cases", () => {
   describe("dashes with quotes", () => {
     it.each([
       // Em dash after closing quote with space
-      [`${RIGHT_DOUBLE_QUOTE} - author`, `${RIGHT_DOUBLE_QUOTE}${EM_DASH}author`],
-      [`${RIGHT_SINGLE_QUOTE} -- source`, `${RIGHT_SINGLE_QUOTE}${EM_DASH}source`],
+      [`${RIGHT_DOUBLE_QUOTE} - author`, `${RIGHT_DOUBLE_QUOTE}${NOWRAP_EM_DASH}author`],
+      [`${RIGHT_SINGLE_QUOTE} -- source`, `${RIGHT_SINGLE_QUOTE}${NOWRAP_EM_DASH}source`],
     ])('handles spaced dashes after quotes: "%s"', (input, expected) => {
       expect(hyphenReplace(input)).toBe(expected)
     })
@@ -393,7 +390,7 @@ describe("competitor-derived edge cases", () => {
     it("handles unspaced double dash between quotes", () => {
       const input = '"first"--"second"'
       const result = hyphenReplace(input)
-      expect(result).toBe(`"first"${EM_DASH}"second"`)
+      expect(result).toBe(`"first"${NOWRAP_EM_DASH}"second"`)
     })
   })
 })
@@ -439,7 +436,7 @@ describe("complex real-world patterns", () => {
   describe("mixed content", () => {
     it("handles multiple em dash transformations", () => {
       const input = 'The meeting -- scheduled for today -- covers important topics.'
-      const expected = `The meeting${EM_DASH}scheduled for today${EM_DASH}covers important topics.`
+      const expected = `The meeting${NOWRAP_EM_DASH}scheduled for today${NOWRAP_EM_DASH}covers important topics.`
       expect(hyphenReplace(input)).toBe(expected)
     })
 
@@ -451,7 +448,7 @@ describe("complex real-world patterns", () => {
 
     it("handles em dash before URL-like text", () => {
       const input = 'Visit -- https://example.com'
-      const expected = `Visit${EM_DASH}https://example.com`
+      const expected = `Visit${NOWRAP_EM_DASH}https://example.com`
       expect(hyphenReplace(input)).toBe(expected)
     })
 
@@ -468,7 +465,7 @@ describe("complex real-world patterns", () => {
 
 describe("idempotency", () => {
   it.each([
-    `word${EM_DASH}word`,
+    `word${NOWRAP_EM_DASH}word`,
     `1${EN_DASH}5`,
     `${MINUS}10`,
     `January${EN_DASH}March`,
@@ -481,15 +478,15 @@ describe("idempotency", () => {
 describe("dashStyle option", () => {
   describe('when "american" (default)', () => {
     it.each([
-      ["word - word", `word${EM_DASH}word`],
-      ["word -- word", `word${EM_DASH}word`],
-      ["since--as you know", `since${EM_DASH}as you know`],
+      ["word - word", `word${NOWRAP_EM_DASH}word`],
+      ["word -- word", `word${NOWRAP_EM_DASH}word`],
+      ["since--as you know", `since${NOWRAP_EM_DASH}as you know`],
     ])("uses unspaced em dash: %s", (input, expected) => {
       expect(hyphenReplace(input, { dashStyle: "american" })).toBe(expected)
     })
 
     it("is the default behavior", () => {
-      expect(hyphenReplace("word - word")).toBe(`word${EM_DASH}word`)
+      expect(hyphenReplace("word - word")).toBe(`word${NOWRAP_EM_DASH}word`)
     })
   })
 
@@ -508,7 +505,7 @@ describe("dashStyle option", () => {
 
     it("converts existing em-dashes to spaced en-dashes", () => {
       // Oxford style uses spaced en-dashes, so em-dashes get converted
-      expect(hyphenReplace(`word ${RAW_EM_DASH} word`, { dashStyle: "british" })).toBe(`word ${EN_DASH} word`)
+      expect(hyphenReplace(`word ${EM_DASH} word`, { dashStyle: "british" })).toBe(`word ${EN_DASH} word`)
     })
 
     it("converts date ranges with spaced en dash", () => {
@@ -534,8 +531,8 @@ describe("dashStyle option", () => {
       "word -- word",
       "since--as you know",
       "Hello. -- Author",
-      `word${RAW_EM_DASH}word`,
-      `"Quote."${RAW_EM_DASH}Author`,
+      `word${EM_DASH}word`,
+      `"Quote."${EM_DASH}Author`,
     ]
 
     it.each(testCases)(
@@ -623,8 +620,8 @@ describe("social media patterns", () => {
 describe("mixed dash types", () => {
   it.each([
     [`pages 1${EN_DASH}5`, `pages 1${EN_DASH}5`],
-    [`word${RAW_EM_DASH}word`, `word${EM_DASH}word`],
-    [`pages 1-5 and word${RAW_EM_DASH}word`, `pages 1${EN_DASH}5 and word${EM_DASH}word`],
+    [`word${EM_DASH}word`, `word${NOWRAP_EM_DASH}word`],
+    [`pages 1-5 and word${EM_DASH}word`, `pages 1${EN_DASH}5 and word${NOWRAP_EM_DASH}word`],
   ])('handles mixed dashes: "%s"', (input, expected) => {
     expect(hyphenReplace(input)).toBe(expected)
   })
@@ -704,11 +701,11 @@ describe("hyphenReplace preserves multi-segment numbers across separators", () =
 
 describe("preventEmDashLineBreak", () => {
   it("inserts word joiner before em dashes", () => {
-    expect(preventEmDashLineBreak(`word${RAW_EM_DASH}word`)).toBe(`word${WORD_JOINER}${RAW_EM_DASH}word`)
+    expect(preventEmDashLineBreak(`word${EM_DASH}word`)).toBe(`word${WORD_JOINER}${EM_DASH}word`)
   })
 
   it("is idempotent", () => {
-    const input = `word${RAW_EM_DASH}word`
+    const input = `word${EM_DASH}word`
     const once = preventEmDashLineBreak(input)
     const twice = preventEmDashLineBreak(once)
     expect(twice).toBe(once)
@@ -719,12 +716,35 @@ describe("preventEmDashLineBreak", () => {
   })
 
   it("handles multiple em dashes", () => {
-    const input = `a${RAW_EM_DASH}b${RAW_EM_DASH}c`
-    const expected = `a${WORD_JOINER}${RAW_EM_DASH}b${WORD_JOINER}${RAW_EM_DASH}c`
+    const input = `a${EM_DASH}b${EM_DASH}c`
+    const expected = `a${WORD_JOINER}${EM_DASH}b${WORD_JOINER}${EM_DASH}c`
     expect(preventEmDashLineBreak(input)).toBe(expected)
   })
 
   it("does not affect en dashes", () => {
     expect(preventEmDashLineBreak(`1${EN_DASH}5`)).toBe(`1${EN_DASH}5`)
+  })
+})
+
+describe("word joiner robustness", () => {
+  it("places exactly one word joiner before each consecutive em dash", () => {
+    const result = hyphenReplace(`a${EM_DASH}b${EM_DASH}c${EM_DASH}d${EM_DASH}e`)
+    const emDashCount = (result.match(new RegExp(EM_DASH, "g")) || []).length
+    const joinerCount = (result.match(new RegExp(WORD_JOINER, "g")) || []).length
+    expect(emDashCount).toBe(4)
+    expect(joinerCount).toBe(4)
+  })
+
+  it.each([
+    ["dashStyle 'none'", "word - word", { dashStyle: "none" as const }],
+    ["british style", "word - word", { dashStyle: "british" as const }],
+  ])("produces no word joiners with %s", (_, input, options) => {
+    expect(hyphenReplace(input, options)).not.toContain(WORD_JOINER)
+  })
+
+  it("word joiner does not leak into en dash ranges", () => {
+    const result = hyphenReplace("pages 1-5 and word - word")
+    const enDashIdx = result.indexOf(EN_DASH)
+    expect(result[enDashIdx - 1]).not.toBe(WORD_JOINER)
   })
 })

--- a/src/tests/index.test.ts
+++ b/src/tests/index.test.ts
@@ -1,6 +1,6 @@
 import { transform, DEFAULT_SEPARATOR, countSeparators } from "../index.js"
 import { ellipsis } from "../symbols.js"
-import { UNICODE_SYMBOLS, REGEX_SPECIAL_CHARS } from "../constants.js"
+import { UNICODE_SYMBOLS, REGEX_SPECIAL_CHARS, NOWRAP_EM_DASH } from "../constants.js"
 
 const {
   LEFT_DOUBLE_QUOTE,
@@ -24,25 +24,26 @@ const {
   MINUS,
   FRACTION_1_2,
   SUPERSCRIPT_ST,
+  WORD_JOINER,
 } = UNICODE_SYMBOLS
 
 describe("transform", () => {
   it("applies both quote and dash transformations", () => {
     const input = '"Hello," she said - "it\'s pages 1-5."'
-    const expected = `${LEFT_DOUBLE_QUOTE}Hello,${RIGHT_DOUBLE_QUOTE} she said${EM_DASH}${LEFT_DOUBLE_QUOTE}it${RIGHT_SINGLE_QUOTE}s pages 1${EN_DASH}5.${RIGHT_DOUBLE_QUOTE}`
+    const expected = `${LEFT_DOUBLE_QUOTE}Hello,${RIGHT_DOUBLE_QUOTE} she said${NOWRAP_EM_DASH}${LEFT_DOUBLE_QUOTE}it${RIGHT_SINGLE_QUOTE}s pages 1${EN_DASH}5.${RIGHT_DOUBLE_QUOTE}`
     expect(transform(input, { nbsp: false })).toBe(expected)
   })
 
   it("handles complex mixed content", () => {
     const input = 'I was born in \'99 - "the best year" - and pages 10-20 are my favorite.'
-    const expected = `I was born in ${RIGHT_SINGLE_QUOTE}99${EM_DASH}${LEFT_DOUBLE_QUOTE}the best year${RIGHT_DOUBLE_QUOTE}${EM_DASH}and pages 10${EN_DASH}20 are my favorite.`
+    const expected = `I was born in ${RIGHT_SINGLE_QUOTE}99${NOWRAP_EM_DASH}${LEFT_DOUBLE_QUOTE}the best year${RIGHT_DOUBLE_QUOTE}${NOWRAP_EM_DASH}and pages 10${EN_DASH}20 are my favorite.`
     expect(transform(input, { nbsp: false })).toBe(expected)
   })
 
   it("preserves separator character", () => {
     const sep = DEFAULT_SEPARATOR
     const input = `"Hello${sep}" - test`
-    expect(transform(input, { separator: sep, nbsp: false })).toBe(`${LEFT_DOUBLE_QUOTE}Hello${sep}${RIGHT_DOUBLE_QUOTE}${EM_DASH}test`)
+    expect(transform(input, { separator: sep, nbsp: false })).toBe(`${LEFT_DOUBLE_QUOTE}Hello${sep}${RIGHT_DOUBLE_QUOTE}${NOWRAP_EM_DASH}test`)
   })
 
   describe("symbol transforms", () => {
@@ -180,7 +181,7 @@ describe("transform", () => {
         ["Rock 'n' Roll", `Rock ${RIGHT_SINGLE_QUOTE}n${RIGHT_SINGLE_QUOTE} Roll`],
         ["I was born in '99", `I was born in ${RIGHT_SINGLE_QUOTE}99`],
         // Em dashes from surrounded hyphens - smartquotes fails
-        ["This is a - hyphen.", `This is a${EM_DASH}hyphen.`],
+        ["This is a - hyphen.", `This is a${NOWRAP_EM_DASH}hyphen.`],
         // Number ranges - smartypants/smartquotes/typograf fail
         ["Pages 1-5", `Pages 1${EN_DASH}5`],
         ["2000-2020", `2000${EN_DASH}2020`],
@@ -227,7 +228,7 @@ describe("transform", () => {
   describe("complex real-world text", () => {
     it("handles dialogue with dashes and quotes", () => {
       const input = '"Wait," she said -- "I don\'t think that\'s right."'
-      const expected = `${LEFT_DOUBLE_QUOTE}Wait,${RIGHT_DOUBLE_QUOTE} she said${EM_DASH}${LEFT_DOUBLE_QUOTE}I don${RIGHT_SINGLE_QUOTE}t think that${RIGHT_SINGLE_QUOTE}s right.${RIGHT_DOUBLE_QUOTE}`
+      const expected = `${LEFT_DOUBLE_QUOTE}Wait,${RIGHT_DOUBLE_QUOTE} she said${NOWRAP_EM_DASH}${LEFT_DOUBLE_QUOTE}I don${RIGHT_SINGLE_QUOTE}t think that${RIGHT_SINGLE_QUOTE}s right.${RIGHT_DOUBLE_QUOTE}`
       expect(transform(input, { nbsp: false })).toEqual(expected)
     })
 
@@ -267,11 +268,11 @@ describe("transform", () => {
     it.each([
       [
         '"Wait..." she said - "it\'s pages 1-5."',
-        `${LEFT_DOUBLE_QUOTE}Wait${ELLIPSIS}${RIGHT_DOUBLE_QUOTE} she said${EM_DASH}${LEFT_DOUBLE_QUOTE}it${RIGHT_SINGLE_QUOTE}s pages 1${EN_DASH}5.${RIGHT_DOUBLE_QUOTE}`,
+        `${LEFT_DOUBLE_QUOTE}Wait${ELLIPSIS}${RIGHT_DOUBLE_QUOTE} she said${NOWRAP_EM_DASH}${LEFT_DOUBLE_QUOTE}it${RIGHT_SINGLE_QUOTE}s pages 1${EN_DASH}5.${RIGHT_DOUBLE_QUOTE}`,
       ],
       [
         "(c) 2024 - Room is 10x12, set to 72 F",
-        `${COPYRIGHT} 2024${EM_DASH}Room is 10${MULTIPLICATION}12, set to 72 ${DEGREE}F`,
+        `${COPYRIGHT} 2024${NOWRAP_EM_DASH}Room is 10${MULTIPLICATION}12, set to 72 ${DEGREE}F`,
       ],
     ])('handles complex transform: "%s"', (input, expected) => {
       expect(transform(input, { degrees: true, nbsp: false })).toBe(expected)
@@ -343,7 +344,7 @@ describe("transform", () => {
   describe("option combinations", () => {
     it("applies all optional transforms together", () => {
       const input = "1st place: 1/2 at 72 F - wow!!"
-      const expected = `1${SUPERSCRIPT_ST} place: ${FRACTION_1_2} at 72 ${DEGREE}F${EM_DASH}wow!`
+      const expected = `1${SUPERSCRIPT_ST} place: ${FRACTION_1_2} at 72 ${DEGREE}F${NOWRAP_EM_DASH}wow!`
       expect(transform(input, {
         fractions: true,
         degrees: true,
@@ -376,7 +377,7 @@ describe("transform", () => {
     })
 
     it.each([
-      [`word${sep} - ${sep}word`, `word${sep}${EM_DASH}${sep}word`],
+      [`word${sep} - ${sep}word`, `word${sep}${NOWRAP_EM_DASH}${sep}word`],
       [`1${sep}-${sep}5`, `1${sep}${EN_DASH}${sep}5`],
     ])('handles separator in dashes', (input, expected) => {
       expect(transform(input, { separator: sep, nbsp: false })).toBe(expected)
@@ -420,7 +421,7 @@ describe("transform", () => {
 
     it.each([
       `${LEFT_DOUBLE_QUOTE}Hello${RIGHT_DOUBLE_QUOTE}`,
-      `word${EM_DASH}word`,
+      `word${NOWRAP_EM_DASH}word`,
       `1${EN_DASH}5`,
       `Wait${ELLIPSIS}`,
       `5${MULTIPLICATION}5`,
@@ -434,7 +435,7 @@ describe("transform", () => {
   describe("style combinations", () => {
     it("applies American conventions throughout", () => {
       const input = '"Hello." - word - "World."'
-      const expected = `${LEFT_DOUBLE_QUOTE}Hello.${RIGHT_DOUBLE_QUOTE}${EM_DASH}word${EM_DASH}${LEFT_DOUBLE_QUOTE}World.${RIGHT_DOUBLE_QUOTE}`
+      const expected = `${LEFT_DOUBLE_QUOTE}Hello.${RIGHT_DOUBLE_QUOTE}${NOWRAP_EM_DASH}word${NOWRAP_EM_DASH}${LEFT_DOUBLE_QUOTE}World.${RIGHT_DOUBLE_QUOTE}`
       expect(transform(input, { punctuationStyle: "american", dashStyle: "american", nbsp: false })).toEqual(expected)
     })
 
@@ -463,7 +464,7 @@ describe("transform", () => {
 
     it("skips quotes but applies dashes with mixed none", () => {
       const input = '"Hello" - pages 1-5'
-      const expected = `"Hello"${EM_DASH}pages 1${EN_DASH}5`
+      const expected = `"Hello"${NOWRAP_EM_DASH}pages 1${EN_DASH}5`
       expect(transform(input, { punctuationStyle: "none", dashStyle: "american", nbsp: false })).toEqual(expected)
     })
   })
@@ -592,6 +593,19 @@ describe("transform", () => {
       const start = performance.now()
       transform(input)
       expect(performance.now() - start).toBeLessThan(MAX_TIMEOUT_MS)
+    })
+  })
+
+  describe("word joiner and quote interaction", () => {
+    it("word joiner is present before every em dash in output", () => {
+      const result = transform('"first" - "second" - "third"', { nbsp: false })
+      expect(result).not.toMatch(new RegExp(`(?<!${WORD_JOINER})${EM_DASH}`))
+    })
+
+    it("style conversion roundtrip: American→British→American", () => {
+      const american = transform('"Hello" - "World"', { dashStyle: "american", nbsp: false })
+      const british = transform(american, { dashStyle: "british", nbsp: false })
+      expect(transform(british, { dashStyle: "american", nbsp: false })).toBe(american)
     })
   })
 })

--- a/src/tests/markdown.test.ts
+++ b/src/tests/markdown.test.ts
@@ -1,11 +1,10 @@
 import { transformMarkdown } from "../markdown.js"
-import { UNICODE_SYMBOLS } from "../constants.js"
+import { UNICODE_SYMBOLS, NOWRAP_EM_DASH } from "../constants.js"
 
 const {
   LEFT_DOUBLE_QUOTE: LDQ,
   RIGHT_DOUBLE_QUOTE: RDQ,
   RIGHT_SINGLE_QUOTE: RSQ,
-  EM_DASH,
   ELLIPSIS,
 } = UNICODE_SYMBOLS
 
@@ -33,7 +32,7 @@ describe("transformMarkdown", () => {
     const expected = [
       `# ${LDQ}Welcome${RDQ}`,
       "",
-      `It${RSQ}s great${EM_DASH}isn${RSQ}t it?`,
+      `It${RSQ}s great${NOWRAP_EM_DASH}isn${RSQ}t it?`,
       "",
       `Wait${ELLIPSIS}`,
       "", // remark-stringify adds trailing newline

--- a/src/tests/rehype.test.ts
+++ b/src/tests/rehype.test.ts
@@ -13,13 +13,12 @@ import {
   assertSmartQuotesMatch,
   collectTransformableElements,
 } from "../rehype.js"
-import { UNICODE_SYMBOLS, DEFAULT_SEPARATOR } from "../constants.js"
+import { UNICODE_SYMBOLS, DEFAULT_SEPARATOR, NOWRAP_EM_DASH } from "../constants.js"
 
 const {
   LEFT_DOUBLE_QUOTE: LDQ,
   RIGHT_DOUBLE_QUOTE: RDQ,
   RIGHT_SINGLE_QUOTE: RSQ,
-  EM_DASH,
   EN_DASH,
   ELLIPSIS,
   MULTIPLICATION,
@@ -42,7 +41,7 @@ describe("rehypePunctilio", () => {
     it.each([
       ["quotes", '<p>"Hello," she said.</p>', `<p>${LDQ}Hello,${RDQ} she said.</p>`],
       ["apostrophes", "<p>It's a test.</p>", `<p>It${RSQ}s a test.</p>`],
-      ["em dashes", "<p>Wait -- here it comes.</p>", `<p>Wait${EM_DASH}here it comes.</p>`],
+      ["em dashes", "<p>Wait -- here it comes.</p>", `<p>Wait${NOWRAP_EM_DASH}here it comes.</p>`],
       ["en dashes", "<p>Pages 1-5</p>", `<p>Pages 1${EN_DASH}5</p>`],
       ["ellipses", "<p>Wait...</p>", `<p>Wait${ELLIPSIS}</p>`],
       ["multiplication", "<p>5x5</p>", `<p>5${MULTIPLICATION}5</p>`],
@@ -110,7 +109,7 @@ describe("rehypePunctilio", () => {
     it.each([
       ["punctuationStyle american", '<p>"Hello."</p>', { punctuationStyle: "american" as const, nbsp: false as const }, `<p>${LDQ}Hello.${RDQ}</p>`],
       ["punctuationStyle british", '<p>"Hello."</p>', { punctuationStyle: "british" as const, nbsp: false as const }, `<p>${LDQ}Hello${RDQ}.</p>`],
-      ["dashStyle american", "<p>word - word</p>", { dashStyle: "american" as const, nbsp: false as const }, `<p>word${EM_DASH}word</p>`],
+      ["dashStyle american", "<p>word - word</p>", { dashStyle: "american" as const, nbsp: false as const }, `<p>word${NOWRAP_EM_DASH}word</p>`],
       ["dashStyle british", "<p>word - word</p>", { dashStyle: "british" as const, nbsp: false as const }, `<p>word ${EN_DASH} word</p>`],
       ["symbols enabled", "<p>5x5</p>", { symbols: true, nbsp: false as const }, `<p>5${MULTIPLICATION}5</p>`],
       ["symbols disabled", "<p>5x5</p>", { symbols: false, nbsp: false as const }, "<p>5x5</p>"],
@@ -127,12 +126,12 @@ describe("rehypePunctilio", () => {
       [
         "article content",
         `<article><h1>"Title's"</h1><p>"quotes" -- dashes</p><p>Pages 1-5</p></article>`,
-        `<article><h1>${LDQ}Title${RSQ}s${RDQ}</h1><p>${LDQ}quotes${RDQ}${EM_DASH}dashes</p><p>Pages 1${EN_DASH}5</p></article>`,
+        `<article><h1>${LDQ}Title${RSQ}s${RDQ}</h1><p>${LDQ}quotes${RDQ}${NOWRAP_EM_DASH}dashes</p><p>Pages 1${EN_DASH}5</p></article>`,
       ],
       [
         "mixed code and prose",
         '<p>The function <code>getValue()</code> returns "the value" -- useful.</p>',
-        `<p>The function <code>getValue()</code> returns ${LDQ}the value${RDQ}${EM_DASH}useful.</p>`,
+        `<p>The function <code>getValue()</code> returns ${LDQ}the value${RDQ}${NOWRAP_EM_DASH}useful.</p>`,
       ],
       [
         "table content",
@@ -142,7 +141,7 @@ describe("rehypePunctilio", () => {
       [
         "list content",
         '<ul><li>"First" -- important</li><li>Pages 1-5</li></ul>',
-        `<ul><li>${LDQ}First${RDQ}${EM_DASH}important</li><li>Pages 1${EN_DASH}5</li></ul>`,
+        `<ul><li>${LDQ}First${RDQ}${NOWRAP_EM_DASH}important</li><li>Pages 1${EN_DASH}5</li></ul>`,
       ],
     ])("handles %s", async (_name, html, expected) => {
       expect(await processHtml(html, { nbsp: false })).toEqual(expected)

--- a/src/tests/remark.test.ts
+++ b/src/tests/remark.test.ts
@@ -3,13 +3,12 @@ import remarkParse from "remark-parse"
 import remarkGfm from "remark-gfm"
 import remarkStringify from "remark-stringify"
 import { remarkPunctilio, type RemarkPunctilioOptions } from "../remark.js"
-import { UNICODE_SYMBOLS } from "../constants.js"
+import { UNICODE_SYMBOLS, NOWRAP_EM_DASH } from "../constants.js"
 
 const {
   LEFT_DOUBLE_QUOTE: LDQ,
   RIGHT_DOUBLE_QUOTE: RDQ,
   RIGHT_SINGLE_QUOTE: RSQ,
-  EM_DASH,
   EN_DASH,
   ELLIPSIS,
   MULTIPLICATION,
@@ -49,7 +48,7 @@ describe("remarkPunctilio", () => {
     it.each([
       ["quotes", '"Hello," she said.', `${LDQ}Hello,${RDQ} she${NBSP}said.`],
       ["apostrophes", "It's a test.", `It${RSQ}s${NBSP}a${NBSP}test.`],
-      ["em dashes", "Wait -- here it comes.", `Wait${EM_DASH}here it${NBSP}comes.`],
+      ["em dashes", "Wait -- here it comes.", `Wait${NOWRAP_EM_DASH}here it${NBSP}comes.`],
       ["en dashes (number range)", "Pages 1-5", `Pages${NBSP}1${EN_DASH}5`],
       ["ellipses", "Wait...", `Wait${ELLIPSIS}`],
       ["multiplication", "5x5", `5${MULTIPLICATION}5`],
@@ -64,7 +63,7 @@ describe("remarkPunctilio", () => {
     it.each([
       ["quotes", '"Hello," she said.', `${LDQ}Hello,${RDQ} she said.`],
       ["apostrophes", "It's a test.", `It${RSQ}s a test.`],
-      ["em dashes", "Wait -- here it comes.", `Wait${EM_DASH}here it comes.`],
+      ["em dashes", "Wait -- here it comes.", `Wait${NOWRAP_EM_DASH}here it comes.`],
       ["ellipses", "Wait...", `Wait${ELLIPSIS}`],
       ["multiplication", "5x5", `5${MULTIPLICATION}5`],
       ["math symbols", "x != y", `x ${NOT_EQUAL} y`],
@@ -79,7 +78,7 @@ describe("remarkPunctilio", () => {
       ["quotes spanning emphasis", '"Hello," *she* said.', `${LDQ}Hello,${RDQ} *she* said.`],
       ["quotes inside emphasis", '*"Hello,"* she said.', `*${LDQ}Hello,${RDQ}* she said.`],
       ["apostrophe in strong", "**It's** fine.", `**It${RSQ}s** fine.`],
-      ["dash between elements", "word *one* -- *two* word", `word *one*${EM_DASH}*two* word`],
+      ["dash between elements", "word *one* -- *two* word", `word *one*${NOWRAP_EM_DASH}*two* word`],
       ["deeply nested elements", '*"Hello **beautiful** world"*', `*${LDQ}Hello **beautiful** world${RDQ}*`],
     ])("handles %s", async (_name, input, expected) => {
       expect(await processMarkdown(input, { nbsp: false })).toEqual(expected)
@@ -95,7 +94,7 @@ describe("remarkPunctilio", () => {
       const result = await processMarkdown(input, { nbsp: false })
       expect(result).toContain('"Hello" -- test...')
       expect(result).not.toContain(LDQ)
-      expect(result).not.toContain(EM_DASH)
+      expect(result).not.toContain(NOWRAP_EM_DASH)
       expect(result).not.toContain(ELLIPSIS)
     })
 
@@ -109,8 +108,8 @@ describe("remarkPunctilio", () => {
     it.each([
       ["h1", '# "Hello"', `# ${LDQ}Hello${RDQ}`],
       ["h2", '## It\'s nice', `## It${RSQ}s nice`],
-      ["h3", "### Wait -- really?", `### Wait${EM_DASH}really?`],
-      ["list items", '- "Hello" -- world', `* ${LDQ}Hello${RDQ}${EM_DASH}world`],
+      ["h3", "### Wait -- really?", `### Wait${NOWRAP_EM_DASH}really?`],
+      ["list items", '- "Hello" -- world', `* ${LDQ}Hello${RDQ}${NOWRAP_EM_DASH}world`],
       ["blockquotes", '> "Hello," she said.', `> ${LDQ}Hello,${RDQ} she said.`],
     ])("transforms %s", async (_name, input, expected) => {
       expect(await processMarkdown(input, { nbsp: false })).toEqual(expected)
@@ -131,7 +130,7 @@ describe("remarkPunctilio", () => {
   describe("GFM extensions", () => {
     it.each([
       ["table cells", '| "Hello" | world |\n| --- | --- |\n| "test" | data |', `| ${LDQ}Hello${RDQ} | world |\n| ------- | ----- |\n| ${LDQ}test${RDQ}  | data  |`],
-      ["strikethrough", '~~"Hello" -- world~~', `~~${LDQ}Hello${RDQ}${EM_DASH}world~~`],
+      ["strikethrough", '~~"Hello" -- world~~', `~~${LDQ}Hello${RDQ}${NOWRAP_EM_DASH}world~~`],
     ])("transforms %s", async (_name, input, expected) => {
       expect(await processGfmMarkdown(input, { nbsp: false })).toEqual(expected)
     })
@@ -141,7 +140,7 @@ describe("remarkPunctilio", () => {
     it.each([
       ["punctuationStyle american", '"Hello."', { punctuationStyle: "american" as const, nbsp: false as const }, `${LDQ}Hello.${RDQ}`],
       ["punctuationStyle british", '"Hello."', { punctuationStyle: "british" as const, nbsp: false as const }, `${LDQ}Hello${RDQ}.`],
-      ["dashStyle american", "word - word", { dashStyle: "american" as const, nbsp: false as const }, `word${EM_DASH}word`],
+      ["dashStyle american", "word - word", { dashStyle: "american" as const, nbsp: false as const }, `word${NOWRAP_EM_DASH}word`],
       ["dashStyle british", "word - word", { dashStyle: "british" as const, nbsp: false as const }, `word ${EN_DASH} word`],
       ["symbols disabled", "5x5", { symbols: false, nbsp: false as const }, "5x5"],
       ["fractions enabled", "1/2 cup", { fractions: true, nbsp: false as const }, `${FRACTION_1_2} cup`],
@@ -155,7 +154,7 @@ describe("remarkPunctilio", () => {
   describe("complex documents", () => {
     it("transforms a multi-paragraph document", async () => {
       const input = '"Hello," she said.\n\nIt\'s a nice day -- isn\'t it?\n\nWait...'
-      const expected = `${LDQ}Hello,${RDQ} she said.\n\nIt${RSQ}s a nice day${EM_DASH}isn${RSQ}t it?\n\nWait${ELLIPSIS}`
+      const expected = `${LDQ}Hello,${RDQ} she said.\n\nIt${RSQ}s a nice day${NOWRAP_EM_DASH}isn${RSQ}t it?\n\nWait${ELLIPSIS}`
       expect(await processMarkdown(input, { nbsp: false })).toEqual(expected)
     })
 


### PR DESCRIPTION
## Summary
- Insert a Word Joiner (U+2060) before each em dash to prevent browsers from breaking the line before it
- Unicode classifies em dash with line break class B2, giving browsers a break opportunity before it — this causes em dashes to appear orphaned at the start of a new line
- The word joiner suppresses this break opportunity, keeping the em dash attached to the preceding word

## Changes
- Added `WORD_JOINER` to `UNICODE_SYMBOLS` in `constants.ts`
- Added `preventEmDashLineBreak()` function in `dashes.ts` using idempotent string operations (strip then re-add)
- Called `preventEmDashLineBreak()` at the end of `hyphenReplace()` so all em dashes get the word joiner
- Exported `preventEmDashLineBreak` from `index.ts`
- Updated test expectations in `dashes.test.ts` to include word joiner before em dashes
- Added dedicated tests for `preventEmDashLineBreak` (idempotency, multiple em dashes, en dash preservation)

## Test plan
- [ ] Run existing dash test suite — all expectations updated to include word joiner
- [ ] Verify idempotency: `hyphenReplace(hyphenReplace(text))` produces same result
- [ ] Verify British style (spaced en dashes) is not affected by word joiner
- [ ] Verify `dashStyle: "none"` still skips all transforms including word joiner

https://claude.ai/code/session_01ARRmRkaAyZYasp8sHx5wf3