### PR TITLE
fix: escape closing brackets in transformMarkdown output

### DIFF
--- a/src/markdown.ts
+++ b/src/markdown.ts
@@ -77,6 +77,10 @@ export async function transformMarkdown(
       bullet: bulletMarker ?? "-",
       rule: ruleMarker ?? "-",
       ...(ruleMarker === "-" || ruleMarker === undefined ? { ruleRepetition: 4 } : {}),
+      // remark-stringify escapes opening brackets but not closing brackets,
+      // producing `\[1]` instead of `\[1\]`. This can cause issues when the
+      // output is re-parsed by markdown renderers.
+      unsafe: [{ character: "]", inConstruct: "phrasing" }],
     })
 
   const result = await processor.process(input)

--- a/src/tests/markdown.test.ts
+++ b/src/tests/markdown.test.ts
@@ -68,4 +68,11 @@ describe("transformMarkdown", () => {
     const result = await transformMarkdown('"Hello"')
     expect(result.trimEnd()).toEqual(`${LDQ}Hello${RDQ}`)
   })
+
+  it("escapes both opening and closing brackets in phrasing content", async () => {
+    const result = await transformMarkdown("See references [1][4][5][6] for details.", {
+      nbsp: false,
+    })
+    expect(result.trimEnd()).toEqual("See references \\[1\\]\\[4\\]\\[5\\]\\[6\\] for details.")
+  })
 })


### PR DESCRIPTION
## Summary

- `remark-stringify` escapes opening brackets (`[` → `\[`) to prevent markdown link parsing, but leaves closing brackets `]` unescaped
- This produces `\[1]\[4]` instead of `\[1\]\[4\]`, which can cause issues when the output is re-parsed by markdown renderers
- Add an `unsafe` pattern to the `remarkStringify` config in `transformMarkdown` so closing brackets are also escaped in phrasing content

## Test plan

- [ ] Added test case verifying `[1][4][5][6]` produces `\[1\]\[4\]\[5\]\[6\]`
- [ ] Existing tests should continue to pass