### PR TITLE
Add GitHub Flavored Markdown support for table parsing

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,12 +97,16 @@
     "unified": "11.0.5"
   },
   "peerDependencies": {
+    "remark-gfm": "^4.0.0",
     "remark-parse": "^11.0.0",
     "remark-stringify": "^11.0.0",
     "unified": "^11.0.0"
   },
   "peerDependenciesMeta": {
     "unified": {
+      "optional": true
+    },
+    "remark-gfm": {
       "optional": true
     },
     "remark-parse": {

--- a/src/markdown.ts
+++ b/src/markdown.ts
@@ -11,6 +11,7 @@
 
 import { unified } from "unified"
 import remarkParse from "remark-parse"
+import remarkGfm from "remark-gfm"
 import remarkStringify from "remark-stringify"
 
 import { remarkPunctilio, type RemarkPunctilioOptions } from "./remark.js"
@@ -70,6 +71,7 @@ export async function transformMarkdown(
 
   const processor = unified()
     .use(remarkParse)
+    .use(remarkGfm)
     .use(remarkPunctilio, punctilioOptions)
     .use(remarkStringify, {
       emphasis: emphasisMarker ?? "*",

--- a/src/tests/markdown.test.ts
+++ b/src/tests/markdown.test.ts
@@ -82,6 +82,16 @@ describe("transformMarkdown", () => {
     expect(result.trimEnd()).toEqual("See references \\[1\\]\\[4\\]\\[5\\]\\[6\\] for details.")
   })
 
+  it.each([
+    ["plain separators", '| Flag | Default |\n| --- | --- |\n| "a" | b |'],
+    ["alignment markers", '| Left | Center | Right |\n| :--- | :---: | ---: |\n| "a" | b | c |'],
+    ["long separators", '| Col |\n| -------------------- |\n| "data" |'],
+  ])("preserves GFM table separators (%s)", async (_name, input) => {
+    const result = await transformMarkdown(input, { nbsp: false })
+    expect(result).not.toContain(EM_DASH)
+    expect(result).toContain(LDQ)
+  })
+
   it("README.md prose is already typographically correct", () => {
     const readme = readFileSync(resolve(__dirname, "../../README.md"), "utf-8")
     const lines = readme.split("\n")


### PR DESCRIPTION
## Summary
This PR adds support for GitHub Flavored Markdown (GFM) tables by integrating the `remark-gfm` plugin into the markdown transformation pipeline. This ensures that GFM table syntax is properly parsed and preserved during typographic transformations.

## Key Changes
- Added `remark-gfm` as an optional peer dependency in `package.json`
- Integrated `remark-gfm` plugin into the unified processor pipeline in `src/markdown.ts`
- Added comprehensive test coverage for GFM table separator preservation with multiple table formats (plain separators, alignment markers, and long separators)

## Implementation Details
- The `remark-gfm` plugin is added to the processor chain after `remarkParse` to enable GFM syntax parsing
- Tests verify that table separators (dashes and pipes) are not incorrectly transformed to em-dashes while smart quotes are still applied to table content
- The plugin is marked as optional in peerDependencies to maintain backward compatibility for users who don't need GFM support

https://claude.ai/code/session_01GD8MSmyQhkcC2VHTa3xjdb