### PR TITLE
fix: extend Latin range, optimize rehype, improve caches, add units

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Setting aside the benchmark, `punctilio`’s test suite includes 1,550+ tests at
 
 ## Works with HTML DOMs via separation boundaries
 
-Perhaps the most innovative feature of the library is that it properly handles DOMs! (This means it’ll also work on Markdown: [convert to HTML](https://github.com/remarkjs/remark), transform with `punctilio`, [convert back to Markdown](https://github.com/JohannesKaufmann/html-to-markdown).)
+Perhaps the most innovative feature of the library is that it properly handles DOMs! For Markdown, use the built-in [`remarkPunctilio`](#for-markdown) or [`transformMarkdown`](#for-markdown) plugins instead of converting to HTML and back.
 
 Other typography libraries take one of two approaches, both with drawbacks. 
 
@@ -118,6 +118,15 @@ unified()
 For Markdown ASTs via `remark`, use `remarkPunctilio` which applies the same separator technique to preserve inline element boundaries, or use `transformMarkdown` for a simpler Markdown-to-Markdown pipeline.
 
 For manual DOM walking or custom transforms, use `transformElement` from `punctilio/rehype`.
+
+The rehype plugin accepts additional options:
+
+```typescript
+rehypePunctilio({
+  skipTags: ["code", "pre", "script", "style", "kbd", "var", "samp"], // default
+  skipClasses: ["no-formatting"], // skip elements with these CSS classes
+});
+```
 
 ## Options
 

--- a/README.md
+++ b/README.md
@@ -119,12 +119,12 @@ For Markdown ASTs via `remark`, use `remarkPunctilio` which applies the same sep
 
 For manual DOM walking or custom transforms, use `transformElement` from `punctilio/rehype`.
 
-The rehype plugin accepts additional options:
+The rehype plugin accepts additional options. Elements matching any `skipTags` tag name or carrying any `skipClasses` class are left untransformed (values shown are the defaults for `skipTags`):
 
 ```typescript
 rehypePunctilio({
-  skipTags: ["code", "pre", "script", "style", "kbd", "var", "samp"], // default
-  skipClasses: ["no-formatting"], // skip elements with these CSS classes
+  skipTags: ["code", "pre", "script", "style", "kbd", "var", "samp"],
+  skipClasses: ["no-formatting"],
 });
 ```
 

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Setting aside the benchmark, `punctilio`’s test suite includes 1,550+ tests at
 
 ## Works with HTML DOMs via separation boundaries
 
-Perhaps the most innovative feature of the library is that it properly handles DOMs! For Markdown, use the built-in [`remarkPunctilio`](#for-markdown) or [`transformMarkdown`](#for-markdown) plugins instead of converting to HTML and back.
+Perhaps the most innovative feature of the library is that it properly handles DOMs! For Markdown, use the built-in `remarkPunctilio` or `transformMarkdown` plugins instead of converting to HTML and back.
 
 Other typography libraries take one of two approaches, both with drawbacks. 
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -117,10 +117,11 @@ export const TERMINAL_PUNCTUATION = [
  * - Latin-1 Supplement: À-Ö, Ø-ö, ø-ÿ (excludes × and ÷)
  * - Latin Extended-A: Ā-ſ (U+0100-017F)
  * - Latin Extended-B: ƀ-ɏ (U+0180-024F)
+ * - Latin Extended Additional: Ḁ-ỿ (U+1E00-1EFF) — Vietnamese, Welsh, medievalist
  *
- * Examples of covered characters: é, ñ, ü, ø, ą, ł, ș
+ * Examples of covered characters: é, ñ, ü, ø, ą, ł, ș, ả, ầ, ẁ, ẃ
  */
-export const LATIN_LETTERS = "A-Za-z\\u00C0-\\u00D6\\u00D8-\\u00F6\\u00F8-\\u00FF\\u0100-\\u017F\\u0180-\\u024F"
+export const LATIN_LETTERS = "A-Za-z\\u00C0-\\u00D6\\u00D8-\\u00F6\\u00F8-\\u00FF\\u0100-\\u017F\\u0180-\\u024F\\u1E00-\\u1EFF"
 
 /**
  * Default separator for text spanning HTML elements.

--- a/src/markdown.ts
+++ b/src/markdown.ts
@@ -13,6 +13,7 @@ import { unified } from "unified"
 import remarkParse from "remark-parse"
 import remarkGfm from "remark-gfm"
 import remarkStringify from "remark-stringify"
+import QuickLRU from "quick-lru"
 
 import { remarkPunctilio, type RemarkPunctilioOptions } from "./remark.js"
 
@@ -70,17 +71,18 @@ function createProcessor(options: MarkdownOptions) {
     })
 }
 
-/** Cached processor and the options key it was built with. */
-let cachedProcessor: ReturnType<typeof createProcessor> | null = null
-let cachedOptionsKey = ""
+const MAX_PROCESSOR_CACHE_SIZE = 8
+
+const processorCache = new QuickLRU<string, ReturnType<typeof createProcessor>>({
+  maxSize: MAX_PROCESSOR_CACHE_SIZE,
+})
 
 /**
  * Clears the processor cache. Exported for test isolation only.
  * @internal
  */
 export function clearProcessorCache(): void {
-  cachedProcessor = null
-  cachedOptionsKey = ""
+  processorCache.clear()
 }
 
 /**
@@ -112,11 +114,12 @@ export async function transformMarkdown(
     Object.entries(options).sort(([a], [b]) => a.localeCompare(b))
   )
 
-  if (!cachedProcessor || cachedOptionsKey !== optionsKey) {
-    cachedProcessor = createProcessor(options)
-    cachedOptionsKey = optionsKey
+  let processor = processorCache.get(optionsKey)
+  if (!processor) {
+    processor = createProcessor(options)
+    processorCache.set(optionsKey, processor)
   }
 
-  const result = await cachedProcessor.process(input)
+  const result = await processor.process(input)
   return String(result)
 }

--- a/src/nbsp.ts
+++ b/src/nbsp.ts
@@ -60,6 +60,16 @@ export const UNITS = [
   "MM", "M", "B", "T",
   // Misc
   "kcal", "mol", "cal", "dB",
+  // Speed
+  "mph", "kph", "fps",
+  // Pressure
+  "atm", "mbar",
+  // Battery / charge
+  "mAh", "Ah",
+  // Torque
+  "Nm",
+  // Light
+  "lm",
 ]
 
 export const HONORIFICS = [

--- a/src/rehype.ts
+++ b/src/rehype.ts
@@ -364,6 +364,35 @@ const TRANSFORMABLE_ELEMENTS = new Set([
 ])
 
 /**
+ * Checks whether an element has any text node descendants (skipping elements
+ * matched by shouldSkip). Returns as soon as one is found — avoids allocating
+ * an array of all text nodes just to check existence.
+ */
+function hasTextDescendant(
+  node: Element | ElementContent,
+  shouldSkip: ElementPredicate,
+  depth: number = 0
+): boolean {
+  if (depth > MAX_RECURSION_DEPTH) {
+    return false
+  }
+
+  if (node.type === "element" && shouldSkip(node)) {
+    return false
+  }
+
+  if (node.type === "text") {
+    return true
+  }
+
+  if (node.type === "element") {
+    return node.children.some((child) => hasTextDescendant(child, shouldSkip, depth + 1))
+  }
+
+  return false
+}
+
+/**
  * Collects elements that should have text transformations applied.
  *
  * An element is collected as a single transformation unit when it:
@@ -403,7 +432,7 @@ export function collectTransformableElements(
     (child) => child.type === "element" && BLOCK_ELEMENTS.has(child.tagName)
   )
   const hasTextDescendants = !hasDirectText && !hasBlockChildren &&
-    flattenTextNodes(node, shouldSkip).length > 0
+    hasTextDescendant(node, shouldSkip)
 
   if (
     TRANSFORMABLE_ELEMENTS.has(node.tagName) &&

--- a/src/tests/index.test.ts
+++ b/src/tests/index.test.ts
@@ -356,7 +356,7 @@ describe("transform", () => {
     })
   })
 
-  describe("Unicode edge cases", () => {
+  describe("Unicode control characters", () => {
     it.each([
       ['"test\u200Bword"', `${LEFT_DOUBLE_QUOTE}test\u200Bword${RIGHT_DOUBLE_QUOTE}`],
       ['"test\u200Fword"', `${LEFT_DOUBLE_QUOTE}test\u200Fword${RIGHT_DOUBLE_QUOTE}`],

--- a/src/tests/markdown.test.ts
+++ b/src/tests/markdown.test.ts
@@ -111,6 +111,19 @@ describe("transformMarkdown", () => {
     expect(british.trimEnd()).toEqual(`${LDQ}Hello${RDQ}.`)
   })
 
+  it("LRU cache retains multiple option sets simultaneously", async () => {
+    const american = { punctuationStyle: "american" as const, nbsp: false }
+    const british = { punctuationStyle: "british" as const, nbsp: false }
+    // Populate both cache entries
+    await transformMarkdown('"A."', american)
+    await transformMarkdown('"B."', british)
+    // Both should still be cached (not evicted)
+    const a2 = await transformMarkdown('"C."', american)
+    const b2 = await transformMarkdown('"D."', british)
+    expect(a2.trimEnd()).toEqual(`${LDQ}C.${RDQ}`)
+    expect(b2.trimEnd()).toEqual(`${LDQ}D${RDQ}.`)
+  })
+
   it("distinguishes explicit undefined from absent options in cache key", async () => {
     // { nbsp: undefined } overrides the default (true), disabling nbsp.
     // The cache must not conflate this with {} which uses the default.

--- a/src/tests/quotes.test.ts
+++ b/src/tests/quotes.test.ts
@@ -137,8 +137,8 @@ describe("niceQuotes", () => {
       [`'hello' "world"`, `${LEFT_SINGLE_QUOTE}hello${RIGHT_SINGLE_QUOTE} ${LEFT_DOUBLE_QUOTE}world${RIGHT_DOUBLE_QUOTE}`],
       // Latin Extended Additional: Vietnamese contraction-like patterns
       ["l'\u1EA3nh", `l${MODIFIER_LETTER_APOSTROPHE}\u1EA3nh`],
-      // Latin Extended Additional: Welsh w-circumflex
-      ["l'\u0175r", `l${MODIFIER_LETTER_APOSTROPHE}\u0175r`],
+      // Latin Extended Additional: Welsh w-acute (U+1E83, in U+1E00-1EFF range)
+      ["l'\u1E83r", `l${MODIFIER_LETTER_APOSTROPHE}\u1E83r`],
     ])('should handle single quotes/apostrophes in "%s"', (input, expected) => {
       expect(classifyApostrophes(input)).toBe(expected)
     })

--- a/src/tests/quotes.test.ts
+++ b/src/tests/quotes.test.ts
@@ -135,6 +135,10 @@ describe("niceQuotes", () => {
       ["Привет's", `Привет${MODIFIER_LETTER_APOSTROPHE}s`],
       // Closing RSQ then opening LDQ
       [`'hello' "world"`, `${LEFT_SINGLE_QUOTE}hello${RIGHT_SINGLE_QUOTE} ${LEFT_DOUBLE_QUOTE}world${RIGHT_DOUBLE_QUOTE}`],
+      // Latin Extended Additional: Vietnamese contraction-like patterns
+      ["l'\u1EA3nh", `l${MODIFIER_LETTER_APOSTROPHE}\u1EA3nh`],
+      // Latin Extended Additional: Welsh w-circumflex
+      ["l'\u0175r", `l${MODIFIER_LETTER_APOSTROPHE}\u0175r`],
     ])('should handle single quotes/apostrophes in "%s"', (input, expected) => {
       expect(classifyApostrophes(input)).toBe(expected)
     })

--- a/src/tests/rehype.test.ts
+++ b/src/tests/rehype.test.ts
@@ -446,6 +446,16 @@ describe("rehypePunctilio", () => {
         expect(collectTransformableElements(tree, ignoreCode)).toHaveLength(0)
       })
 
+      it("returns empty when only non-text, non-element children exist", () => {
+        const tree: Element = {
+          type: "element",
+          tagName: "p",
+          properties: {},
+          children: [{ type: "comment", value: "a comment" } as unknown as ElementContent],
+        }
+        expect(collectTransformableElements(tree, ignoreNone)).toHaveLength(0)
+      })
+
       it("stops at max recursion depth", () => {
         let deep: Element = h("p", "deep") as Element
         for (let i = 0; i < 1100; i++) deep = h("div", [deep]) as Element


### PR DESCRIPTION
## Summary

Thorough codebase audit found and fixed 7 issues across correctness, performance, feature gaps, and documentation:

- **`constants.ts`**: `LATIN_LETTERS` now covers Latin Extended Additional (U+1E00–1EFF) — Vietnamese (ả, ầ, ẩ), Welsh (ẁ, ẃ), and medievalist characters were previously excluded, causing incorrect word boundary detection and contraction handling for these languages
- **`rehype.ts`**: Replaced `flattenTextNodes(node, shouldSkip).length > 0` with an early-return `hasTextDescendant()` helper — the old code allocated a full array just to check existence, O(n) wasted allocation on large DOMs
- **`markdown.ts`**: Upgraded processor cache from single-entry to `QuickLRU(8)` — alternating between two option sets previously got 0% cache hits and rebuilt the full unified pipeline every call
- **`nbsp.ts`**: Added 9 missing common units: `mph`, `kph`, `fps`, `atm`, `mbar`, `mAh`, `Ah`, `Nm`, `lm`
- **`index.test.ts`**: Renamed duplicate `describe("Unicode edge cases")` block to `"Unicode control characters"` for unambiguous test output
- **`README.md`**: Fixed outdated advice suggesting HTML roundtrip for Markdown (native `remarkPunctilio`/`transformMarkdown` exist); documented the undocumented `skipClasses` rehype option

All 1585 tests pass at 100% branch/function/line/statement coverage. Lint clean.

## Test plan

- [x] `pnpm test` — 1585 tests pass, 100% coverage maintained
- [x] `pnpm lint` — clean
- [x] `pnpm build --noEmit` — type check passes
- [x] New tests: Vietnamese/Welsh contractions, LRU cache retention, comment node traversal

https://claude.ai/code/session_01BcZLa1Wwg7RpzXZTTwwb4m