### PR TITLE
fix: security hardening from red team audit

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "build": "tsc",
     "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js",
     "lint": "eslint src",
-    "prepare": "(tsc || true) && (bash scripts/install-hooks.sh || true)",
+    "prepare": "if [ -d src ]; then tsc; else true; fi && (bash scripts/install-hooks.sh || true)",
     "prepublishOnly": "pnpm run build && pnpm run test",
     "install-hooks": "bash scripts/install-hooks.sh"
   },

--- a/scripts/hooks/pre-push
+++ b/scripts/hooks/pre-push
@@ -46,7 +46,7 @@ fi
 
 # Publish to npm
 echo "📤 Publishing to npm..."
-pnpm publish --access public 
+pnpm publish --provenance --access public --no-git-checks
 
 if [ $? -ne 0 ]; then
   echo "❌ Publish failed. Push aborted."

--- a/scripts/hooks/pre-push
+++ b/scripts/hooks/pre-push
@@ -46,7 +46,11 @@ fi
 
 # Publish to npm
 echo "📤 Publishing to npm..."
-pnpm publish --provenance --access public --no-git-checks
+if [ -n "${CI:-}" ]; then
+  pnpm publish --provenance --access public --no-git-checks
+else
+  pnpm publish --access public
+fi
 
 if [ $? -ne 0 ]; then
   echo "❌ Publish failed. Push aborted."

--- a/scripts/version-bump.sh
+++ b/scripts/version-bump.sh
@@ -28,8 +28,10 @@ else
   DIFF_STAT=$(git show --stat HEAD 2>/dev/null || echo "Unable to get diff")
 fi
 
-# Sanitize commit messages: truncate each line, remove control chars, limit total length
-COMMITS=$(echo "$COMMITS_RAW" | head -20 | cut -c1-100 | tr -cd '[:print:]\n' | head -c 2000)
+# Sanitize commit messages: truncate each line, remove control chars, strip prompt-like
+# prefixes (e.g., "SYSTEM:", "ASSISTANT:"), and limit total length
+COMMITS=$(echo "$COMMITS_RAW" | head -20 | cut -c1-100 | tr -cd '[:print:]\n' \
+  | sed 's/\b\(SYSTEM\|ASSISTANT\|USER\|HUMAN\|INSTRUCTIONS\?\):\s*//gI' | head -c 2000)
 
 if [ -z "$COMMITS" ]; then
   echo "No commits to analyze. Skipping."
@@ -90,13 +92,13 @@ RESPONSE=$(curl -s https://api.anthropic.com/v1/messages \
     }')")
 
 # Extract the bump level from Claude's structured tool use response
-echo "API response: $RESPONSE"
 BUMP=$(echo "$RESPONSE" | jq -r '.content[] | select(.type == "tool_use") | .input.bump_type')
 
 # Validate response - fail if Claude couldn't determine bump type
 if [[ "$BUMP" != "major" && "$BUMP" != "minor" && "$BUMP" != "patch" ]]; then
-  echo "Error: Unexpected response from Claude: $BUMP"
-  echo "Full response: $RESPONSE"
+  echo "Error: Unexpected bump type from Claude: $BUMP"
+  # Log only the stop_reason and type, not the full response (may contain metadata)
+  echo "Response stop_reason: $(echo "$RESPONSE" | jq -r '.stop_reason // "unknown"')"
   exit 1
 fi
 

--- a/scripts/version-bump.sh
+++ b/scripts/version-bump.sh
@@ -28,10 +28,8 @@ else
   DIFF_STAT=$(git show --stat HEAD 2>/dev/null || echo "Unable to get diff")
 fi
 
-# Sanitize commit messages: truncate each line, remove control chars, strip prompt-like
-# prefixes (e.g., "SYSTEM:", "ASSISTANT:"), and limit total length
-COMMITS=$(echo "$COMMITS_RAW" | head -20 | cut -c1-100 | tr -cd '[:print:]\n' \
-  | sed 's/\b\(SYSTEM\|ASSISTANT\|USER\|HUMAN\|INSTRUCTIONS\?\):\s*//gI' | head -c 2000)
+# Sanitize commit messages: truncate each line, remove control chars, limit total length
+COMMITS=$(echo "$COMMITS_RAW" | head -20 | cut -c1-100 | tr -cd '[:print:]\n' | head -c 2000)
 
 if [ -z "$COMMITS" ]; then
   echo "No commits to analyze. Skipping."

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -201,23 +201,15 @@ export function spaceBoundaryEnd(escapedSeparator: string): string {
 /**
  * Cache for compiled RegExp objects keyed by `pattern + '\0' + flags`.
  * Avoids recompiling identical regexes on every function call (common
- * when using the default separator).
- *
- * Capped at {@link MAX_REGEX_CACHE_SIZE} entries to prevent unbounded
- * memory growth when callers supply many distinct separator values.
+ * when using the default separator). Capped to prevent unbounded growth.
  */
 const regexCache = new Map<string, RegExp>()
-
-/** Maximum number of entries in the regex cache before eviction. */
 const MAX_REGEX_CACHE_SIZE = 1000
 
 /**
  * Returns a cached RegExp for the given pattern and flags.
  * Resets `lastIndex` before returning to prevent stale state when
  * callers use `.test()` or `.exec()` on global-flag regexes.
- *
- * When the cache exceeds {@link MAX_REGEX_CACHE_SIZE}, the oldest
- * entry is evicted (Map iteration order = insertion order).
  */
 export function cachedRegExp(pattern: string, flags: string): RegExp {
   const key = `${pattern}\0${flags}`

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -202,19 +202,33 @@ export function spaceBoundaryEnd(escapedSeparator: string): string {
  * Cache for compiled RegExp objects keyed by `pattern + '\0' + flags`.
  * Avoids recompiling identical regexes on every function call (common
  * when using the default separator).
+ *
+ * Capped at {@link MAX_REGEX_CACHE_SIZE} entries to prevent unbounded
+ * memory growth when callers supply many distinct separator values.
  */
 const regexCache = new Map<string, RegExp>()
+
+/** Maximum number of entries in the regex cache before eviction. */
+const MAX_REGEX_CACHE_SIZE = 1000
 
 /**
  * Returns a cached RegExp for the given pattern and flags.
  * Resets `lastIndex` before returning to prevent stale state when
  * callers use `.test()` or `.exec()` on global-flag regexes.
+ *
+ * When the cache exceeds {@link MAX_REGEX_CACHE_SIZE}, the oldest
+ * entry is evicted (Map iteration order = insertion order).
  */
 export function cachedRegExp(pattern: string, flags: string): RegExp {
   const key = `${pattern}\0${flags}`
   let re = regexCache.get(key)
   if (!re) {
     re = new RegExp(pattern, flags)
+    if (regexCache.size >= MAX_REGEX_CACHE_SIZE) {
+      // Evict oldest entry (first key in insertion order)
+      const oldest = regexCache.keys().next().value!
+      regexCache.delete(oldest)
+    }
     regexCache.set(key, re)
   }
   re.lastIndex = 0

--- a/src/rehype.ts
+++ b/src/rehype.ts
@@ -389,7 +389,8 @@ export function collectTransformableElements(
     // Otherwise, recurse into children
     for (const child of node.children) {
       if (child.type === "element") {
-        results.push(...collectTransformableElements(child, shouldSkip, depth + 1))
+        const childResults = collectTransformableElements(child, shouldSkip, depth + 1)
+        for (const r of childResults) results.push(r)
       }
     }
   }

--- a/src/tests/utils.test.ts
+++ b/src/tests/utils.test.ts
@@ -1,5 +1,5 @@
 import { assertSeparatorAbsent, countSeparators, assertSeparatorCountPreserved, formatErrorString } from "../utils.js"
-import { DEFAULT_SEPARATOR } from "../constants.js"
+import { DEFAULT_SEPARATOR, cachedRegExp } from "../constants.js"
 
 describe("assertSeparatorAbsent", () => {
   it.each([
@@ -72,6 +72,19 @@ describe("assertSeparatorCountPreserved", () => {
         expect(() => assertSeparatorCountPreserved(original, transformed)).not.toThrow()
       }
     })
+  })
+})
+
+describe("cachedRegExp", () => {
+  it("evicts oldest entry when cache exceeds max size", () => {
+    // Fill the cache well beyond 1000 entries with unique patterns
+    for (let i = 0; i < 1010; i++) {
+      const re = cachedRegExp(`unique-pattern-${i}`, "g")
+      expect(re).toBeInstanceOf(RegExp)
+    }
+    // Verify the cache still works correctly after eviction
+    const re = cachedRegExp("unique-pattern-1009", "g")
+    expect(re.source).toBe("unique-pattern-1009")
   })
 })
 


### PR DESCRIPTION
## Summary
- Red team audit of the codebase identified and fixed several security and robustness issues
- No critical vulnerabilities found; the codebase has strong security fundamentals
- All fixes maintain 100% test coverage (1461 tests)

## Changes
- **Regex cache eviction**: Cap `cachedRegExp` cache at 1000 entries to prevent unbounded memory growth in long-running server processes using rehype/remark plugins
- **Stack overflow fix**: Replace `results.push(...spread)` with loop-based push in `collectTransformableElements` to prevent argument stack overflow on wide HTML trees (V8 limits ~65k args)
- **npm provenance**: Add `--provenance` flag to pre-push publish, gated on CI environment (requires OIDC tokens from GitHub Actions)
- **Reduced info leakage**: Remove full API response from version-bump.sh error output; log only `stop_reason`
- **Loud tsc failures**: `prepare` script now fails loudly on TypeScript errors during local dev (src/ exists) while skipping cleanly for consumers (src/ not shipped)

## Testing
- `pnpm build` — passes
- `pnpm lint` — passes
- `pnpm test` — 1461 tests, 100% coverage across all metrics
- Added test for regex cache eviction behavior

https://claude.ai/code/session_01AgMqPnVB11TMpG9qyi5g7t