### PR TITLE
fix: tighten toll-free heuristic, collapse tabs, code quality improvements

### DIFF
--- a/src/dashes.ts
+++ b/src/dashes.ts
@@ -64,9 +64,10 @@ export function enDashNumberRange(text: string, options: DashOptions = {}): stri
       // Skip phone number patterns: 3 digits followed by 4 digits with preceding area code
       // e.g., 555-123-4567 or (555) 123-4567 where we're matching the "123-4567" part
       if (precedingAreaCode && /^\d{3}$/.test(startNum) && /^\d{4}$/.test(endNum)) return match
-      // Skip US country code + area code pattern: 1-800, 1-888, etc.
-      // These look like truncated phone numbers, not ranges
-      if (/^1$/.test(startNum) && /^\d{3}$/.test(endNum)) return match
+      // Skip US toll-free prefix pattern: 1-800, 1-888, 1-877, etc.
+      // All US toll-free area codes start with 8 (800, 888, 877, 866, 855, 844, 833).
+      // We only block 1-8XX to avoid false negatives on legitimate ranges like 1-100.
+      if (/^1$/.test(startNum) && /^8\d{2}$/.test(endNum)) return match
       return `${precedingAreaCode || ""}${start}${EN_DASH}${end}${suffix || ""}`
     }
   )

--- a/src/index.ts
+++ b/src/index.ts
@@ -179,6 +179,20 @@ export { assertSeparatorAbsent, assertSeparatorCountPreserved, countSeparators, 
 export { DEFAULT_SEPARATOR, UNICODE_SYMBOLS } from "./constants.js"
 export const MODIFIER_LETTER_APOSTROPHE = UNICODE_SYMBOLS.MODIFIER_LETTER_APOSTROPHE
 
+const defaultOpts: Required<Omit<TransformOptions, "separator">> = {
+  symbols: true,
+  includeArrows: true,
+  fractions: false,
+  degrees: false,
+  superscript: false,
+  ligatures: false,
+  nbsp: true,
+  collapseSpaces: true,
+  checkIdempotency: true,
+  punctuationStyle: "american",
+  dashStyle: "american",
+}
+
 /**
  * Applies all typography transformations: smart quotes, proper dashes,
  * and symbol improvements.
@@ -213,20 +227,6 @@ export const MODIFIER_LETTER_APOSTROPHE = UNICODE_SYMBOLS.MODIFIER_LETTER_APOSTR
  * // → 'Add ½ cup'
  * ```
  */
-const defaultOpts: Required<Omit<TransformOptions, "separator">> = {
-  symbols: true,
-  includeArrows: true,
-  fractions: false,
-  degrees: false,
-  superscript: false,
-  ligatures: false,
-  nbsp: true,
-  collapseSpaces: true,
-  checkIdempotency: true,
-  punctuationStyle: "american",
-  dashStyle: "american",
-}
-
 export function transform(text: string, options: TransformOptions = {}): string {
   const separator = options.separator ?? DEFAULT_SEPARATOR
 

--- a/src/rehype.ts
+++ b/src/rehype.ts
@@ -217,7 +217,7 @@ export function getFirstTextNode(
 ): Text | null {
   if (!node || depth > MAX_RECURSION_DEPTH) return null
 
-  if (node.type === "text" && "value" in node) {
+  if (node.type === "text") {
     return node as Text
   }
 
@@ -247,21 +247,21 @@ export function getFirstTextNode(
  * assertSmartQuotesMatch('\u201CHello')        // throws Error
  * ```
  */
+const QUOTE_OPENERS = new Set(["\u201C"])
+const CLOSER_TO_OPENER: Record<string, string> = { "\u201D": "\u201C" }
+
 export function assertSmartQuotesMatch(input: string): void {
   if (!input) return
 
-  const openers = new Set(["\u201C"])   // left double quote opens
-  const closerToOpener: Record<string, string> = { "\u201D": "\u201C" }  // right closes left
   const stack: string[] = []
 
   for (const char of input) {
-    if (openers.has(char)) {
+    if (QUOTE_OPENERS.has(char)) {
       stack.push(char)
-    } else if (char in closerToOpener) {
-      if (stack.length > 0 && stack[stack.length - 1] === closerToOpener[char]) {
+    } else if (char in CLOSER_TO_OPENER) {
+      if (stack.length > 0 && stack[stack.length - 1] === CLOSER_TO_OPENER[char]) {
         stack.pop()
       } else {
-        // Unmatched closer
         throw new Error(`Mismatched quotes in ${formatErrorString(input, "input")}`)
       }
     }

--- a/src/rehype.ts
+++ b/src/rehype.ts
@@ -231,6 +231,9 @@ export function getFirstTextNode(
   return null
 }
 
+const QUOTE_OPENERS = new Set(["\u201C"])
+const CLOSER_TO_OPENER: Record<string, string> = { "\u201D": "\u201C" }
+
 /**
  * Validates that smart double quotes in a text string are properly matched.
  *
@@ -247,9 +250,6 @@ export function getFirstTextNode(
  * assertSmartQuotesMatch('\u201CHello')        // throws Error
  * ```
  */
-const QUOTE_OPENERS = new Set(["\u201C"])
-const CLOSER_TO_OPENER: Record<string, string> = { "\u201D": "\u201C" }
-
 export function assertSmartQuotesMatch(input: string): void {
   if (!input) return
 

--- a/src/symbols.ts
+++ b/src/symbols.ts
@@ -123,6 +123,9 @@ export function mathSymbols(text: string, options: SymbolOptions = {}): string {
 /** Predicate that decides whether a legal symbol should be converted based on surrounding text. */
 type ContextPredicate = (before: string, after: string) => boolean
 
+/** Number of characters before/after a legal symbol to inspect for context clues. */
+const LEGAL_CONTEXT_WINDOW = 25
+
 /**
  * Context-aware replacement for legal symbols like (c), (r), (tm).
  * Extracts surrounding text, strips separator characters from the context
@@ -136,8 +139,8 @@ function contextAwareLegalReplace(
   separator: string,
 ): string {
   return text.replace(pattern, (match: string, offset: number, str: string) => {
-    const before = str.slice(Math.max(0, offset - 25), offset).replaceAll(separator, "")
-    const after = str.slice(offset + match.length, offset + match.length + 25).replaceAll(separator, "")
+    const before = str.slice(Math.max(0, offset - LEGAL_CONTEXT_WINDOW), offset).replaceAll(separator, "")
+    const after = str.slice(offset + match.length, offset + match.length + LEGAL_CONTEXT_WINDOW).replaceAll(separator, "")
     return shouldConvert(before, after) ? replacement : match
   })
 }
@@ -390,10 +393,9 @@ export function superscriptOrdinal(text: string, options: SymbolOptions = {}): s
   })
 }
 
-/** Collapse multiple spaces to single space. Prefers nbsp if any nbsp is present. */
+/** Collapse multiple spaces (including tabs) to single space. Prefers nbsp if any nbsp is present. */
 export function collapseSpaces(text: string): string {
-  return text.replace(cachedRegExp(`[${SPACE_CHARS}]{2,}`, "g"), (match) => {
-    // If any nbsp is present, prefer nbsp (more likely to be intentional)
+  return text.replace(cachedRegExp(`[${SPACE_CHARS}\\t]{2,}`, "g"), (match) => {
     return match.includes(NBSP) ? NBSP : " "
   })
 }

--- a/src/tests/dashes.test.ts
+++ b/src/tests/dashes.test.ts
@@ -658,6 +658,8 @@ describe("phone number preservation", () => {
     ["1-877", "1-877", "toll-free prefix 877"],
     ["1-866", "1-866", "toll-free prefix 866"],
     ["1-855", "1-855", "toll-free prefix 855"],
+    ["1-844", "1-844", "toll-free prefix 844"],
+    ["1-833", "1-833", "toll-free prefix 833"],
     ["Call 1-800-...", "Call 1-800-...", "truncated toll-free"],
     ["1-800-555-1234", "1-800-555-1234", "full toll-free"],
     ["1-888-555-1234", "1-888-555-1234", "full toll-free 888"],
@@ -675,6 +677,10 @@ describe("phone number preservation", () => {
     ["1-5", `1${EN_DASH}5`, "simple range"],
     ["1-50", `1${EN_DASH}50`, "range to two digits"],
     ["1-99", `1${EN_DASH}99`, "range to 99"],
+    ["1-100", `1${EN_DASH}100`, "range to 100 (not a toll-free prefix)"],
+    ["1-200", `1${EN_DASH}200`, "range to 200 (not a toll-free prefix)"],
+    ["1-500", `1${EN_DASH}500`, "range to 500 (not a toll-free prefix)"],
+    ["1-999", `1${EN_DASH}999`, "range to 999 (not a toll-free prefix)"],
     ["2-800", `2${EN_DASH}800`, "non-US country code pattern"],
   ])("%s → %s (%s)", (input, expected) => {
     expect(hyphenReplace(input)).toBe(expected)

--- a/src/tests/index.test.ts
+++ b/src/tests/index.test.ts
@@ -125,6 +125,8 @@ describe("transform", () => {
       [`foo${NBSP}${NBSP}bar`, `foo${NBSP}bar`, "multiple nbsp"],
       [`a ${NBSP}b`, `a${NBSP}b`, "mixed spaces prefer nbsp"],
       [`a${NBSP} b`, `a${NBSP}b`, "mixed spaces prefer nbsp"],
+      ["hello\t\tworld", "hello world", "multiple tabs"],
+      ["hello\t world", "hello world", "mixed tab and space"],
     ])("collapses %s by default", (input, expected) => {
       expect(transform(input, { nbsp: false })).toBe(expected)
     })
@@ -132,6 +134,7 @@ describe("transform", () => {
     it.each([
       ["hello  world", "hello  world", "multiple spaces"],
       [`foo${NBSP}${NBSP}bar`, `foo${NBSP}${NBSP}bar`, "multiple nbsp"],
+      ["hello\t\tworld", "hello\t\tworld", "multiple tabs"],
     ])("preserves %s when disabled", (input, expected) => {
       expect(transform(input, { collapseSpaces: false, nbsp: false })).toBe(expected)
     })

--- a/src/tests/symbols.test.ts
+++ b/src/tests/symbols.test.ts
@@ -388,11 +388,20 @@ describe("collapseSpaces", () => {
     // Multiple groups of spaces
     ["a  b  c", "a b c"],
     [`x${NBSP}${NBSP}y  z`, `x${NBSP}y z`],
+    // Tabs
+    ["hello\t\tworld", "hello world"],
+    ["a\t\t\tb", "a b"],
+    // Mixed tabs and spaces
+    ["a\t b", "a b"],
+    ["a \tb", "a b"],
+    [`a\t${NBSP}b`, `a${NBSP}b`],
     // Edge cases
     ["", ""],
     ["  ", " "],
     [`${NBSP}${NBSP}`, NBSP],
     ["no spaces", "no spaces"],
+    // Single tab unchanged
+    ["hello\tworld", "hello\tworld"],
   ])('converts "%s" to "%s"', (input, expected) => {
     expect(collapseSpaces(input)).toBe(expected)
   })


### PR DESCRIPTION
## Summary

- Fix overbroad toll-free heuristic that blocked legitimate ranges like `1-100` from en-dash conversion
- Fix `collapseSpaces` to handle tab characters, consistent with the nbsp module
- Improve code quality: fix misplaced JSDoc blocks, hoist static allocations, extract magic number, remove redundant check

## Changes

### Bug fixes
- **`enDashNumberRange` toll-free heuristic** (`dashes.ts`): Was blocking ALL `1-XXX` patterns (any 3-digit end number), now only blocks `1-8XX` (actual US toll-free prefixes: 800, 888, 877, 866, 855, 844, 833). This fixes false negatives on legitimate ranges like `1-100`, `1-200`, `1-500`.
- **`collapseSpaces` tab handling** (`symbols.ts`): Added `\t` to the character class so multiple tabs (or mixed tabs/spaces) are collapsed. Previously only spaces and nbsp were collapsed, inconsistent with the nbsp module which matches tabs.

### Code quality
- **JSDoc placement** (`index.ts`): Moved the `transform()` JSDoc block from above `defaultOpts` to directly above the function, so IDE tooltips display correctly.
- **JSDoc placement** (`rehype.ts`): Moved hoisted `QUOTE_OPENERS`/`CLOSER_TO_OPENER` constants above the JSDoc for `assertSmartQuotesMatch` to avoid the same misplacement bug.
- **Hoisted static allocations** (`rehype.ts`): Moved `Set` and `Record` in `assertSmartQuotesMatch` to module-level constants to avoid per-call allocations.
- **Named constant** (`symbols.ts`): Extracted magic number `25` in `contextAwareLegalReplace` to `LEGAL_CONTEXT_WINDOW`.
- **Redundant check removal** (`rehype.ts`): Removed `&& "value" in node` from `getFirstTextNode` — already narrowed by `node.type === "text"`.

### Tests (15 new, 1611 total)
- Toll-free prefix preservation: added 1-844, 1-833
- Range conversion: added 1-100, 1-200, 1-500, 1-999
- Tab collapsing: multiple tabs, mixed tabs/spaces, tabs with nbsp, single tab preserved
- Tab handling through main `transform()` pipeline (enabled/disabled)

## Testing

- All 1,611 tests pass with 100% branch/line/function/statement coverage
- `pnpm build --noEmit` type-check passes
- `pnpm lint` passes
- Self-critique sub-agent reviewed all changes and approved
- Manual self-critique caught and fixed a JSDoc misplacement introduced by the hoisting change

https://claude.ai/code/session_01JYxW65a8uG2QBvxFmzzZwN