### PR TITLE
fix: cache markdown processor, optimize rehype visitor, CI and packaging

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     timeout-minutes: 15
     strategy:
       matrix:
-        node-version: [18, 24]
+        node-version: [18, 20, 24]
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.0-git",
   "description": "Smart typography transformations: curly quotes, em-dashes, en-dashes, and more",
   "type": "module",
+  "sideEffects": false,
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {

--- a/src/markdown.ts
+++ b/src/markdown.ts
@@ -75,6 +75,15 @@ let cachedProcessor: ReturnType<typeof createProcessor> | null = null
 let cachedOptionsKey = ""
 
 /**
+ * Clears the processor cache. Exported for test isolation only.
+ * @internal
+ */
+export function clearProcessorCache(): void {
+  cachedProcessor = null
+  cachedOptionsKey = ""
+}
+
+/**
  * Transforms Markdown text with typographic improvements.
  *
  * Parses the input as Markdown, applies punctilio typography transformations
@@ -99,10 +108,9 @@ export async function transformMarkdown(
   input: string,
   options: MarkdownOptions = {}
 ): Promise<string> {
-  // Use a replacer to preserve undefined-valued keys in the cache key.
-  // JSON.stringify omits undefined values, so { nbsp: undefined } and {}
-  // would collide despite producing different behavior (undefined overrides defaults).
-  const optionsKey = JSON.stringify(options, (_key, value) => value === undefined ? null : value)
+  const optionsKey = JSON.stringify(
+    Object.entries(options).sort(([a], [b]) => a.localeCompare(b))
+  )
 
   if (!cachedProcessor || cachedOptionsKey !== optionsKey) {
     cachedProcessor = createProcessor(options)

--- a/src/markdown.ts
+++ b/src/markdown.ts
@@ -40,10 +40,48 @@ export interface MarkdownOptions extends RemarkPunctilioOptions {
 }
 
 /**
+ * Creates a unified processor pipeline for Markdown typography transformations.
+ */
+function createProcessor(options: MarkdownOptions) {
+  const {
+    emphasisMarker,
+    strongMarker,
+    bulletMarker,
+    ruleMarker,
+    ...punctilioOptions
+  } = options
+
+  return unified()
+    .use(remarkParse)
+    .use(remarkGfm)
+    .use(remarkPunctilio, punctilioOptions)
+    .use(remarkStringify, {
+      emphasis: emphasisMarker ?? "*",
+      strong: strongMarker ?? "*",
+      bullet: bulletMarker ?? "-",
+      rule: ruleMarker ?? "-",
+      // Use 4 dashes (----) for thematic breaks to avoid ambiguity with
+      // YAML front matter delimiters (---) during re-parsing
+      ...(ruleMarker === "-" || ruleMarker === undefined ? { ruleRepetition: 4 } : {}),
+      // remark-stringify escapes opening brackets but not closing brackets,
+      // producing `\[1]` instead of `\[1\]`. This can cause issues when the
+      // output is re-parsed by markdown renderers.
+      unsafe: [{ character: "]", inConstruct: "phrasing" }],
+    })
+}
+
+/** Cached processor and the options key it was built with. */
+let cachedProcessor: ReturnType<typeof createProcessor> | null = null
+let cachedOptionsKey = ""
+
+/**
  * Transforms Markdown text with typographic improvements.
  *
  * Parses the input as Markdown, applies punctilio typography transformations
  * (smart quotes, em-dashes, ellipses, etc.), and serializes back to Markdown.
+ *
+ * The unified processor pipeline is cached and reused across calls with
+ * identical options, avoiding redundant pipeline construction.
  *
  * @param input - The Markdown text to transform
  * @param options - Configuration options for both the transform and serializer
@@ -61,32 +99,16 @@ export async function transformMarkdown(
   input: string,
   options: MarkdownOptions = {}
 ): Promise<string> {
-  const {
-    emphasisMarker,
-    strongMarker,
-    bulletMarker,
-    ruleMarker,
-    ...punctilioOptions
-  } = options
+  // Use a replacer to preserve undefined-valued keys in the cache key.
+  // JSON.stringify omits undefined values, so { nbsp: undefined } and {}
+  // would collide despite producing different behavior (undefined overrides defaults).
+  const optionsKey = JSON.stringify(options, (_key, value) => value === undefined ? null : value)
 
-  const processor = unified()
-    .use(remarkParse)
-    .use(remarkGfm)
-    .use(remarkPunctilio, punctilioOptions)
-    .use(remarkStringify, {
-      emphasis: emphasisMarker ?? "*",
-      strong: strongMarker ?? "*",
-      bullet: bulletMarker ?? "-",
-      rule: ruleMarker ?? "-",
-      // Use 4 dashes (----) for thematic breaks to avoid ambiguity with
-      // YAML front matter delimiters (---) during re-parsing
-      ...(ruleMarker === "-" || ruleMarker === undefined ? { ruleRepetition: 4 } : {}),
-      // remark-stringify escapes opening brackets but not closing brackets,
-      // producing `\[1]` instead of `\[1\]`. This can cause issues when the
-      // output is re-parsed by markdown renderers.
-      unsafe: [{ character: "]", inConstruct: "phrasing" }],
-    })
+  if (!cachedProcessor || cachedOptionsKey !== optionsKey) {
+    cachedProcessor = createProcessor(options)
+    cachedOptionsKey = optionsKey
+  }
 
-  const result = await processor.process(input)
+  const result = await cachedProcessor.process(input)
   return String(result)
 }

--- a/src/rehype.ts
+++ b/src/rehype.ts
@@ -510,15 +510,13 @@ export function rehypePunctilio(
     const transformed = new Set<Element>()
 
     visitParents(tree, "element", (node, ancestors) => {
-      const element = node as Element
-
       // Skip if already transformed
-      if (transformed.has(element)) {
+      if (transformed.has(node)) {
         return
       }
 
       // Check if this node or any ancestor should be skipped
-      if (shouldSkip(element)) {
+      if (shouldSkip(node)) {
         return
       }
       if (hasAncestor(ancestors as Parent[], shouldSkip)) {
@@ -526,7 +524,7 @@ export function rehypePunctilio(
       }
 
       // Collect and transform elements with text content
-      const elementsToTransform = collectTransformableElements(element, shouldSkip)
+      const elementsToTransform = collectTransformableElements(node, shouldSkip)
       for (const elt of elementsToTransform) {
         if (!transformed.has(elt)) {
           transformElement(elt, transformFn, shouldSkip, separator)

--- a/src/rehype.ts
+++ b/src/rehype.ts
@@ -112,7 +112,7 @@ export function flattenTextNodes(
     return [node]
   }
 
-  if (node.type === "element" && "children" in node) {
+  if (node.type === "element") {
     return node.children.flatMap((child) => flattenTextNodes(child, shouldSkip, depth + 1))
   }
 
@@ -509,12 +509,7 @@ export function rehypePunctilio(
     // Track transformed elements to avoid double-processing
     const transformed = new Set<Element>()
 
-    visitParents(tree, (node, ancestors) => {
-      // Only process element nodes
-      if (node.type !== "element") {
-        return
-      }
-
+    visitParents(tree, "element", (node, ancestors) => {
       const element = node as Element
 
       // Skip if already transformed

--- a/src/tests/markdown.test.ts
+++ b/src/tests/markdown.test.ts
@@ -1,7 +1,7 @@
 import { readFileSync } from "fs"
 import { resolve } from "path"
 import { fileURLToPath } from "url"
-import { transformMarkdown } from "../markdown.js"
+import { transformMarkdown, clearProcessorCache } from "../markdown.js"
 import { transform } from "../index.js"
 import { UNICODE_SYMBOLS } from "../constants.js"
 
@@ -16,6 +16,10 @@ const {
 } = UNICODE_SYMBOLS
 
 describe("transformMarkdown", () => {
+  afterEach(() => {
+    clearProcessorCache()
+  })
+
   it("transforms basic typography", async () => {
     const result = await transformMarkdown('"Hello," she said.', { nbsp: false })
     expect(result.trimEnd()).toEqual(`${LDQ}Hello,${RDQ} she said.`)
@@ -98,6 +102,13 @@ describe("transformMarkdown", () => {
     const second = await transformMarkdown('"World."', opts)
     expect(first.trimEnd()).toEqual(`${LDQ}Hello${RDQ}.`)
     expect(second.trimEnd()).toEqual(`${LDQ}World${RDQ}.`)
+  })
+
+  it("invalidates cache when options change", async () => {
+    const american = await transformMarkdown('"Hello."', { punctuationStyle: "american", nbsp: false })
+    const british = await transformMarkdown('"Hello."', { punctuationStyle: "british", nbsp: false })
+    expect(american.trimEnd()).toEqual(`${LDQ}Hello.${RDQ}`)
+    expect(british.trimEnd()).toEqual(`${LDQ}Hello${RDQ}.`)
   })
 
   it("distinguishes explicit undefined from absent options in cache key", async () => {

--- a/src/tests/markdown.test.ts
+++ b/src/tests/markdown.test.ts
@@ -92,6 +92,23 @@ describe("transformMarkdown", () => {
     expect(result).toContain(LDQ)
   })
 
+  it("reuses cached processor for identical options", async () => {
+    const opts = { punctuationStyle: "british" as const, nbsp: false }
+    const first = await transformMarkdown('"Hello."', opts)
+    const second = await transformMarkdown('"World."', opts)
+    expect(first.trimEnd()).toEqual(`${LDQ}Hello${RDQ}.`)
+    expect(second.trimEnd()).toEqual(`${LDQ}World${RDQ}.`)
+  })
+
+  it("distinguishes explicit undefined from absent options in cache key", async () => {
+    // { nbsp: undefined } overrides the default (true), disabling nbsp.
+    // The cache must not conflate this with {} which uses the default.
+    const withDefault = await transformMarkdown("Dr. Smith")
+    const withUndefined = await transformMarkdown("Dr. Smith", { nbsp: undefined })
+    expect(withDefault).toContain("\u00A0")
+    expect(withUndefined).not.toContain("\u00A0")
+  })
+
   it("README.md prose is already typographically correct", () => {
     const readme = readFileSync(resolve(__dirname, "../../README.md"), "utf-8")
     const lines = readme.split("\n")


### PR DESCRIPTION
## Summary
- Cache the unified processor in `transformMarkdown()` to avoid rebuilding the pipeline on every call — significant win for repeated use (e.g., static site generators)
- Clean up rehype visitor: use typed `visitParents` filter, remove redundant type guards
- Add Node 20 (LTS) to CI matrix and declare `sideEffects: false` for bundler tree-shaking

## Changes

### `src/markdown.ts`
- Extract `createProcessor()` helper and cache the processor keyed by sorted `Object.entries` serialization
- `Object.entries().sort()` naturally handles both `undefined`-valued keys (which `JSON.stringify` silently drops) and property ordering
- Export `clearProcessorCache()` for test isolation, following the existing `clearRegexCache()` pattern

### `src/rehype.ts`
- Use `visitParents(tree, "element", ...)` to skip non-element callback invocations instead of manual `node.type !== "element"` guard
- Remove redundant `"children" in node` check in `flattenTextNodes` — `Element` always has `children`
- Remove now-unnecessary `as Element` cast since the typed visitor narrows correctly

### `src/tests/markdown.test.ts`
- Add `afterEach(clearProcessorCache)` for test isolation
- Add cache-reuse test, cache-invalidation test, and `undefined`-vs-absent options test

### `.github/workflows/test.yml`
- Add Node 20 to test matrix (`.nvmrc` specifies 20 but CI only tested 18 and 24)

### `package.json`
- Add `"sideEffects": false` to enable bundler tree-shaking of unused exports

## Testing
- 1572 tests pass (3 new), 100% branch/function/line/statement coverage maintained
- TypeScript strict mode compiles cleanly
- ESLint passes

https://claude.ai/code/session_01LYdaDnTKSrVxM8sQiaARbH