### PR TITLE
fix(benchmark): correct expected output for em-dash between quotes

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ My [`benchmark.mjs`](https://github.com/alexander-turner/punctilio/blob/main/ben
 
 ## Test suite
 
-Setting aside the benchmark, `punctilio`’s test suite includes 1,100+ tests at 100% branch coverage, including edge cases derived from competitor libraries ([`smartquotes`](https://github.com/kellym/smartquotes.js), [`retext-smartypants`](https://github.com/retextjs/retext-smartypants), [`typograf`](https://github.com/typograf/typograf)) and the [Standard Ebooks typography manual](https://standardebooks.org/manual/). I also verify that all transformations are stable when applied multiple times.
+Setting aside the benchmark, `punctilio`’s test suite includes 1,400+ tests at 100% branch coverage, including edge cases derived from competitor libraries ([`smartquotes`](https://github.com/kellym/smartquotes.js), [`retext-smartypants`](https://github.com/retextjs/retext-smartypants), [`typograf`](https://github.com/typograf/typograf)) and the [Standard Ebooks typography manual](https://standardebooks.org/manual/). I also verify that all transformations are stable when applied multiple times.
 
 ## Works with HTML DOMs via separation boundaries
 

--- a/benchmark_cases.json
+++ b/benchmark_cases.json
@@ -47,7 +47,7 @@
     ["since--as you know", "since\u2014as you know"]
   ],
   "Em dashes - between quotes": [
-    ["\"Hello\"--\"World\"", "\"Hello\"\u2014\"World\""]
+    ["\"Hello\"--\"World\"", "\u201CHello\u201D\u2014\u201CWorld\u201D"]
   ],
   "Number ranges - en dash": [
     ["Pages 1-5", "Pages 1\u20135"],


### PR DESCRIPTION
## Summary
- Fix incorrect expected value in benchmark that used straight quotes instead of curly quotes for the em-dash between quotes test case
- Update README test count from 1,100+ to 1,400+ to reflect current suite size (1,461 tests)

## Changes
- `benchmark_cases.json`: Changed expected output for `"Hello"--"World"` from straight quotes (`"Hello"—"World"`) to curly quotes (`\u201CHello\u201D\u2014\u201CWorld\u201D`) — punctilio correctly converts both the dashes and the quotes
- `README.md`: Updated test count in the "Test suite" section

## Testing
- All 1,461 tests pass with 100% branch coverage
- Benchmark re-run confirms punctilio score remains 154/159 (97%)

https://claude.ai/code/session_01NVtbe4kNQUwbdscsqwKZsT