### PR TITLE
Support double and triple dashes in number ranges

### DIFF
--- a/src/dashes.ts
+++ b/src/dashes.ts
@@ -49,9 +49,9 @@ export function enDashNumberRange(text: string, options: DashOptions = {}): stri
   const moreSegments = `(?<following>(?:${chr}?[-${MINUS}]${chr}?\\d+)*)` // -4567 in phone numbers
   const unitSuffix = `(?<suffix>${chr}?(?:[AaPp][Mm]|[xKBTM]))?`         // am/pm, K/M/B
 
-  // Positive ranges: 1-5, $100-$200, €5-€10, p.10-15
+  // Positive ranges: 1-5, 5--10, $100-$200, €5-€10, p.10-15
   const positiveRangePattern = [
-    phoneAreaCode, wb, notAfterDash, rangeStart, "-", rangeEnd, moreSegments, unitSuffix, wbe
+    phoneAreaCode, wb, notAfterDash, rangeStart, "-{1,3}", rangeEnd, moreSegments, unitSuffix, wbe
   ].join("")
 
   text = text.replace(
@@ -75,7 +75,7 @@ export function enDashNumberRange(text: string, options: DashOptions = {}): stri
   // Separate regex because MINUS isn't a word char, so \b in ${wb} would match after it
   text = text.replace(
     cachedRegExp(
-      `(?<![${LATIN_LETTERS}])(?<start>${MINUS}\\d[\\d.,]*${chr}?)-(?<neg>-)?(?<end>${chr}?\\d[\\d.,]*)(?<following>(?:${chr}?-${chr}?\\d+)*)(?<suffix>${chr}?[xKBTM])?${wbe}`,
+      `(?<![${LATIN_LETTERS}])(?<start>${MINUS}\\d[\\d.,]*${chr}?)-{1,3}?(?<neg>-)?(?<end>${chr}?\\d[\\d.,]*)(?<following>(?:${chr}?-${chr}?\\d+)*)(?<suffix>${chr}?[xKBTM])?${wbe}`,
       "g"
     ),
     (match, start, neg, end, following, suffix = "") => {
@@ -221,8 +221,8 @@ export function hyphenReplace(text: string, options: DashOptions = {}): string {
   if (style === "none") return text
   text = minusReplace(text, options)
   text = enDashDateRange(text, options)
+  text = enDashNumberRange(text, options)
   text = convertParentheticalDashes(text, sep, style)
   if (style === "american") text = normalizeEmDashSpacing(text, sep)
-  text = enDashNumberRange(text, options)
   return text
 }

--- a/src/tests/dashes.test.ts
+++ b/src/tests/dashes.test.ts
@@ -106,6 +106,7 @@ describe("hyphenReplace", () => {
   describe("number ranges to en dashes", () => {
     it.each([
       ["Pages 1-5", `Pages 1${EN_DASH}5`],
+      ["5--10", `5${EN_DASH}10`],
       ["2000-2020", `2000${EN_DASH}2020`],
       ["2018-2021. Then 1-3", `2018${EN_DASH}2021. Then 1${EN_DASH}3`],
       ["p.10-15", `p.10${EN_DASH}15`],
@@ -186,6 +187,9 @@ describe("enDashNumberRange", () => {
     ["$100-$200", `$100${EN_DASH}$200`],
     ["$1.50-$3.50", `$1.50${EN_DASH}$3.50`],
     ["$1-3", `$1${EN_DASH}3`],
+    ["5--10", `5${EN_DASH}10`], // Double dash as range separator
+    ["5---10", `5${EN_DASH}10`], // Triple dash as range separator
+    ["$100--$200", `$100${EN_DASH}$200`], // Double dash with currency
     ["1 - 2", "1 - 2"], // Spaced ranges should not change
     // Multiplier suffixes
     ["1-10x", `1${EN_DASH}10x`], // lowercase x for multiplier


### PR DESCRIPTION
## Summary
This PR extends the number range detection to support double (`--`) and triple (`---`) dashes as range separators, in addition to single dashes. This is useful for cases where users may type multiple dashes instead of a single dash when specifying ranges.

## Key Changes
- Updated `enDashNumberRange()` regex patterns to match 1-3 consecutive dashes (`-{1,3}` and `-{1,3}?`) instead of just single dashes
- Reordered function calls in `hyphenReplace()` to process `enDashNumberRange()` before `convertParentheticalDashes()`, ensuring proper dash normalization order
- Added test cases for double and triple dash scenarios:
  - `5--10` → `5–10`
  - `5---10` → `5–10`
  - `$100--$200` → `$100–$200`

## Implementation Details
- Modified two regex patterns in `enDashNumberRange()`:
  - Positive range pattern: changed `-` to `-{1,3}`
  - Negative number range pattern: changed `-` to `-{1,3}?` (non-greedy to properly handle negative numbers)
- The function call reordering in `hyphenReplace()` ensures that multiple consecutive dashes are normalized to en dashes before other dash transformations occur

https://claude.ai/code/session_018urRe6hj7naVbydWd68fBM