### PR TITLE
Add live demo link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Lint](https://github.com/alexander-turner/punctilio/actions/workflows/lint.yml/badge.svg)](https://github.com/alexander-turner/punctilio/actions/workflows/lint.yml)
 [![Coverage](https://img.shields.io/badge/coverage-100%25-brightgreen)](https://github.com/alexander-turner/punctilio)
 
-Pretty good at making your text pretty. The most feature-complete and reliable English typography package. `punctilio` transforms plain ASCII into typographically correct Unicode, even across HTML element boundaries.
+Pretty good at making your text pretty. The most feature-complete and reliable English typography package. `punctilio` transforms plain ASCII into typographically correct Unicode, even across HTML element boundaries. Try it live at [turntrout.com/punctilio](https://turntrout.com/punctilio).
 
 **Smart quotes** · **Em/en dashes** · **Ellipses** · **Math symbols** · **Legal symbols** · **Arrows** · **Primes** · **Fractions** · **Superscripts** · **Ligatures** · **Non-breaking spaces** · **HTML-aware** · **Markdown support** · **Bri’ish, German, and French localisation support**
 


### PR DESCRIPTION
## Summary
Updated the README to include a link to the live demo of punctilio.

## Changes
- Added a reference to the live demo at [turntrout.com/punctilio](https://turntrout.com/punctilio) in the main description paragraph, making it easier for users to try the tool before diving into the documentation.

## Details
This is a documentation-only change that improves discoverability of the interactive demo by prominently featuring it in the project's README introduction.

https://claude.ai/code/session_01JD4T163i4r8tTgcv5bre7V