### PR TITLE
Support nested quotes in American punctuation style

### DIFF
--- a/src/quotes.ts
+++ b/src/quotes.ts
@@ -17,6 +17,14 @@ const {
 /** Joined string of all terminal punctuation characters for use in regex character classes. */
 const TERMINAL_PUNCTUATION_CLASS = TERMINAL_PUNCTUATION.join("")
 
+/**
+ * Maximum consecutive closing quotes the punctuation-placement regexes will
+ * traverse in a single match (e.g., '". for two-deep nesting). Bounded to keep
+ * the regex linear on pathological inputs that contain many closing quotes
+ * without any following period or comma.
+ */
+const MAX_NESTED_QUOTES = 4
+
 export type PunctuationStyle = "american" | "british" | "german" | "french" | "none"
 
 export interface QuoteOptions {
@@ -162,18 +170,21 @@ function applyPunctuationStyle(text: string, sep: string, style: PunctuationStyl
 
   if (style === "american") {
     // Period outside → inside: "Hello". → "Hello."
+    // Match up to MAX_NESTED_QUOTES consecutive closing quotes so nested quotes
+    // like '". become .'" in one pass. The bound keeps the regex linear on
+    // pathological inputs (sequences of closing quotes without a period).
     const periodOutsideRegex = cachedRegExp(
-      `(?<![${TERMINAL_PUNCTUATION_CLASS}])(?<sepBefore>${escapedSep}?)(?<quote>[${RIGHT_SINGLE_QUOTE}${RIGHT_DOUBLE_QUOTE}])(?<sepAfter>${escapedSep}?)(?!\\.\\.\\.)\\.`,
+      `(?<![${TERMINAL_PUNCTUATION_CLASS}])(?<sepBefore>${escapedSep}?)(?<quotes>[${RIGHT_SINGLE_QUOTE}${RIGHT_DOUBLE_QUOTE}](?:${escapedSep}?[${RIGHT_SINGLE_QUOTE}${RIGHT_DOUBLE_QUOTE}]){0,${MAX_NESTED_QUOTES - 1}})(?<sepAfter>${escapedSep}?)(?!\\.\\.\\.)\\.`,
       "g"
     )
-    text = text.replace(periodOutsideRegex, "$<sepBefore>.$<quote>$<sepAfter>")
+    text = text.replace(periodOutsideRegex, "$<sepBefore>.$<quotes>$<sepAfter>")
 
     // Comma outside → inside: "Hello", → "Hello,"
     const commaOutsideRegex = cachedRegExp(
-      `(?<![${TERMINAL_PUNCTUATION_CLASS}])(?<sepBefore>${escapedSep}?)(?<quote>[${RIGHT_SINGLE_QUOTE}${RIGHT_DOUBLE_QUOTE}])(?<sepAfter>${escapedSep}?),`,
+      `(?<![${TERMINAL_PUNCTUATION_CLASS}])(?<sepBefore>${escapedSep}?)(?<quotes>[${RIGHT_SINGLE_QUOTE}${RIGHT_DOUBLE_QUOTE}](?:${escapedSep}?[${RIGHT_SINGLE_QUOTE}${RIGHT_DOUBLE_QUOTE}]){0,${MAX_NESTED_QUOTES - 1}})(?<sepAfter>${escapedSep}?),`,
       "g"
     )
-    text = text.replace(commaOutsideRegex, "$<sepBefore>,$<quote>$<sepAfter>")
+    text = text.replace(commaOutsideRegex, "$<sepBefore>,$<quotes>$<sepAfter>")
   } else if (style === "british" || style === "german" || style === "french") {
     // Period inside → outside: "Hello." → "Hello".
     // No terminal punctuation guard — "Stop!." inside is always wrong; move the period out.

--- a/src/quotes.ts
+++ b/src/quotes.ts
@@ -164,27 +164,56 @@ function convertDoubleQuotes(text: string, sep: string): string {
   return text
 }
 
+/**
+ * Build a regex that matches a punctuation mark sitting OUTSIDE one or more
+ * consecutive closing quotes, for American-style inside-the-quotes placement.
+ *
+ * Shape: `<non-terminal>(sepBefore)(quotes)(sepAfter)<punctuation>`
+ *
+ * - The lookbehind ensures the char just before the match isn't already terminal
+ *   punctuation (so we don't rewrite, e.g., "Stop!".).
+ * - `quotes` matches 1 to MAX_NESTED_QUOTES closing quotes (possibly separated
+ *   by element-boundary markers). The bound keeps the regex linear on
+ *   pathological inputs — unbounded `*` causes catastrophic backtracking when
+ *   many closing quotes appear with no following punctuation.
+ * - `punctuationPattern` is the trailing pattern (e.g. `,` or `(?!\.\.\.)\.`).
+ */
+function buildOutsidePunctuationRegex(escapedSep: string, punctuationPattern: string): RegExp {
+  const closingQuoteClass = `[${RIGHT_SINGLE_QUOTE}${RIGHT_DOUBLE_QUOTE}]`
+  const additionalQuotes = `(?:${escapedSep}?${closingQuoteClass}){0,${MAX_NESTED_QUOTES - 1}}`
+  const nonTerminalLookbehind = `(?<![${TERMINAL_PUNCTUATION_CLASS}])`
+  const pattern =
+    `${nonTerminalLookbehind}` +
+    `(?<sepBefore>${escapedSep}?)` +
+    `(?<quotes>${closingQuoteClass}${additionalQuotes})` +
+    `(?<sepAfter>${escapedSep}?)` +
+    punctuationPattern
+  return cachedRegExp(pattern, "g")
+}
+
+/**
+ * Move a punctuation mark sitting outside one or more consecutive closing
+ * quotes to the inside (American style): `Hello'".` → `Hello.'"`.
+ */
+function moveOutsideToInside(
+  text: string,
+  escapedSep: string,
+  replacementChar: string,
+  punctuationPattern: string,
+): string {
+  const regex = buildOutsidePunctuationRegex(escapedSep, punctuationPattern)
+  return text.replace(regex, `$<sepBefore>${replacementChar}$<quotes>$<sepAfter>`)
+}
+
 /** Apply American or British punctuation style */
 function applyPunctuationStyle(text: string, sep: string, style: PunctuationStyle): string {
   const escapedSep = getEscapedSeparator({ separator: sep })
 
   if (style === "american") {
-    // Period outside → inside: "Hello". → "Hello."
-    // Match up to MAX_NESTED_QUOTES consecutive closing quotes so nested quotes
-    // like '". become .'" in one pass. The bound keeps the regex linear on
-    // pathological inputs (sequences of closing quotes without a period).
-    const periodOutsideRegex = cachedRegExp(
-      `(?<![${TERMINAL_PUNCTUATION_CLASS}])(?<sepBefore>${escapedSep}?)(?<quotes>[${RIGHT_SINGLE_QUOTE}${RIGHT_DOUBLE_QUOTE}](?:${escapedSep}?[${RIGHT_SINGLE_QUOTE}${RIGHT_DOUBLE_QUOTE}]){0,${MAX_NESTED_QUOTES - 1}})(?<sepAfter>${escapedSep}?)(?!\\.\\.\\.)\\.`,
-      "g"
-    )
-    text = text.replace(periodOutsideRegex, "$<sepBefore>.$<quotes>$<sepAfter>")
-
-    // Comma outside → inside: "Hello", → "Hello,"
-    const commaOutsideRegex = cachedRegExp(
-      `(?<![${TERMINAL_PUNCTUATION_CLASS}])(?<sepBefore>${escapedSep}?)(?<quotes>[${RIGHT_SINGLE_QUOTE}${RIGHT_DOUBLE_QUOTE}](?:${escapedSep}?[${RIGHT_SINGLE_QUOTE}${RIGHT_DOUBLE_QUOTE}]){0,${MAX_NESTED_QUOTES - 1}})(?<sepAfter>${escapedSep}?),`,
-      "g"
-    )
-    text = text.replace(commaOutsideRegex, "$<sepBefore>,$<quotes>$<sepAfter>")
+    // Period outside → inside: Hello". → Hello."  (and Hello'". → Hello.'")
+    text = moveOutsideToInside(text, escapedSep, ".", `(?!\\.\\.\\.)\\.`)
+    // Comma outside → inside: Hello", → Hello,"
+    text = moveOutsideToInside(text, escapedSep, ",", `,`)
   } else if (style === "british" || style === "german" || style === "french") {
     // Period inside → outside: "Hello." → "Hello".
     // No terminal punctuation guard — "Stop!." inside is always wrong; move the period out.

--- a/src/tests/quotes.test.ts
+++ b/src/tests/quotes.test.ts
@@ -719,6 +719,23 @@ describe("niceQuotes", () => {
       const first = niceQuotes(`"He said, 'Hello.'"`, { punctuationStyle: style })
       expect(niceQuotes(first, { punctuationStyle: style })).toBe(first)
     })
+
+    it.each([
+      // Period moves past all closing quotes in one pass
+      [
+        `${LEFT_DOUBLE_QUOTE}He said, ${LEFT_SINGLE_QUOTE}Hello${RIGHT_SINGLE_QUOTE}${RIGHT_DOUBLE_QUOTE}.`,
+        `${LEFT_DOUBLE_QUOTE}He said, ${LEFT_SINGLE_QUOTE}Hello.${RIGHT_SINGLE_QUOTE}${RIGHT_DOUBLE_QUOTE}`,
+      ],
+      // Comma moves past all closing quotes in one pass
+      [
+        `${LEFT_DOUBLE_QUOTE}He said, ${LEFT_SINGLE_QUOTE}Hello${RIGHT_SINGLE_QUOTE}${RIGHT_DOUBLE_QUOTE}, she replied.`,
+        `${LEFT_DOUBLE_QUOTE}He said, ${LEFT_SINGLE_QUOTE}Hello,${RIGHT_SINGLE_QUOTE}${RIGHT_DOUBLE_QUOTE} she replied.`,
+      ],
+    ])("american moves past all closing quotes: %s → %s", (input, expected) => {
+      const result = niceQuotes(input, { punctuationStyle: "american" })
+      expect(result).toBe(expected)
+      expect(niceQuotes(result, { punctuationStyle: "american" })).toBe(result)
+    })
   })
 
   describe("pathological inputs", () => {


### PR DESCRIPTION
## Summary
Enhanced the American punctuation style to correctly handle nested quotes by moving periods and commas past multiple consecutive closing quotes in a single pass, rather than requiring multiple iterations.

## Key Changes
- Added `MAX_NESTED_QUOTES` constant (set to 4) to bound regex complexity and prevent performance degradation on pathological inputs with many consecutive closing quotes
- Updated `periodOutsideRegex` to match up to `MAX_NESTED_QUOTES` consecutive closing quotes (with optional separators between them) instead of just a single quote
- Updated `commaOutsideRegex` with the same nested quote matching logic
- Renamed capture group from `quote` to `quotes` to reflect that it now captures multiple quotes
- Added comprehensive test cases verifying that periods and commas correctly move past all closing quotes in nested quote scenarios (e.g., `"He said, 'Hello'".` → `"He said, 'Hello.'"`)
- Added idempotency checks to ensure repeated application produces stable results

## Implementation Details
The regex now uses a non-capturing group pattern `(?:${escapedSep}?[${RIGHT_SINGLE_QUOTE}${RIGHT_DOUBLE_QUOTE}]){0,${MAX_NESTED_QUOTES - 1}}` to match additional closing quotes beyond the first one. This allows punctuation to traverse nested quote structures in one pass while maintaining linear regex performance through the bounded repetition limit.

https://claude.ai/code/session_019fYwe282wsjTui3XUPbX3r