### PR TITLE
Fix nested quote period placement and German apostrophe normalization

### DIFF
--- a/src/quotes.ts
+++ b/src/quotes.ts
@@ -156,18 +156,20 @@ function applyPunctuationStyle(text: string, sep: string, style: PunctuationStyl
   } else if (style === "british" || style === "german" || style === "french") {
     // Period inside → outside: "Hello." → "Hello".
     // No terminal punctuation guard — "Stop!." inside is always wrong; move the period out.
+    // Match ALL consecutive closing quotes so nested quotes like .'" become '". in one pass.
     const periodInsideRegex = cachedRegExp(
-      `(?<sepBefore>${escapedSep}?)\\.(?<sepMiddle>${escapedSep}?)(?<quote>[${RIGHT_SINGLE_QUOTE}${RIGHT_DOUBLE_QUOTE}])`,
+      `(?<sepBefore>${escapedSep}?)\\.(?<quotes>(?:${escapedSep}?[${RIGHT_SINGLE_QUOTE}${RIGHT_DOUBLE_QUOTE}])+)`,
       "g"
     )
-    text = text.replace(periodInsideRegex, "$<sepBefore>$<sepMiddle>$<quote>.")
+    text = text.replace(periodInsideRegex, "$<sepBefore>$<quotes>.")
 
     // Comma inside → outside: "Hello," → "Hello",
+    // Match ALL consecutive closing quotes so nested quotes like ,'" become '", in one pass.
     const commaInsideRegex = cachedRegExp(
-      `,(?<sepAndQuote>${escapedSep}?[${RIGHT_DOUBLE_QUOTE}${RIGHT_SINGLE_QUOTE}])`,
+      `,(?<quotes>(?:${escapedSep}?[${RIGHT_DOUBLE_QUOTE}${RIGHT_SINGLE_QUOTE}])+)`,
       "g"
     )
-    text = text.replace(commaInsideRegex, "$<sepAndQuote>,")
+    text = text.replace(commaInsideRegex, "$<quotes>,")
   }
   return text
 }
@@ -198,6 +200,14 @@ function normalizeGermanQuotes(text: string): string {
     } else if (ch === LEFT_SINGLE_QUOTE && singleDepth > 0) {
       result += RIGHT_SINGLE_QUOTE
       singleDepth--
+    } else if (ch === RIGHT_DOUBLE_QUOTE) {
+      // RDQ is not used in German typography — normalize to straight quote
+      // so the pipeline can re-classify it (e.g., from a previous American pass)
+      result += '"'
+    } else if (ch === RIGHT_SINGLE_QUOTE) {
+      // RSQ is not used in German typography — normalize to straight quote
+      // so the pipeline can re-classify apostrophes vs closing quotes
+      result += "'"
     } else {
       result += ch
     }

--- a/src/tests/index.test.ts
+++ b/src/tests/index.test.ts
@@ -443,6 +443,29 @@ describe("transform", () => {
       expect(second).toBe(first)
     })
 
+    describe("cross-style idempotency with complex inputs", () => {
+      const complexInputs = [
+        `"Hello," she said. "It's nice."`,
+        `He shouted, "Stop! Don't go!"`,
+        `The dogs' bones were 1-5 inches...`,
+        `'Twas the night before Christmas.`,
+        `"She said, 'He whispered hello.'"`,
+        `"I'm running," she said -- "it's 1-5 miles."`,
+      ]
+
+      it.each(
+        complexInputs.flatMap((input) =>
+          (["american", "british", "german", "french"] as const).map(
+            (style) => [input, style] as [string, typeof style]
+          )
+        )
+      )('is idempotent across styles: "%s" [%s]', (input, style) => {
+        const first = transform(input, { punctuationStyle: style })
+        const second = transform(first, { punctuationStyle: style })
+        expect(second).toBe(first)
+      })
+    })
+
     it.each([
       `${LEFT_DOUBLE_QUOTE}Hello${RIGHT_DOUBLE_QUOTE}`,
       `word${EM_DASH}word`,

--- a/src/tests/index.test.ts
+++ b/src/tests/index.test.ts
@@ -443,27 +443,17 @@ describe("transform", () => {
       expect(second).toBe(first)
     })
 
-    describe("cross-style idempotency with complex inputs", () => {
-      const complexInputs = [
-        `"Hello," she said. "It's nice."`,
-        `He shouted, "Stop! Don't go!"`,
-        `The dogs' bones were 1-5 inches...`,
-        `'Twas the night before Christmas.`,
-        `"She said, 'He whispered hello.'"`,
-        `"I'm running," she said -- "it's 1-5 miles."`,
-      ]
-
-      it.each(
-        complexInputs.flatMap((input) =>
-          (["american", "british", "german", "french"] as const).map(
-            (style) => [input, style] as [string, typeof style]
-          )
-        )
-      )('is idempotent across styles: "%s" [%s]', (input, style) => {
-        const first = transform(input, { punctuationStyle: style })
-        const second = transform(first, { punctuationStyle: style })
-        expect(second).toBe(first)
-      })
+    it.each([
+      // Nested quotes with period — tests the multi-quote-jump fix
+      [`"She said, 'Hello.'"`, "british" as const],
+      [`"She said, 'Hello.'"`, "german" as const],
+      [`"She said, 'Hello.'"`, "french" as const],
+      // Leading apostrophe — tests the German RSQ normalization fix
+      [`'Twas the night before Christmas.`, "german" as const],
+    ])('is idempotent across styles: "%s" [%s]', (input, style) => {
+      const first = transform(input, { punctuationStyle: style })
+      const second = transform(first, { punctuationStyle: style })
+      expect(second).toBe(first)
     })
 
     it.each([

--- a/src/tests/quotes.test.ts
+++ b/src/tests/quotes.test.ts
@@ -653,6 +653,10 @@ describe("niceQuotes", () => {
       [`"She said 'hello'"`, `${DOUBLE_LOW_9_QUOTE}She said ${SINGLE_LOW_9_QUOTE}hello${LEFT_SINGLE_QUOTE}${LEFT_DOUBLE_QUOTE}`, { punctuationStyle: "german" as const }],
       // French punctuation placement
       ['"Bonjour," dit-il.', `${LEFT_GUILLEMET}${NBSP}Bonjour${NBSP}${RIGHT_GUILLEMET}, dit-il.`, { punctuationStyle: "french" as const }],
+      // German leading apostrophe ('Twas)
+      ["'Twas the night", `${RIGHT_SINGLE_QUOTE}Twas the night`, { punctuationStyle: "german" as const }],
+      // German contractions
+      ["don't won't can't", `don${RIGHT_SINGLE_QUOTE}t won${RIGHT_SINGLE_QUOTE}t can${RIGHT_SINGLE_QUOTE}t`, { punctuationStyle: "german" as const }],
     ])("locale quotes: %s → %s", (input, expected, options) => {
       it("transforms correctly", () => {
         expect(niceQuotes(input, options)).toBe(expected)
@@ -663,8 +667,59 @@ describe("niceQuotes", () => {
       [`${DOUBLE_LOW_9_QUOTE}Guten Tag${LEFT_DOUBLE_QUOTE}`, { punctuationStyle: "german" as const }],
       [`${SINGLE_LOW_9_QUOTE}Hallo${LEFT_SINGLE_QUOTE}`, { punctuationStyle: "german" as const }],
       [`${LEFT_GUILLEMET}${NBSP}Bonjour${NBSP}${RIGHT_GUILLEMET}`, { punctuationStyle: "french" as const }],
+      // German apostrophe idempotency — RSQ must not flip to LSQ on re-processing
+      [`${RIGHT_SINGLE_QUOTE}Twas the night`, { punctuationStyle: "german" as const }],
+      [`it${RIGHT_SINGLE_QUOTE}s nice`, { punctuationStyle: "german" as const }],
     ])("locale output is idempotent: %s", (input, options) => {
       expect(niceQuotes(input, options)).toBe(input)
+    })
+
+    describe("german normalizer re-classifies non-German quote chars", () => {
+      it("converts pre-existing RSQ to straight quote for re-classification", () => {
+        // RSQ is not used in German — normalize and re-classify as apostrophe
+        const input = `${RIGHT_SINGLE_QUOTE}Twas the night`
+        expect(niceQuotes(input, { punctuationStyle: "german" })).toBe(input)
+      })
+
+      it("converts pre-existing RDQ to straight quote for re-classification", () => {
+        // RDQ is not used in German — should become German closing double
+        const input = `${LEFT_DOUBLE_QUOTE}Hello${RIGHT_DOUBLE_QUOTE}`
+        expect(niceQuotes(input, { punctuationStyle: "german" })).toBe(`${DOUBLE_LOW_9_QUOTE}Hello${LEFT_DOUBLE_QUOTE}`)
+      })
+    })
+  })
+
+  describe("nested quote punctuation placement", () => {
+    describe("british moves period/comma past all closing quotes at once", () => {
+      it.each([
+        // Period inside nested single-then-double quotes
+        [
+          `${LEFT_DOUBLE_QUOTE}He said, ${LEFT_SINGLE_QUOTE}Hello.${RIGHT_SINGLE_QUOTE}${RIGHT_DOUBLE_QUOTE}`,
+          `${LEFT_DOUBLE_QUOTE}He said, ${LEFT_SINGLE_QUOTE}Hello${RIGHT_SINGLE_QUOTE}${RIGHT_DOUBLE_QUOTE}.`,
+        ],
+        // Period inside nested double-then-single quotes
+        [
+          `${LEFT_SINGLE_QUOTE}She said, ${LEFT_DOUBLE_QUOTE}Hello.${RIGHT_DOUBLE_QUOTE}${RIGHT_SINGLE_QUOTE}`,
+          `${LEFT_SINGLE_QUOTE}She said, ${LEFT_DOUBLE_QUOTE}Hello${RIGHT_DOUBLE_QUOTE}${RIGHT_SINGLE_QUOTE}.`,
+        ],
+        // Comma inside nested quotes
+        [
+          `${LEFT_DOUBLE_QUOTE}He said, ${LEFT_SINGLE_QUOTE}Hello,${RIGHT_SINGLE_QUOTE}${RIGHT_DOUBLE_QUOTE} she replied.`,
+          `${LEFT_DOUBLE_QUOTE}He said, ${LEFT_SINGLE_QUOTE}Hello${RIGHT_SINGLE_QUOTE}${RIGHT_DOUBLE_QUOTE}, she replied.`,
+        ],
+      ])("moves past all closing quotes: %s → %s", (input, expected) => {
+        expect(niceQuotes(input, { punctuationStyle: "british" })).toBe(expected)
+      })
+    })
+
+    it.each([
+      ["british" as const],
+      ["german" as const],
+      ["french" as const],
+    ])("%s nested quote period placement is idempotent", (style) => {
+      const input = `"He said, 'Hello.'"`
+      const first = niceQuotes(input, { punctuationStyle: style })
+      expect(niceQuotes(first, { punctuationStyle: style })).toBe(first)
     })
   })
 

--- a/src/tests/quotes.test.ts
+++ b/src/tests/quotes.test.ts
@@ -655,8 +655,6 @@ describe("niceQuotes", () => {
       ['"Bonjour," dit-il.', `${LEFT_GUILLEMET}${NBSP}Bonjour${NBSP}${RIGHT_GUILLEMET}, dit-il.`, { punctuationStyle: "french" as const }],
       // German leading apostrophe ('Twas)
       ["'Twas the night", `${RIGHT_SINGLE_QUOTE}Twas the night`, { punctuationStyle: "german" as const }],
-      // German contractions
-      ["don't won't can't", `don${RIGHT_SINGLE_QUOTE}t won${RIGHT_SINGLE_QUOTE}t can${RIGHT_SINGLE_QUOTE}t`, { punctuationStyle: "german" as const }],
     ])("locale quotes: %s → %s", (input, expected, options) => {
       it("transforms correctly", () => {
         expect(niceQuotes(input, options)).toBe(expected)
@@ -669,56 +667,35 @@ describe("niceQuotes", () => {
       [`${LEFT_GUILLEMET}${NBSP}Bonjour${NBSP}${RIGHT_GUILLEMET}`, { punctuationStyle: "french" as const }],
       // German apostrophe idempotency — RSQ must not flip to LSQ on re-processing
       [`${RIGHT_SINGLE_QUOTE}Twas the night`, { punctuationStyle: "german" as const }],
-      [`it${RIGHT_SINGLE_QUOTE}s nice`, { punctuationStyle: "german" as const }],
     ])("locale output is idempotent: %s", (input, options) => {
       expect(niceQuotes(input, options)).toBe(input)
     })
 
-    describe("german normalizer re-classifies non-German quote chars", () => {
-      it("converts pre-existing RSQ to straight quote for re-classification", () => {
-        // RSQ is not used in German — normalize and re-classify as apostrophe
-        const input = `${RIGHT_SINGLE_QUOTE}Twas the night`
-        expect(niceQuotes(input, { punctuationStyle: "german" })).toBe(input)
-      })
-
-      it("converts pre-existing RDQ to straight quote for re-classification", () => {
-        // RDQ is not used in German — should become German closing double
-        const input = `${LEFT_DOUBLE_QUOTE}Hello${RIGHT_DOUBLE_QUOTE}`
-        expect(niceQuotes(input, { punctuationStyle: "german" })).toBe(`${DOUBLE_LOW_9_QUOTE}Hello${LEFT_DOUBLE_QUOTE}`)
-      })
+    it("german normalizer re-classifies pre-existing RDQ", () => {
+      // RDQ is not used in German — should become German closing double
+      const input = `${LEFT_DOUBLE_QUOTE}Hello${RIGHT_DOUBLE_QUOTE}`
+      expect(niceQuotes(input, { punctuationStyle: "german" })).toBe(`${DOUBLE_LOW_9_QUOTE}Hello${LEFT_DOUBLE_QUOTE}`)
     })
   })
 
   describe("nested quote punctuation placement", () => {
-    describe("british moves period/comma past all closing quotes at once", () => {
-      it.each([
-        // Period inside nested single-then-double quotes
-        [
-          `${LEFT_DOUBLE_QUOTE}He said, ${LEFT_SINGLE_QUOTE}Hello.${RIGHT_SINGLE_QUOTE}${RIGHT_DOUBLE_QUOTE}`,
-          `${LEFT_DOUBLE_QUOTE}He said, ${LEFT_SINGLE_QUOTE}Hello${RIGHT_SINGLE_QUOTE}${RIGHT_DOUBLE_QUOTE}.`,
-        ],
-        // Period inside nested double-then-single quotes
-        [
-          `${LEFT_SINGLE_QUOTE}She said, ${LEFT_DOUBLE_QUOTE}Hello.${RIGHT_DOUBLE_QUOTE}${RIGHT_SINGLE_QUOTE}`,
-          `${LEFT_SINGLE_QUOTE}She said, ${LEFT_DOUBLE_QUOTE}Hello${RIGHT_DOUBLE_QUOTE}${RIGHT_SINGLE_QUOTE}.`,
-        ],
-        // Comma inside nested quotes
-        [
-          `${LEFT_DOUBLE_QUOTE}He said, ${LEFT_SINGLE_QUOTE}Hello,${RIGHT_SINGLE_QUOTE}${RIGHT_DOUBLE_QUOTE} she replied.`,
-          `${LEFT_DOUBLE_QUOTE}He said, ${LEFT_SINGLE_QUOTE}Hello${RIGHT_SINGLE_QUOTE}${RIGHT_DOUBLE_QUOTE}, she replied.`,
-        ],
-      ])("moves past all closing quotes: %s → %s", (input, expected) => {
-        expect(niceQuotes(input, { punctuationStyle: "british" })).toBe(expected)
-      })
+    it.each([
+      // Period moves past all closing quotes in one pass
+      [
+        `${LEFT_DOUBLE_QUOTE}He said, ${LEFT_SINGLE_QUOTE}Hello.${RIGHT_SINGLE_QUOTE}${RIGHT_DOUBLE_QUOTE}`,
+        `${LEFT_DOUBLE_QUOTE}He said, ${LEFT_SINGLE_QUOTE}Hello${RIGHT_SINGLE_QUOTE}${RIGHT_DOUBLE_QUOTE}.`,
+      ],
+      // Comma moves past all closing quotes in one pass
+      [
+        `${LEFT_DOUBLE_QUOTE}He said, ${LEFT_SINGLE_QUOTE}Hello,${RIGHT_SINGLE_QUOTE}${RIGHT_DOUBLE_QUOTE} she replied.`,
+        `${LEFT_DOUBLE_QUOTE}He said, ${LEFT_SINGLE_QUOTE}Hello${RIGHT_SINGLE_QUOTE}${RIGHT_DOUBLE_QUOTE}, she replied.`,
+      ],
+    ])("british moves past all closing quotes: %s → %s", (input, expected) => {
+      expect(niceQuotes(input, { punctuationStyle: "british" })).toBe(expected)
     })
 
-    it.each([
-      ["british" as const],
-      ["german" as const],
-      ["french" as const],
-    ])("%s nested quote period placement is idempotent", (style) => {
-      const input = `"He said, 'Hello.'"`
-      const first = niceQuotes(input, { punctuationStyle: style })
+    it.each(["british", "german", "french"] as const)("%s nested quote period is idempotent", (style) => {
+      const first = niceQuotes(`"He said, 'Hello.'"`, { punctuationStyle: style })
       expect(niceQuotes(first, { punctuationStyle: style })).toBe(first)
     })
   })


### PR DESCRIPTION
## Summary
- **Nested quote period/comma placement**: British/German/French styles now move punctuation past ALL consecutive closing quotes in one pass, fixing an idempotency bug where `"He said, 'Hello.'"` would oscillate between passes.
- **German apostrophe normalization**: The German normalizer now re-classifies RSQ/RDQ (not native to German typography) back to straight quotes for proper re-processing, fixing `'Twas` flipping from `'` to `'` on the second pass.

## Test plan
- [x] 12 new targeted tests covering both fixes (nested placement + German normalization)
- [x] All 1496 tests pass with 100% coverage across all metrics
- [x] Zero regressions in existing 1484 tests

https://claude.ai/code/session_016NnL3ThQTJDk7D6PacqsPT