### PR TITLE
fix: use multi-character sentinel to avoid CJK separator collision

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -118,23 +118,28 @@ export const TERMINAL_PUNCTUATION = [
 export const LATIN_LETTERS = "A-Za-z\\u00C0-\\u00D6\\u00D8-\\u00F6\\u00F8-\\u00FF\\u0100-\\u017F\\u0180-\\u024F"
 
 /**
- * Default separator character for text spanning HTML elements.
- * Uses Unicode Private Use Area character U+E000.
+ * Default separator for text spanning HTML elements.
+ * Uses a two-character sentinel from the Unicode Private Use Area
+ * (U+E000 U+E001) to avoid collisions with CJK fonts, Apple emoji
+ * internals, PDF-to-text output, and icon fonts that repurpose U+E000.
  */
-export const DEFAULT_SEPARATOR = "\uE000"
+export const DEFAULT_SEPARATOR = "\uE000\uE001"
 export const ESCAPED_DEFAULT_SEPARATOR = escapeStringRegexp(DEFAULT_SEPARATOR)
 
 /**
- * Returns the regex-escaped separator string for the given options.
- * Centralizes the common pattern of falling back to the pre-escaped default.
+ * Returns the regex-escaped separator string for the given options,
+ * wrapped in a non-capturing group so that quantifiers like `?` and `*`
+ * apply to the entire separator sequence (critical for multi-character
+ * separators like the default U+E000 U+E001).
  *
  * @param options - Object with an optional `separator` field
- * @returns Regex-escaped separator string
+ * @returns Regex-escaped separator string wrapped in `(?:...)`
  */
 export function getEscapedSeparator(options: { separator?: string }): string {
-  return options.separator
+  const escaped = options.separator
     ? escapeStringRegexp(options.separator)
     : ESCAPED_DEFAULT_SEPARATOR
+  return `(?:${escaped})`
 }
 
 /**
@@ -193,22 +198,28 @@ export const SPACE_CHARS = ` ${UNICODE_SYMBOLS.NBSP}`
  * Creates a lookbehind pattern that matches after whitespace, separator, or start of string.
  * Used for arrow patterns and other constructs that should appear at word boundaries.
  *
- * @param escapedSeparator - Regex-escaped separator string
- * @returns Pattern string: `(?<=[\\s${sep}]|^)`
+ * Uses alternation instead of a character class so that multi-character
+ * separators are matched as a sequence, not as individual characters.
+ *
+ * @param escapedSeparator - Regex-escaped separator string (may be grouped)
+ * @returns Pattern string: `(?<=\\s|${sep}|^)`
  */
 export function spaceBoundaryStart(escapedSeparator: string): string {
-  return `(?<=[\\s${escapedSeparator}]|^)`
+  return `(?<=\\s|${escapedSeparator}|^)`
 }
 
 /**
  * Creates a lookahead pattern that matches before whitespace, separator, or end of string.
  * Used for arrow patterns and other constructs that should appear at word boundaries.
  *
- * @param escapedSeparator - Regex-escaped separator string
- * @returns Pattern string: `(?=[\\s${sep}]|$)`
+ * Uses alternation instead of a character class so that multi-character
+ * separators are matched as a sequence, not as individual characters.
+ *
+ * @param escapedSeparator - Regex-escaped separator string (may be grouped)
+ * @returns Pattern string: `(?=\\s|${sep}|$)`
  */
 export function spaceBoundaryEnd(escapedSeparator: string): string {
-  return `(?=[\\s${escapedSeparator}]|$)`
+  return `(?=\\s|${escapedSeparator}|$)`
 }
 
 /**

--- a/src/dashes.ts
+++ b/src/dashes.ts
@@ -150,7 +150,7 @@ export function minusReplace(text: string, options: DashOptions = {}): string {
 function convertParentheticalDashes(text: string, sep: string, style: DashStyle): string {
   const localizedDash = style === "british" ? EN_DASH : EM_DASH
   const maybeSpace = style === "british" ? " " : ""
-  const escapedSep = escapeStringRegexp(sep)
+  const escapedSep = `(?:${escapeStringRegexp(sep)})`
 
   // Convert spaced dashes: "word - word" or "word — word"
   // When a separator follows the dash, preserve trailing spaces (they belong to the next text segment).
@@ -198,7 +198,7 @@ function convertParentheticalDashes(text: string, sep: string, style: DashStyle)
  * allows a space after the dash: "Don't inter— Hey! Who threw that?"
  */
 function normalizeEmDashSpacing(text: string, sep: string): string {
-  const escapedSep = escapeStringRegexp(sep)
+  const escapedSep = `(?:${escapeStringRegexp(sep)})`
 
   // Remove all spaces around em-dashes
   text = text.replace(

--- a/src/dashes.ts
+++ b/src/dashes.ts
@@ -2,7 +2,6 @@
  * Dash transformation: hyphens → em-dashes, en-dashes, minus signs.
  */
 
-import escapeStringRegexp from "escape-string-regexp"
 import { UNICODE_SYMBOLS, DEFAULT_SEPARATOR, LATIN_LETTERS, wordBoundaryStart, wordBoundaryEnd, getEscapedSeparator, cachedRegExp } from "./constants.js"
 
 export type DashStyle = "american" | "british" | "none"
@@ -150,7 +149,7 @@ export function minusReplace(text: string, options: DashOptions = {}): string {
 function convertParentheticalDashes(text: string, sep: string, style: DashStyle): string {
   const localizedDash = style === "british" ? EN_DASH : EM_DASH
   const maybeSpace = style === "british" ? " " : ""
-  const escapedSep = `(?:${escapeStringRegexp(sep)})`
+  const escapedSep = getEscapedSeparator({ separator: sep })
 
   // Convert spaced dashes: "word - word" or "word — word"
   // When a separator follows the dash, preserve trailing spaces (they belong to the next text segment).
@@ -198,7 +197,7 @@ function convertParentheticalDashes(text: string, sep: string, style: DashStyle)
  * allows a space after the dash: "Don't inter— Hey! Who threw that?"
  */
 function normalizeEmDashSpacing(text: string, sep: string): string {
-  const escapedSep = `(?:${escapeStringRegexp(sep)})`
+  const escapedSep = getEscapedSeparator({ separator: sep })
 
   // Remove all spaces around em-dashes
   text = text.replace(

--- a/src/index.ts
+++ b/src/index.ts
@@ -218,14 +218,18 @@ const defaultOpts: Required<Omit<TransformOptions, "separator">> = {
 export function transform(text: string, options: TransformOptions = {}): string {
   const separator = options.separator ?? DEFAULT_SEPARATOR
 
-  // Validate separator: must be a single UTF-16 code unit (BMP character)
-  // Multi-codepoint characters (surrogate pairs like emoji) cause issues with regex patterns
-  if (separator.length !== 1) {
-    throw new Error(
-      `Invalid separator: must be a single character. ` +
-      `Received "${separator}" (length: ${separator.length}). ` +
-      `Use a single-codepoint character like the default "\\uE000".`
-    )
+  // Validate separator: must be non-empty and contain only BMP characters.
+  // Surrogate pairs (emoji, supplementary plane chars) break regex patterns.
+  if (separator.length === 0) {
+    throw new Error("Invalid separator: must not be empty.")
+  }
+  for (const ch of separator) {
+    if (ch.length > 1) {
+      throw new Error(
+        `Invalid separator: must contain only BMP characters (no emoji or supplementary-plane characters). ` +
+        `Received "${separator}" which contains a non-BMP character.`
+      )
+    }
   }
 
   const original = text

--- a/src/index.ts
+++ b/src/index.ts
@@ -219,14 +219,15 @@ export function transform(text: string, options: TransformOptions = {}): string 
   const separator = options.separator ?? DEFAULT_SEPARATOR
 
   // Validate separator: must be non-empty and contain only BMP characters.
-  // Surrogate pairs (emoji, supplementary plane chars) break regex patterns.
+  // for...of iterates by code point; surrogate pairs (non-BMP) yield a
+  // two-UTF16-unit string, so ch.length > 1 detects them.
   if (separator.length === 0) {
     throw new Error("Invalid separator: must not be empty.")
   }
   for (const ch of separator) {
     if (ch.length > 1) {
       throw new Error(
-        `Invalid separator: must contain only BMP characters (no emoji or supplementary-plane characters). ` +
+        `Invalid separator: must contain only BMP characters (no characters outside the Basic Multilingual Plane). ` +
         `Received "${separator}" which contains a non-BMP character.`
       )
     }

--- a/src/nbsp.ts
+++ b/src/nbsp.ts
@@ -135,8 +135,9 @@ export function nbspBetweenNumberAndUnit(text: string, options: NbspOptions = {}
  */
 export function nbspBeforeLastWord(text: string, options: NbspOptions = {}): string {
   const sep = getEscapedSeparator(options)
+  // Use alternation instead of character classes for multi-char separator support
   const pattern = cachedRegExp(
-    `(?<=[\\w${sep}])${SPACE}(?<lastWord>[^\\s${sep}]{1,10})(?<ending>${sep}?(?:\\n\\n|$))`,
+    `(?<=\\w|${sep})${SPACE}(?<lastWord>(?:(?!\\s)(?!${sep}).){1,10})(?<ending>${sep}?(?:\\n\\n|$))`,
     "g"
   )
   return text.replace(pattern, `${NBSP}$<lastWord>$<ending>`)

--- a/src/quotes.ts
+++ b/src/quotes.ts
@@ -3,7 +3,7 @@
  */
 
 import escapeStringRegexp from "escape-string-regexp"
-import { UNICODE_SYMBOLS, DEFAULT_SEPARATOR, LATIN_LETTERS, TERMINAL_PUNCTUATION, cachedRegExp } from "./constants.js"
+import { UNICODE_SYMBOLS, DEFAULT_SEPARATOR, LATIN_LETTERS, TERMINAL_PUNCTUATION, getEscapedSeparator, cachedRegExp } from "./constants.js"
 
 const {
   EM_DASH,
@@ -28,7 +28,7 @@ export interface QuoteOptions {
 
 /** Convert straight single quotes to curly quotes and apostrophes */
 function convertSingleQuotes(text: string, sep: string): string {
-  const escapedSep = `(?:${escapeStringRegexp(sep)})`
+  const escapedSep = getEscapedSeparator({ separator: sep })
 
   // Handle empty single quotes '' and whitespace-only quotes ' ' first
   // Only match straight quotes, not already-converted curly quotes
@@ -96,7 +96,7 @@ function convertUnmatchedPluralPossessives(text: string, sep: string): string {
         return match
       }
       let i = offset - 1
-      while (i >= sep.length - 1 && text.substring(i - sep.length + 1, i + 1) === sep) {
+      while (i >= sep.length - 1 && text.startsWith(sep, i - sep.length + 1)) {
         i -= sep.length
       }
       if (i >= 0 && (text[i] === "s" || text[i] === "S")) {
@@ -110,7 +110,7 @@ function convertUnmatchedPluralPossessives(text: string, sep: string): string {
 /** Convert straight double quotes to curly quotes */
 function convertDoubleQuotes(text: string, sep: string): string {
   const rawEscSep = escapeStringRegexp(sep)
-  const escapedSep = `(?:${rawEscSep})`
+  const escapedSep = getEscapedSeparator({ separator: sep })
 
   // Handle empty quotes "" first - match only when not part of adjacent quotes
   // Require word boundary or start/end of string on at least one side
@@ -137,7 +137,7 @@ function convertDoubleQuotes(text: string, sep: string): string {
 
 /** Apply American or British punctuation style */
 function applyPunctuationStyle(text: string, sep: string, style: PunctuationStyle): string {
-  const escapedSep = `(?:${escapeStringRegexp(sep)})`
+  const escapedSep = getEscapedSeparator({ separator: sep })
 
   if (style === "american") {
     // Period outside → inside: "Hello". → "Hello."

--- a/src/quotes.ts
+++ b/src/quotes.ts
@@ -28,7 +28,7 @@ export interface QuoteOptions {
 
 /** Convert straight single quotes to curly quotes and apostrophes */
 function convertSingleQuotes(text: string, sep: string): string {
-  const escapedSep = escapeStringRegexp(sep)
+  const escapedSep = `(?:${escapeStringRegexp(sep)})`
 
   // Handle empty single quotes '' and whitespace-only quotes ' ' first
   // Only match straight quotes, not already-converted curly quotes
@@ -96,7 +96,9 @@ function convertUnmatchedPluralPossessives(text: string, sep: string): string {
         return match
       }
       let i = offset - 1
-      while (i >= 0 && text[i] === sep) i--
+      while (i >= sep.length - 1 && text.substring(i - sep.length + 1, i + 1) === sep) {
+        i -= sep.length
+      }
       if (i >= 0 && (text[i] === "s" || text[i] === "S")) {
         return MODIFIER_LETTER_APOSTROPHE
       }
@@ -107,7 +109,8 @@ function convertUnmatchedPluralPossessives(text: string, sep: string): string {
 
 /** Convert straight double quotes to curly quotes */
 function convertDoubleQuotes(text: string, sep: string): string {
-  const escapedSep = escapeStringRegexp(sep)
+  const rawEscSep = escapeStringRegexp(sep)
+  const escapedSep = `(?:${rawEscSep})`
 
   // Handle empty quotes "" first - match only when not part of adjacent quotes
   // Require word boundary or start/end of string on at least one side
@@ -116,7 +119,7 @@ function convertDoubleQuotes(text: string, sep: string): string {
   text = text.replace(/(?<=^|[\s([{])"(?<whitespace>\s+)"(?=$|[\s)\]}.!?,;:])/g, `${LEFT_DOUBLE_QUOTE}$<whitespace>${RIGHT_DOUBLE_QUOTE}`)
 
   const beginningDouble = cachedRegExp(
-    `(?<=^|[\\s\\(\\/\\[\\{\\-${EM_DASH}${escapedSep}])(?<beforeChr>${escapedSep}?)["](?<afterChr>(?<sepWithPunct>${escapedSep}[ .,])|(?=${escapedSep}?\\.{3}|${escapedSep}?[^\\s\\)\\${EM_DASH},!?${escapedSep};:.\\}]))`,
+    `(?<=^|[\\s\\(\\/\\[\\{\\-${EM_DASH}]|${escapedSep})(?<beforeChr>${escapedSep}?)["](?<afterChr>(?<sepWithPunct>${escapedSep}[ .,])|(?=${escapedSep}?\\.{3}|${escapedSep}?[^\\s\\)${EM_DASH},!?;:.\\}${rawEscSep}]))`,
     "gm"
   )
   text = text.replace(beginningDouble, `$<beforeChr>${LEFT_DOUBLE_QUOTE}$<afterChr>`)
@@ -134,7 +137,7 @@ function convertDoubleQuotes(text: string, sep: string): string {
 
 /** Apply American or British punctuation style */
 function applyPunctuationStyle(text: string, sep: string, style: PunctuationStyle): string {
-  const escapedSep = escapeStringRegexp(sep)
+  const escapedSep = `(?:${escapeStringRegexp(sep)})`
 
   if (style === "american") {
     // Period outside → inside: "Hello". → "Hello."

--- a/src/tests/index.test.ts
+++ b/src/tests/index.test.ts
@@ -533,18 +533,17 @@ describe("transform", () => {
 
   describe("separator validation", () => {
     const invalidSeparators = [
-      ["🎉", "emoji (multi-codepoint)"],
-      ["ab", "multi-character"],
+      ["🎉", "emoji (non-BMP)"],
       ["", "empty string"],
     ] as const
 
     it.each(invalidSeparators)("rejects %s separator (%s)", (sep) => {
       expect(() => transform('"Hello"', { separator: sep, nbsp: false })).toThrow(
-        /Invalid separator.*must be a single character/
+        /Invalid separator/
       )
     })
 
-    const validSeparators = ["\uE000", "|", "\u2603"] // Default, pipe, snowman
+    const validSeparators = ["\uE000\uE001", "\uE000", "|", "\u2603", "ab"] // Default, single PUA, pipe, snowman, multi-char
 
     it.each(validSeparators)("accepts '%s' as separator", (sep) => {
       expect(() => transform('"Hello"', { separator: sep, nbsp: false })).not.toThrow()

--- a/src/tests/index.test.ts
+++ b/src/tests/index.test.ts
@@ -558,6 +558,25 @@ describe("transform", () => {
     })
   })
 
+  describe("multi-character separator behavior", () => {
+    const sep = "\uE000\uE001"
+
+    it.each([
+      ["quotes with separator at boundary", `${sep}"Hello"`, `${sep}${LEFT_DOUBLE_QUOTE}Hello${RIGHT_DOUBLE_QUOTE}`],
+      ["em-dash with adjacent separators", `word${sep} - ${sep}word`, `word${sep}${EM_DASH}${sep}word`],
+      ["ellipsis with separator between dots", `a.${sep}.${sep}.`, `a\u2026${sep}${sep}`],
+      ["nbsp before last word with trailing separator", `Hello world${sep}`, `Hello${NBSP}world${sep}`],
+    ])("%s", (_desc, input, expected) => {
+      expect(transform(input, { separator: sep, nbsp: true })).toBe(expected)
+    })
+
+    it("preserves separator count through transform", () => {
+      const input = `${sep}"Hello"${sep} -- ${sep}world${sep}`
+      const result = transform(input, { separator: sep })
+      expect(countSeparators(result, sep)).toBe(countSeparators(input, sep))
+    })
+  })
+
   describe("Unicode preservation", () => {
     it.each([
       ["emoji", '"Hello 👋 World"', `${LEFT_DOUBLE_QUOTE}Hello 👋 World${RIGHT_DOUBLE_QUOTE}`],

--- a/src/tests/utils.test.ts
+++ b/src/tests/utils.test.ts
@@ -10,9 +10,9 @@ describe("assertSeparatorAbsent", () => {
   })
 
   it.each([
-    ["default separator", [`hello${DEFAULT_SEPARATOR}world`], DEFAULT_SEPARATOR, /U\+E000/],
+    ["default separator", [`hello${DEFAULT_SEPARATOR}world`], DEFAULT_SEPARATOR, /U\+E000 U\+E001/],
     ["custom separator", ["hello|world"], "|", /U\+007C/],
-    ["separator in middle element", ["clean", `has${DEFAULT_SEPARATOR}sep`, "also clean"], DEFAULT_SEPARATOR, /separator character/],
+    ["separator in middle element", ["clean", `has${DEFAULT_SEPARATOR}sep`, "also clean"], DEFAULT_SEPARATOR, /separator sequence/],
   ])("throws: %s", (_desc, values, separator, expectedPattern) => {
     expect(() => assertSeparatorAbsent(values, separator)).toThrow(expectedPattern)
   })

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -48,10 +48,12 @@ export function assertSeparatorAbsent(textValues: string[], separator: string): 
   for (const value of textValues) {
     if (!value.includes(separator)) continue
 
-    const codePoint = `U+${separator.codePointAt(0)!.toString(16).toUpperCase().padStart(4, "0")}`
+    const codePoints = [...separator]
+      .map(ch => `U+${ch.codePointAt(0)!.toString(16).toUpperCase().padStart(4, "0")}`)
+      .join(" ")
     throw new Error(
-      `Text contains the separator character ${codePoint} which is used internally by punctilio ` +
-      `to track element boundaries. Pass a different character via the "separator" option.\n` +
+      `Text contains the separator sequence ${codePoints} which is used internally by punctilio ` +
+      `to track element boundaries. Pass a different separator via the "separator" option.\n` +
       `Text: ${formatErrorString(value, "input")}`
     )
   }
@@ -59,8 +61,10 @@ export function assertSeparatorAbsent(textValues: string[], separator: string): 
 
 export function countSeparators(text: string, separator: string = DEFAULT_SEPARATOR): number {
   let count = 0
-  for (const char of text) {
-    if (char === separator) count++
+  let index = 0
+  while ((index = text.indexOf(separator, index)) !== -1) {
+    count++
+    index += separator.length
   }
   return count
 }


### PR DESCRIPTION
## Summary
- Single-char U+E000 collides with CJK fonts, Apple emoji internals, PDF-to-text output, and icon fonts. Switches `DEFAULT_SEPARATOR` to a two-character PUA sequence (U+E000 U+E001) to eliminate false positives.
- All regex patterns, string utilities, and validation updated for multi-character separator support.

## Changes
- **constants.ts**: `DEFAULT_SEPARATOR` → `"\uE000\uE001"`; `getEscapedSeparator` wraps in `(?:...)` for safe quantifier use; `spaceBoundaryStart/End` use alternation instead of character classes
- **utils.ts**: `countSeparators` uses `indexOf` loop for multi-char; `assertSeparatorAbsent` formats all code points in error message
- **index.ts**: Separator validation allows multi-char but rejects empty and non-BMP characters
- **quotes.ts**: Uses `getEscapedSeparator` helper; `convertDoubleQuotes` uses raw form for character classes, grouped for quantifiers; `convertUnmatchedPluralPossessives` walks separator by full length using `startsWith`
- **dashes.ts**: Uses `getEscapedSeparator` helper; removed unused `escape-string-regexp` import
- **nbsp.ts**: `nbspBeforeLastWord` uses alternation and negative lookahead instead of character classes
- **Tests**: Updated validation tests, error message patterns, added behavioral tests for multi-char separator with quotes, dashes, ellipsis, and nbsp

## Testing
- All 1467 tests pass with 100% branch coverage
- Added new behavioral tests exercising multi-char separator across quote, dash, ellipsis, and nbsp transforms
- Separator count preservation verified through transforms

https://claude.ai/code/session_01WzJ2A1LfvQJ7nBBy9QbUcR