### PR TITLE
Fix quoted punctuation handling in double quote conversion

### DIFF
--- a/src/quotes.ts
+++ b/src/quotes.ts
@@ -107,6 +107,29 @@ function convertUnmatchedPluralPossessives(text: string, sep: string): string {
   )
 }
 
+/** Build the beginning-double-quote regex pattern from named fragments. */
+function buildBeginningDoublePattern(escapedSep: string, rawEscSep: string): string {
+  const lookbehind = `(?<=^|[\\s\\(\\/\\[\\{\\-${EM_DASH}]|${escapedSep})`
+  const beforeCapture = `(?<beforeChr>${escapedSep}?)`
+  const quote = `["]`
+
+  // Characters that normally signal an ending-quote position
+  const endingChars = `\\s\\)${EM_DASH},!?;:.\\}${rawEscSep}`
+
+  const afterAlternatives = [
+    // Separator followed by space/period/comma (consumed into afterChr)
+    `(?<sepWithPunct>${escapedSep}[ .,])`,
+    // Three-period ellipsis or a character that isn't ending punctuation
+    `(?=${escapedSep}?\\.{3}|${escapedSep}?[^${endingChars}])`,
+    // Content followed by a matching closing straight quote — handles
+    // quoted punctuation like "?" and "!" where the first char after the
+    // opening quote would otherwise look like an ending-quote context
+    `(?=[^"\\n]{1,50}")`,
+  ]
+
+  return `${lookbehind}${beforeCapture}${quote}(?<afterChr>${afterAlternatives.join("|")})`
+}
+
 /** Convert straight double quotes to curly quotes */
 function convertDoubleQuotes(text: string, sep: string): string {
   const rawEscSep = escapeStringRegexp(sep)
@@ -118,10 +141,7 @@ function convertDoubleQuotes(text: string, sep: string): string {
   // Handle whitespace-only quotes " " - require non-quote chars on both sides
   text = text.replace(/(?<=^|[\s([{])"(?<whitespace>\s+)"(?=$|[\s)\]}.!?,;:])/g, `${LEFT_DOUBLE_QUOTE}$<whitespace>${RIGHT_DOUBLE_QUOTE}`)
 
-  const beginningDouble = cachedRegExp(
-    `(?<=^|[\\s\\(\\/\\[\\{\\-${EM_DASH}]|${escapedSep})(?<beforeChr>${escapedSep}?)["](?<afterChr>(?<sepWithPunct>${escapedSep}[ .,])|(?=${escapedSep}?\\.{3}|${escapedSep}?[^\\s\\)${EM_DASH},!?;:.\\}${rawEscSep}]))`,
-    "gm"
-  )
+  const beginningDouble = cachedRegExp(buildBeginningDoublePattern(escapedSep, rawEscSep), "gm")
   text = text.replace(beginningDouble, `$<beforeChr>${LEFT_DOUBLE_QUOTE}$<afterChr>`)
 
   text = text.replace(cachedRegExp(`(?<=\\{)(?<sepSpace>${escapedSep}? )?["]`, "g"), `$<sepSpace>${LEFT_DOUBLE_QUOTE}`)

--- a/src/quotes.ts
+++ b/src/quotes.ts
@@ -109,13 +109,6 @@ function convertUnmatchedPluralPossessives(text: string, sep: string): string {
 
 /**
  * Build the beginning-double-quote regex pattern from named fragments.
- *
- * Unlike the single-quote pattern (which can use a simple `\S` lookahead),
- * the double-quote lookbehind accepts the separator itself as a trigger.
- * This creates ambiguity: `word${sep}"—` (closing quote after an HTML
- * boundary) would wrongly match `\S` on `—`. The exclusion list resolves
- * this, and the closing-quote override handles legitimate short-quoted
- * punctuation like `"?"` and `"!"`.
  */
 function buildBeginningDoublePattern(escapedSep: string, rawEscSep: string): string {
   const lookbehind = `(?<=^|[\\s\\(\\/\\[\\{\\-${EM_DASH}]|${escapedSep})`

--- a/src/quotes.ts
+++ b/src/quotes.ts
@@ -107,13 +107,22 @@ function convertUnmatchedPluralPossessives(text: string, sep: string): string {
   )
 }
 
-/** Build the beginning-double-quote regex pattern from named fragments. */
+/**
+ * Build the beginning-double-quote regex pattern from named fragments.
+ *
+ * Unlike the single-quote pattern (which can use a simple `\S` lookahead),
+ * the double-quote lookbehind accepts the separator itself as a trigger.
+ * This creates ambiguity: `word${sep}"—` (closing quote after an HTML
+ * boundary) would wrongly match `\S` on `—`. The exclusion list resolves
+ * this, and the closing-quote override handles legitimate short-quoted
+ * punctuation like `"?"` and `"!"`.
+ */
 function buildBeginningDoublePattern(escapedSep: string, rawEscSep: string): string {
   const lookbehind = `(?<=^|[\\s\\(\\/\\[\\{\\-${EM_DASH}]|${escapedSep})`
   const beforeCapture = `(?<beforeChr>${escapedSep}?)`
   const quote = `["]`
 
-  // Characters that normally signal an ending-quote position
+  // Characters that signal an ending-quote position (not valid openers)
   const endingChars = `\\s\\)${EM_DASH},!?;:.\\}${rawEscSep}`
 
   const afterAlternatives = [
@@ -124,7 +133,7 @@ function buildBeginningDoublePattern(escapedSep: string, rawEscSep: string): str
     // Content followed by a matching closing straight quote — handles
     // quoted punctuation like "?" and "!" where the first char after the
     // opening quote would otherwise look like an ending-quote context
-    `(?=[^"\\n]{1,50}")`,
+    `(?=[^"]{1,50}")`,
   ]
 
   return `${lookbehind}${beforeCapture}${quote}(?<afterChr>${afterAlternatives.join("|")})`

--- a/src/quotes.ts
+++ b/src/quotes.ts
@@ -113,7 +113,6 @@ function convertUnmatchedPluralPossessives(text: string, sep: string): string {
 function buildBeginningDoublePattern(escapedSep: string, rawEscSep: string): string {
   const lookbehind = `(?<=^|[\\s\\(\\/\\[\\{\\-${EM_DASH}]|${escapedSep})`
   const beforeCapture = `(?<beforeChr>${escapedSep}?)`
-  const quote = `["]`
 
   // Characters that signal an ending-quote position (not valid openers)
   const endingChars = `\\s\\)${EM_DASH},!?;:.\\}${rawEscSep}`
@@ -129,7 +128,7 @@ function buildBeginningDoublePattern(escapedSep: string, rawEscSep: string): str
     `(?=[^"]{1,50}")`,
   ]
 
-  return `${lookbehind}${beforeCapture}${quote}(?<afterChr>${afterAlternatives.join("|")})`
+  return `${lookbehind}${beforeCapture}["](?<afterChr>${afterAlternatives.join("|")})`
 }
 
 /** Convert straight double quotes to curly quotes */

--- a/src/quotes.ts
+++ b/src/quotes.ts
@@ -260,8 +260,13 @@ function applyFrenchQuotes(text: string): string {
     .replaceAll(RIGHT_DOUBLE_QUOTE, `${UNICODE_SYMBOLS.NBSP}${UNICODE_SYMBOLS.RIGHT_GUILLEMET}`)
 }
 
+interface LocaleQuoteTransform {
+  normalize: (text: string) => string
+  apply: (text: string) => string
+}
+
 /** Locale-specific normalize (pre-pipeline) and apply (post-pipeline) functions. */
-const localeQuoteTransforms: Partial<Record<PunctuationStyle, { normalize: (t: string) => string; apply: (t: string) => string }>> = {
+const localeQuoteTransforms: Partial<Record<PunctuationStyle, LocaleQuoteTransform>> = {
   german: { normalize: normalizeGermanQuotes, apply: applyGermanQuotes },
   french: { normalize: normalizeFrenchQuotes, apply: applyFrenchQuotes },
 }

--- a/src/rehype.ts
+++ b/src/rehype.ts
@@ -16,6 +16,12 @@ import { transform, type TransformOptions } from "./index.js"
 import { DEFAULT_SEPARATOR } from "./constants.js"
 import { assertSeparatorAbsent, formatErrorString } from "./utils.js"
 
+/** Predicate that decides whether an HTML element should be skipped during transformation. */
+type ElementPredicate = (node: Element) => boolean
+
+/** Function that transforms a plain-text string (e.g. smart quotes, dashes). */
+type TextTransformer = (input: string) => string
+
 /**
  * Options for the rehype-punctilio plugin.
  */
@@ -66,7 +72,7 @@ function hasClass(node: Element, className: string): boolean {
  */
 function hasAncestor(
   ancestors: Parent[],
-  predicate: (node: Element) => boolean
+  predicate: ElementPredicate
 ): boolean {
   return ancestors.some((ancestor) => {
     if (ancestor.type === "element") {
@@ -91,7 +97,7 @@ function hasAncestor(
  */
 export function flattenTextNodes(
   node: Element | ElementContent,
-  shouldSkip: (n: Element) => boolean,
+  shouldSkip: ElementPredicate,
   depth: number = 0
 ): Text[] {
   if (depth > MAX_RECURSION_DEPTH) {
@@ -128,7 +134,7 @@ export function flattenTextNodes(
  */
 export function getTextContent(
   node: Element,
-  shouldSkip: (n: Element) => boolean = () => false
+  shouldSkip: ElementPredicate = () => false
 ): string {
   return flattenTextNodes(node, shouldSkip)
     .map((n) => n.value)
@@ -241,8 +247,8 @@ export function assertSmartQuotesMatch(input: string): void {
  */
 export function transformElement(
   node: Element,
-  transformFn: (input: string) => string,
-  shouldSkip: (input: Element) => boolean,
+  transformFn: TextTransformer,
+  shouldSkip: ElementPredicate,
   separator: string,
   checkInvariance: boolean = false
 ): void {
@@ -365,7 +371,7 @@ const TRANSFORMABLE_ELEMENTS = [
  */
 export function collectTransformableElements(
   node: Element,
-  shouldSkip: (n: Element) => boolean,
+  shouldSkip: ElementPredicate,
   depth: number = 0
 ): Element[] {
   /* istanbul ignore if -- defensive: prevents stack overflow from malicious HTML */

--- a/src/symbols.ts
+++ b/src/symbols.ts
@@ -92,11 +92,14 @@ export function multiplication(text: string, options: SymbolOptions = {}): strin
   return text
 }
 
+/** [leftChars, rightChars, negativeLookahead, replacement] */
+type MathSymbolRule = [string, string, string, string]
+
 /**
- * Math symbol replacement map: [left char(s), right char(s), negative lookahead, replacement].
+ * Math symbol replacement map.
  * The separator is inserted between left and right when building the regex.
  */
-const MATH_SYMBOL_MAP: [string, string, string, string][] = [
+const MATH_SYMBOL_MAP: MathSymbolRule[] = [
   ["!", "=", "(?!=)", NOT_EQUAL],
   ["\\+/", "-", "", PLUS_MINUS],
   ["\\+", "-", "", PLUS_MINUS],
@@ -117,6 +120,9 @@ export function mathSymbols(text: string, options: SymbolOptions = {}): string {
   return text
 }
 
+/** Predicate that decides whether a legal symbol should be converted based on surrounding text. */
+type ContextPredicate = (before: string, after: string) => boolean
+
 /**
  * Context-aware replacement for legal symbols like (c), (r), (tm).
  * Extracts surrounding text and delegates the convert/skip decision to a predicate.
@@ -125,7 +131,7 @@ function contextAwareLegalReplace(
   text: string,
   pattern: RegExp,
   replacement: string,
-  shouldConvert: (before: string, after: string) => boolean,
+  shouldConvert: ContextPredicate,
 ): string {
   return text.replace(pattern, (match: string, offset: number, str: string) => {
     const before = str.slice(Math.max(0, offset - 25), offset)
@@ -152,8 +158,11 @@ export function legalSymbols(text: string): string {
   return text
 }
 
+/** [asciiPattern, unicodeSymbol] */
+type ArrowRule = [string, string]
+
 /** Arrow pattern map: arrow shape → Unicode symbol */
-const ARROW_MAP: [string, string][] = [
+const ARROW_MAP: ArrowRule[] = [
   [`<-+${"%CHR%"}?>`, ARROW_LEFT_RIGHT], // Bidirectional: <-> or <-->
   ["-+>", ARROW_RIGHT],                   // Right: -> or -->
   ["<-+", ARROW_LEFT],                    // Left: <- or <--
@@ -293,11 +302,14 @@ export function primeMarks(text: string, options: SymbolOptions = {}): string {
   return text
 }
 
+/** [numerator, denominator, unicodeChar] */
+type FractionRule = [string, string, string]
+
 /**
- * Supported Unicode fractions: [numerator, denominator, unicode character].
+ * Supported Unicode fractions.
  * The regex alternation and lookup map are both derived from this list.
  */
-const FRACTION_TUPLES: [string, string, string][] = [
+const FRACTION_TUPLES: FractionRule[] = [
   ["1", "4", UNICODE_SYMBOLS.FRACTION_1_4],
   ["1", "2", UNICODE_SYMBOLS.FRACTION_1_2],
   ["3", "4", UNICODE_SYMBOLS.FRACTION_3_4],
@@ -381,12 +393,15 @@ export function collapseSpaces(text: string): string {
   })
 }
 
+/** [firstChar, repeatedChar, replacement] */
+type LigatureRule = [string, string, string]
+
 /**
- * Punctuation ligature map: [first char, repeated char, replacement]
+ * Punctuation ligature map.
  * Pattern: first(sep)?repeated(?:sep?repeated)* → replacement
  * Order matters: handle mixed punctuation first, then repeated
  */
-const PUNCTUATION_LIGATURE_MAP: [string, string, string][] = [
+const PUNCTUATION_LIGATURE_MAP: LigatureRule[] = [
   ["\\?", "!", QUESTION_EXCLAMATION],  // ?!+ → ⁈
   ["!", "\\?", EXCLAMATION_QUESTION],  // !?+ → ⁉
   ["\\?", "\\?", DOUBLE_QUESTION],     // ??+ → ⁇

--- a/src/tests/quotes.test.ts
+++ b/src/tests/quotes.test.ts
@@ -59,6 +59,22 @@ describe("niceQuotes", () => {
     })
   })
 
+  describe("quoted punctuation (short strings of punctuation inside quotes)", () => {
+    it.each([
+      ['"?"', `${LEFT_DOUBLE_QUOTE}?${RIGHT_DOUBLE_QUOTE}`],
+      ['"!"', `${LEFT_DOUBLE_QUOTE}!${RIGHT_DOUBLE_QUOTE}`],
+      ['"."', `${LEFT_DOUBLE_QUOTE}.${RIGHT_DOUBLE_QUOTE}`],
+      ['","', `${LEFT_DOUBLE_QUOTE},${RIGHT_DOUBLE_QUOTE}`],
+      ['";"', `${LEFT_DOUBLE_QUOTE};${RIGHT_DOUBLE_QUOTE}`],
+      ['"?!"', `${LEFT_DOUBLE_QUOTE}?!${RIGHT_DOUBLE_QUOTE}`],
+      ['why not "?"', `why not ${LEFT_DOUBLE_QUOTE}?${RIGHT_DOUBLE_QUOTE}`],
+      ['She asked "?" and left.', `She asked ${LEFT_DOUBLE_QUOTE}?${RIGHT_DOUBLE_QUOTE} and left.`],
+      ['("?")', `(${LEFT_DOUBLE_QUOTE}?${RIGHT_DOUBLE_QUOTE})`],
+    ])('handles quoted punctuation: "%s"', (input, expected) => {
+      expect(classifyApostrophes(input)).toBe(expected)
+    })
+  })
+
   describe("single quotes and apostrophes", () => {
     it.each([
       ["He said, 'Hi'", `He said, ${LEFT_SINGLE_QUOTE}Hi${RIGHT_SINGLE_QUOTE}`],


### PR DESCRIPTION
## Summary
This PR fixes the handling of quoted punctuation (e.g., `"?"`, `"!"`) in the double quote conversion logic by extracting the beginning-double-quote regex pattern into a dedicated function and adding a new lookahead assertion to properly detect these cases.

## Key Changes
- **Extracted regex pattern into `buildBeginningDoublePattern()` function**: The complex beginning-double-quote regex pattern is now built in a dedicated function with clear documentation explaining the pattern's logic and the ambiguity it resolves
- **Added quoted punctuation detection**: Introduced a new lookahead assertion `(?=[^"]{1,50}")` that matches content followed by a closing straight quote, enabling proper handling of short quoted punctuation strings
- **Added comprehensive test coverage**: Added 9 test cases covering various quoted punctuation scenarios including single punctuation marks, combinations, and punctuation in different contexts

## Implementation Details
The new lookahead assertion `(?=[^"]{1,50}")` works by:
1. Matching 1-50 non-quote characters after the opening quote
2. Ensuring a closing straight quote follows
3. This prevents the regex from incorrectly treating punctuation characters (which are typically ending-quote signals) as invalid opening contexts

The function includes detailed documentation explaining why the double-quote pattern requires special handling compared to single quotes, particularly around the separator lookahead and the need for an exclusion list to avoid false matches.

https://claude.ai/code/session_01AvXHqXSoFdLG6mSX7DqXrW