### PR TITLE
refactor: de-duplicate constants, name magic numbers, minor cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ My [`benchmark.mjs`](https://github.com/alexander-turner/punctilio/blob/main/ben
 
 ## Test suite
 
-Setting aside the benchmark, `punctilio`’s test suite includes 1,550+ tests at 100% branch coverage, including edge cases derived from competitor libraries ([`smartquotes`](https://github.com/kellym/smartquotes.js), [`retext-smartypants`](https://github.com/retextjs/retext-smartypants), [`typograf`](https://github.com/typograf/typograf)) and the [Standard Ebooks typography manual](https://standardebooks.org/manual/). I also verify that all transformations are stable when applied multiple times. All transforms run in linear time, with scaling tests that guard against quadratic RegEx backtracking.
+Setting aside the benchmark, `punctilio`’s test suite runs at 100% branch coverage with well over a thousand tests, including edge cases derived from competitor libraries ([`smartquotes`](https://github.com/kellym/smartquotes.js), [`retext-smartypants`](https://github.com/retextjs/retext-smartypants), [`typograf`](https://github.com/typograf/typograf)) and the [Standard Ebooks typography manual](https://standardebooks.org/manual/). I also verify that all transformations are stable when applied multiple times. All transforms run in linear time, with scaling tests that guard against quadratic RegEx backtracking.
 
 ## Works with HTML DOMs via separation boundaries
 

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "build": "tsc",
     "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js",
     "lint": "eslint src",
+    "benchmark": "pnpm run build && node benchmark.mjs",
     "prepare": "if [ -d src ]; then tsc; else true; fi",
     "prepublishOnly": "pnpm run build && pnpm run test"
   },

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -229,6 +229,19 @@ export function spaceBoundaryEnd(escapedSeparator: string): string {
 }
 
 /**
+ * Maximum recursion depth used by the rehype and remark tree walkers.
+ * Guards against stack overflow from maliciously or accidentally deep
+ * AST nesting. Shared so both plugins behave identically.
+ */
+export const MAX_RECURSION_DEPTH = 1000
+
+/**
+ * Canonical issue tracker URL, referenced in user-facing error messages
+ * so there's exactly one source of truth if the repository ever moves.
+ */
+export const ISSUES_URL = "https://github.com/alexander-turner/punctilio/issues"
+
+/**
  * LRU cache for compiled RegExp objects keyed by `pattern + '\0' + flags`.
  * Avoids recompiling identical regexes on every function call (common
  * when using the default separator). Capped to prevent unbounded growth.

--- a/src/dashes.ts
+++ b/src/dashes.ts
@@ -22,6 +22,16 @@ const { EN_DASH, EM_DASH, MINUS, LEFT_DOUBLE_QUOTE, RIGHT_DOUBLE_QUOTE, LEFT_SIN
  */
 export const numberRangeDisallowedPrefixes = ["-", EN_DASH, EM_DASH, MINUS] as const
 
+/**
+ * Regex character-class fragment built from {@link numberRangeDisallowedPrefixes}.
+ * Non-ASCII dashes are escaped to `\uXXXX` form so the fragment is safe to
+ * embed inside a `[...]` class regardless of the regex source encoding.
+ * Computed once at module load — the inputs are `const`.
+ */
+const DISALLOWED_PREFIX_CLASS_FRAGMENT = numberRangeDisallowedPrefixes
+  .map((c) => (c === "-" ? c : `\\u${c.charCodeAt(0).toString(16).padStart(4, "0")}`))
+  .join("")
+
 export const months = [
   "January", "February", "March", "April", "May", "June",
   "July", "August", "September", "October", "November", "December",
@@ -35,15 +45,13 @@ export function enDashNumberRange(text: string, options: DashOptions = {}): stri
   const wb = wordBoundaryStart(chr)
   const wbe = wordBoundaryEnd(chr)
 
-  // Escape dash-like chars for lookbehind: prevents matching after dashes (e.g., Llama-2-7B)
-  const disallowed = numberRangeDisallowedPrefixes.map(c => c === "-" ? c : `\\u${c.charCodeAt(0).toString(16).padStart(4, "0")}`).join("")
-
   // Common currency symbols for price ranges
   const currencies = "$€£¥₹"
 
   // Build positive range pattern from readable components
   const phoneAreaCode = `(?<precedingAreaCode>\\d{3}-|\\(\\d{3}\\) ?)?`  // 555- or (555)
-  const notAfterDash = `(?<![${disallowed}${LATIN_LETTERS}.+])`          // prevent Llama-2-7B, +44-20
+  // Lookbehind prevents matching after dashes, so Llama-2-7B and +44-20 don't en-dash.
+  const notAfterDash = `(?<![${DISALLOWED_PREFIX_CLASS_FRAGMENT}${LATIN_LETTERS}.+])`
   const rangeStart = `(?<start>(?:p\\.?|[${currencies}])?\\d[\\d.,]*${chr}?)`  // p.10, $100, 1,000
   const rangeEnd = `(?<end>${chr}?[${currencies}]?\\d[\\d.,]*)`          // 20, $200, 2,000
   const moreSegments = `(?<following>(?:${chr}?[-${MINUS}]${chr}?\\d+)*)` // -4567 in phone numbers

--- a/src/index.ts
+++ b/src/index.ts
@@ -173,7 +173,7 @@ import { hyphenReplace } from "./dashes.js"
 import { symbolTransform, fractions as fractionsTransform, degrees as degreesTransform, superscriptOrdinal as superscriptTransform, primeMarks, collapseSpaces as collapseSpacesTransform, punctuationLigatures as ligaturesTransform } from "./symbols.js"
 import { nbspTransform as nbspTransformFn } from "./nbsp.js"
 import { assertSeparatorCountPreserved, formatErrorString } from "./utils.js"
-import { DEFAULT_SEPARATOR, UNICODE_SYMBOLS } from "./constants.js"
+import { DEFAULT_SEPARATOR, ISSUES_URL, UNICODE_SYMBOLS } from "./constants.js"
 
 export { assertSeparatorAbsent, assertSeparatorCountPreserved, countSeparators, transformTextNodes } from "./utils.js"
 export { DEFAULT_SEPARATOR, UNICODE_SYMBOLS } from "./constants.js"
@@ -296,7 +296,7 @@ export function transform(text: string, options: TransformOptions = {}): string 
         `Transform is not idempotent.\n` +
         `First pass:  ${formatErrorString(text, "first-pass")}\n` +
         `Second pass: ${formatErrorString(secondPass, "second-pass")}\n` +
-        `This is a bug in punctilio. Please file an issue at https://github.com/alexander-turner/punctilio/issues\n` +
+        `This is a bug in punctilio. Please file an issue at ${ISSUES_URL}\n` +
         `Include the input text that caused this error.`
       )
     }

--- a/src/nbsp.ts
+++ b/src/nbsp.ts
@@ -137,17 +137,25 @@ export function nbspBetweenNumberAndUnit(text: string, options: NbspOptions = {}
 }
 
 /**
+ * Maximum length, in characters, of the "last word" that gets an NBSP
+ * glued to its preceding space. Short enough that a typical English word
+ * qualifies but an entire trailing URL or long token does not. Only affects
+ * widow prevention at end-of-string and paragraph breaks.
+ */
+const MAX_LAST_WORD_LENGTH = 10
+
+/**
  * Adds non-breaking space before the last word to prevent widows.
  *
- * Only applies to final words of 1-10 characters, at end of string or
- * paragraph break (\n\n). Uses non-multiline mode so $ matches only the
- * true end of string.
+ * Only applies to final words of 1 to {@link MAX_LAST_WORD_LENGTH} characters,
+ * at end of string or paragraph break (\n\n). Uses non-multiline mode so $
+ * matches only the true end of string.
  */
 export function nbspBeforeLastWord(text: string, options: NbspOptions = {}): string {
   const sep = getEscapedSeparator(options)
   // Use alternation instead of character classes for multi-char separator support
   const pattern = cachedRegExp(
-    `(?<=\\w|${sep})${SPACE}(?<lastWord>(?:(?!\\s)(?!${sep}).){1,10})(?<ending>${sep}?(?:\\n\\n|$))`,
+    `(?<=\\w|${sep})${SPACE}(?<lastWord>(?:(?!\\s)(?!${sep}).){1,${MAX_LAST_WORD_LENGTH}})(?<ending>${sep}?(?:\\n\\n|$))`,
     "g"
   )
   return text.replace(pattern, `${NBSP}$<lastWord>$<ending>`)

--- a/src/rehype.ts
+++ b/src/rehype.ts
@@ -13,7 +13,7 @@ import type { Transformer } from "unified"
 import { visitParents } from "unist-util-visit-parents"
 
 import { transform, type TransformOptions } from "./index.js"
-import { DEFAULT_SEPARATOR } from "./constants.js"
+import { DEFAULT_SEPARATOR, MAX_RECURSION_DEPTH } from "./constants.js"
 import { transformTextNodes, formatErrorString } from "./utils.js"
 
 /** Predicate that decides whether an HTML element should be skipped during transformation. */
@@ -74,12 +74,6 @@ export interface RehypePunctilioOptions
 }
 
 const DEFAULT_SKIP_TAGS = ["code", "pre", "script", "style", "kbd", "var", "samp"]
-
-/**
- * Maximum recursion depth for tree traversal functions.
- * Prevents stack overflow from maliciously deep HTML nesting.
- */
-const MAX_RECURSION_DEPTH = 1000
 
 /**
  * Check if an element has a specific CSS class.

--- a/src/remark.ts
+++ b/src/remark.ts
@@ -13,16 +13,10 @@ import type { Transformer } from "unified"
 import { visitParents } from "unist-util-visit-parents"
 
 import { transform, type TransformOptions } from "./index.js"
-import { DEFAULT_SEPARATOR } from "./constants.js"
+import { DEFAULT_SEPARATOR, MAX_RECURSION_DEPTH } from "./constants.js"
 import { transformTextNodes } from "./utils.js"
 
 export type RemarkPunctilioOptions = TransformOptions
-
-/**
- * Maximum recursion depth for tree traversal functions.
- * Prevents stack overflow from maliciously deep Markdown nesting.
- */
-const MAX_RECURSION_DEPTH = 1000
 
 /**
  * MDAST node types that contain phrasing (inline) content and should

--- a/src/symbols.ts
+++ b/src/symbols.ts
@@ -124,6 +124,14 @@ export function mathSymbols(text: string, options: SymbolOptions = {}): string {
 type ContextPredicate = (before: string, after: string) => boolean
 
 /**
+ * Context window, in characters, examined on each side of a legal-symbol
+ * candidate. Large enough to fit a 4-digit year plus surrounding whitespace
+ * or the word "copyright" plus a space, but small enough that the slice
+ * stays cheap on long inputs.
+ */
+const LEGAL_SYMBOL_CONTEXT_WINDOW = 25
+
+/**
  * Context-aware replacement for legal symbols like (c), (r), (tm).
  * Extracts surrounding text, strips separator characters from the context
  * windows, and delegates the convert/skip decision to a predicate.
@@ -136,8 +144,12 @@ function contextAwareLegalReplace(
   separator: string,
 ): string {
   return text.replace(pattern, (match: string, offset: number, str: string) => {
-    const before = str.slice(Math.max(0, offset - 25), offset).replaceAll(separator, "")
-    const after = str.slice(offset + match.length, offset + match.length + 25).replaceAll(separator, "")
+    const before = str
+      .slice(Math.max(0, offset - LEGAL_SYMBOL_CONTEXT_WINDOW), offset)
+      .replaceAll(separator, "")
+    const after = str
+      .slice(offset + match.length, offset + match.length + LEGAL_SYMBOL_CONTEXT_WINDOW)
+      .replaceAll(separator, "")
     return shouldConvert(before, after) ? replacement : match
   })
 }
@@ -163,14 +175,20 @@ export function legalSymbols(text: string, options: SymbolOptions = {}): string 
   return text
 }
 
-/** [asciiPattern, unicodeSymbol] */
-type ArrowRule = [string, string]
+/**
+ * Builds an arrow-shape regex fragment from the escaped separator pattern.
+ * The separator may appear between the halves of a bidirectional `<->`.
+ */
+type ArrowPatternBuilder = (escapedSeparator: string) => string
 
-/** Arrow pattern map: arrow shape → Unicode symbol */
-const ARROW_MAP: ArrowRule[] = [
-  [`<-+${"%CHR%"}?>`, ARROW_LEFT_RIGHT], // Bidirectional: <-> or <-->
-  ["-+>", ARROW_RIGHT],                   // Right: -> or -->
-  ["<-+", ARROW_LEFT],                    // Left: <- or <--
+/** Arrow pattern map: shape builder → Unicode symbol */
+const ARROW_RULES: readonly [ArrowPatternBuilder, string][] = [
+  // Bidirectional: <-> or <--> (separator may fall between the halves)
+  [(sep) => `<-+${sep}?>`, ARROW_LEFT_RIGHT],
+  // Right: -> or -->
+  [() => "-+>", ARROW_RIGHT],
+  // Left: <- or <--
+  [() => "<-+", ARROW_LEFT],
 ]
 
 /** Convert -> and <-> to arrows. */
@@ -180,8 +198,8 @@ export function arrows(text: string, options: SymbolOptions = {}): string {
   const start = spaceBoundaryStart(chr)
   const end = spaceBoundaryEnd(chr)
 
-  for (const [arrowPattern, replacement] of ARROW_MAP) {
-    const pattern = cachedRegExp(`${start}${arrowPattern.replace("%CHR%", chr)}${end}`, "g")
+  for (const [buildArrow, replacement] of ARROW_RULES) {
+    const pattern = cachedRegExp(`${start}${buildArrow(chr)}${end}`, "g")
     text = text.replace(pattern, replacement)
   }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -4,7 +4,7 @@
  * @module utils
  */
 
-import { DEFAULT_SEPARATOR } from "./constants.js"
+import { DEFAULT_SEPARATOR, ISSUES_URL } from "./constants.js"
 
 /** Threshold above which strings are truncated in error messages. */
 const ERROR_STRING_THRESHOLD = 2000
@@ -135,7 +135,7 @@ export function assertSeparatorCountPreserved(
   if (originalCount !== transformedCount) {
     throw new Error(
       `${transformName} altered separator count: expected ${originalCount}, got ${transformedCount}.\n` +
-      `This is a bug in punctilio. Please file an issue at https://github.com/alexander-turner/punctilio/issues\n` +
+      `This is a bug in punctilio. Please file an issue at ${ISSUES_URL}\n` +
       `Include the input text that caused this error.`
     )
   }


### PR DESCRIPTION
## Summary

A targeted code-quality pass. No behavior changes; all 1,596 tests still pass at 100% statement/branch/function/line coverage.

### Hot-path perf
- **`enDashNumberRange` no longer re-maps `numberRangeDisallowedPrefixes` on every call.** The escaped-class fragment is derived from a `const` array, so it's now computed once at module load as `DISALLOWED_PREFIX_CLASS_FRAGMENT`. Every `transform()` call went through this mapping previously.

### De-duplication
- **`MAX_RECURSION_DEPTH`** was duplicated verbatim in `src/rehype.ts` and `src/remark.ts`. Moved to `src/constants.ts` so the two plugins can't drift.
- **The GitHub issue-tracker URL** was hard-coded in both `src/utils.ts` and `src/index.ts` error messages. Now sourced from a single `ISSUES_URL` constant.

### Readability
- **`ARROW_MAP`'s `%CHR%` string-replace placeholder** was a bespoke mini-templating system; two of three entries ran through `.replace("%CHR%", chr)` despite not using the placeholder. Replaced with a typed `ArrowPatternBuilder` so the separator is passed as a proper function argument.
- **Named two magic numbers:**
  - `LEGAL_SYMBOL_CONTEXT_WINDOW = 25` (legal-symbol regex context window, `src/symbols.ts`)
  - `MAX_LAST_WORD_LENGTH = 10` (widow-prevention word-length cap, `src/nbsp.ts`)
  Both with JSDoc explaining why that number.

### Tooling & docs
- **Added `pnpm run benchmark` script** — `benchmark.mjs` is documented in the README but previously had no discoverable npm script.
- **De-staled the README test-count claim** — said "1,550+ tests" while the suite has grown to 1,596. Replaced with a phrasing that won't rot the next time a test is added.

### Deliberately out of scope
- I did not touch `balancedPrimeReplacer`'s `args.length - N` indexing in `src/symbols.ts`. It's brittle but sits inside critical quote-balance logic with 100% coverage; a refactor would be a higher-risk change best done separately.
- No regex logic was modified.
- No formatting-only changes, per `CLAUDE.md`'s "no unnecessary refactoring or whitespace changes."

## Test plan
- [x] `pnpm run build` — clean
- [x] `pnpm run lint` — clean
- [x] `pnpm test` — 1,596 / 1,596 passing, 100% coverage in every category
- [ ] CI (test matrix: Node 18/20/24) passes on this PR
