### PR TITLE
Simplify linear scaling benchmark to use minimum time across iterations

### DIFF
--- a/src/tests/index.test.ts
+++ b/src/tests/index.test.ts
@@ -608,12 +608,12 @@ describe("transform", () => {
 
   describe("large input handling", () => {
     it("scales linearly on seeded mixed content", () => {
-      assertLinearScaling(transform, (n) => buildMixedContent(n * 100), 50)
+      assertLinearScaling(transform, (n) => buildMixedContent(n * 100), 100)
     })
 
     it("scales linearly with all features enabled", () => {
       const allFeatures = { fractions: true, degrees: true, superscript: true, ligatures: true }
-      assertLinearScaling((input) => transform(input, allFeatures), (n) => buildMixedContent(n * 100), 50)
+      assertLinearScaling((input) => transform(input, allFeatures), (n) => buildMixedContent(n * 100), 100)
     })
   })
 
@@ -688,6 +688,10 @@ describe("transform", () => {
 
     it("scales linearly on seeded mixed content", () => {
       assertLinearScaling(transform, (n) => buildMixedContent(n * 10))
+    })
+
+    it("rejects inputs below minimum length", () => {
+      expect(() => assertLinearScaling(transform, (n) => "a".repeat(n), 100)).toThrow("minimum")
     })
   })
 

--- a/src/tests/symbols.test.ts
+++ b/src/tests/symbols.test.ts
@@ -686,7 +686,7 @@ describe("symbolTransform", () => {
 describe("multiplication ReDoS regression", () => {
   it("scales linearly for long digit strings", () => {
     // Before fix: quadratic (~100x for 10x input). After fix: linear.
-    assertLinearScaling(multiplication, (n) => "1".repeat(n), 5_000)
+    assertLinearScaling(multiplication, (n) => "1".repeat(n))
   })
 })
 

--- a/src/tests/test-helpers.ts
+++ b/src/tests/test-helpers.ts
@@ -98,5 +98,5 @@ export function assertLinearScaling(
   // For linear: rate_8x / rate_4x ≈ 1. For quadratic: ≈ 2.
   const rate4x = msPerChar[2]
   const rate8x = msPerChar[3]
-  expect(rate8x / rate4x).toBeLessThan(1.5)
+  expect(rate8x / rate4x).toBeLessThan(2.0)
 }

--- a/src/tests/test-helpers.ts
+++ b/src/tests/test-helpers.ts
@@ -49,57 +49,61 @@ export function buildMixedContent(charCount: number, seed: string = "42"): strin
   return result
 }
 
+const MIN_INPUT_LENGTH = 10_000
+
 /**
  * Asserts that a function scales linearly (not quadratically) with input size.
  *
- * Measures ms/char at 4 input sizes (1x, 2x, 4x, 8x) after a JIT warmup pass.
- * Compares the two largest sizes (4x vs 8x) which have the best signal-to-noise
- * ratio. For a linear algorithm, doubling input keeps ms/char constant (ratio ~1).
- * For a quadratic one, doubling input doubles ms/char (ratio ~2).
+ * Measures ms/char at two sizes (1x, 2x) after a JIT warmup pass, using the
+ * minimum time across iterations (immune to GC pauses). For a linear algorithm,
+ * doubling input keeps ms/char constant (ratio ~1). For a quadratic one,
+ * doubling input doubles ms/char (ratio ~2).
  *
- * Default startingN of 5000 produces inputs from ~5K to ~40K chars, which is
- * past V8's string allocation overhead inflection point where ms/char stabilizes.
- *
- * Uses median of min 5 iterations / 50ms per size for GC-noise resilience.
+ * Requires the 1x input to be at least {@link MIN_INPUT_LENGTH} chars to
+ * avoid noise from small-input overhead.
  *
  * @param fn - The function to benchmark
  * @param buildInput - Builds an input string of approximately `n` units
- * @param startingN - Size parameter for the smallest input (default: 5000)
+ * @param startingN - Size parameter for the smaller input (default: 10000)
  */
 export function assertLinearScaling(
   fn: (input: string) => unknown,
   buildInput: (n: number) => string,
-  startingN: number = 5000
+  startingN: number = 10_000
 ): void {
-  const multipliers = [1, 2, 4, 8]
+  const input1x = buildInput(startingN)
+  const input2x = buildInput(startingN * 2)
 
-  // Warmup with the largest input so JIT compiles all code paths before timing.
-  fn(buildInput(startingN * multipliers[multipliers.length - 1]))
+  if (input1x.length < MIN_INPUT_LENGTH) {
+    throw new Error(
+      `1x input is only ${input1x.length} chars (minimum: ${MIN_INPUT_LENGTH}). ` +
+      `Increase startingN or use a buildInput that produces longer strings.`
+    )
+  }
 
-  function measureMsPerChar(mult: number): number {
-    const input = buildInput(startingN * mult)
+  // Warmup with the larger input so JIT compiles all code paths before timing.
+  fn(input2x)
+
+  function measureMinMsPerChar(input: string): number {
     const minIterations = 5
     const minElapsedMs = 50
-    const times: number[] = []
+    let best = Infinity
     let totalElapsed = 0
-    while (times.length < minIterations || totalElapsed < minElapsedMs) {
+    let iterations = 0
+    while (iterations < minIterations || totalElapsed < minElapsedMs) {
       const start = performance.now()
       fn(input)
       const elapsed = performance.now() - start
-      times.push(elapsed)
+      best = Math.min(best, elapsed)
       totalElapsed += elapsed
+      iterations++
     }
-    times.sort((a, b) => a - b)
-    const median = times[Math.floor(times.length / 2)]
-    return median / input.length
+    return best / input.length
   }
 
-  // Measure all sizes (exercises the function at various scales)
-  const msPerChar = multipliers.map(measureMsPerChar)
+  const rate1x = measureMinMsPerChar(input1x)
+  const rate2x = measureMinMsPerChar(input2x)
 
-  // Compare the two largest inputs (best SNR, per-call overhead is negligible).
-  // For linear: rate_8x / rate_4x ≈ 1. For quadratic: ≈ 2.
-  const rate4x = msPerChar[2]
-  const rate8x = msPerChar[3]
-  expect(rate8x / rate4x).toBeLessThan(2.0)
+  // For linear: rate2x / rate1x ≈ 1. For quadratic: ≈ 2.
+  expect(rate2x / rate1x).toBeLessThan(1.5)
 }

--- a/src/tests/test-helpers.ts
+++ b/src/tests/test-helpers.ts
@@ -60,7 +60,7 @@ export function buildMixedContent(charCount: number, seed: string = "42"): strin
  * Default startingN of 5000 produces inputs from ~5K to ~40K chars, which is
  * past V8's string allocation overhead inflection point where ms/char stabilizes.
  *
- * Uses min 3 iterations and min 20ms per size to get stable averages.
+ * Uses median of min 5 iterations / 50ms per size for GC-noise resilience.
  *
  * @param fn - The function to benchmark
  * @param buildInput - Builds an input string of approximately `n` units
@@ -78,17 +78,20 @@ export function assertLinearScaling(
 
   function measureMsPerChar(mult: number): number {
     const input = buildInput(startingN * mult)
-    const minIterations = 3
-    const minElapsedMs = 20
+    const minIterations = 5
+    const minElapsedMs = 50
+    const times: number[] = []
     let totalElapsed = 0
-    let iterations = 0
-    while (iterations < minIterations || totalElapsed < minElapsedMs) {
+    while (times.length < minIterations || totalElapsed < minElapsedMs) {
       const start = performance.now()
       fn(input)
-      totalElapsed += performance.now() - start
-      iterations++
+      const elapsed = performance.now() - start
+      times.push(elapsed)
+      totalElapsed += elapsed
     }
-    return totalElapsed / iterations / input.length
+    times.sort((a, b) => a - b)
+    const median = times[Math.floor(times.length / 2)]
+    return median / input.length
   }
 
   // Measure all sizes (exercises the function at various scales)


### PR DESCRIPTION
## Summary
Refactored the `assertLinearScaling` benchmark helper to use a simpler, more robust approach for detecting quadratic scaling. Instead of measuring across 4 input sizes (1x, 2x, 4x, 8x) and comparing the two largest, the new implementation measures just 2 sizes (1x, 2x) and uses the minimum elapsed time across iterations to eliminate noise from GC pauses.

## Key Changes
- **Simplified measurement strategy**: Reduced from 4 input sizes to 2 (1x and 2x), making the test faster and easier to reason about
- **Minimum time tracking**: Changed from averaging elapsed time to tracking the minimum across iterations, which is immune to GC pauses and provides better signal-to-noise ratio
- **Input validation**: Added explicit check that 1x input meets `MIN_INPUT_LENGTH` (10,000 chars) to avoid noise from small-input overhead
- **Increased iteration thresholds**: Raised minimum iterations from 3 to 5 and minimum elapsed time from 20ms to 50ms for more stable measurements
- **Updated test parameters**: Adjusted `startingN` values in test cases to ensure inputs meet the new minimum length requirement
- **Added validation test**: New test case verifies that the function properly rejects inputs below the minimum length threshold

## Implementation Details
- The `measureMinMsPerChar` function now tracks `best = Math.min(best, elapsed)` instead of averaging, making it resilient to timing noise
- Default `startingN` increased from 5,000 to 10,000 to align with the new `MIN_INPUT_LENGTH` constant
- The ratio comparison remains the same: linear algorithms should have `rate2x / rate1x ≈ 1`, while quadratic ones would be `≈ 2`
- Threshold for failure remains at 1.5, providing a safety margin between linear and quadratic behavior

https://claude.ai/code/session_01XZpkeVQuttUhQjsNUivMtD