### PR TITLE
refactor: name capture groups, fix callback indexing, improve error msg

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -293,7 +293,8 @@ export function transform(text: string, options: TransformOptions = {}): string 
         `First pass:  ${formatErrorString(text, "first-pass")}\n` +
         `Second pass: ${formatErrorString(secondPass, "second-pass")}\n` +
         `This is a bug in punctilio. Please file an issue at https://github.com/alexander-turner/punctilio/issues\n` +
-        `Include the input text that caused this error.`
+        `Include the input text that caused this error.\n` +
+        `To suppress this check, pass { checkIdempotency: false }.`
       )
     }
   }

--- a/src/quotes.ts
+++ b/src/quotes.ts
@@ -35,7 +35,7 @@ function convertSingleQuotes(text: string, sep: string): string {
   const singleQuoteChars = `'${LEFT_SINGLE_QUOTE}${RIGHT_SINGLE_QUOTE}${MODIFIER_LETTER_APOSTROPHE}`
   const singleQuoteOrWord = `[${singleQuoteChars}\\w]`
   text = text.replace(cachedRegExp(`(?<!${singleQuoteOrWord})''(?!${singleQuoteOrWord})`, "g"), `${LEFT_SINGLE_QUOTE}${RIGHT_SINGLE_QUOTE}`)
-  text = text.replace(cachedRegExp(`(?<!${singleQuoteOrWord})'(\\s+)'(?!${singleQuoteOrWord})`, "g"), `${LEFT_SINGLE_QUOTE}$1${RIGHT_SINGLE_QUOTE}`)
+  text = text.replace(cachedRegExp(`(?<!${singleQuoteOrWord})'(?<ws>\\s+)'(?!${singleQuoteOrWord})`, "g"), `${LEFT_SINGLE_QUOTE}$<ws>${RIGHT_SINGLE_QUOTE}`)
 
   const afterEndingSinglePatterns = `\\s\\.!?;,\\)${EM_DASH}\\-\\]"`
   // Full pattern with optional 's' for lookahead detection in apostropheRegex
@@ -64,7 +64,7 @@ function convertSingleQuotes(text: string, sep: string): string {
   const endQuoteNotContraction = `(?!${contraction})[${RIGHT_SINGLE_QUOTE}${MODIFIER_LETTER_APOSTROPHE}]${afterEndingSingle}`
   // Limit lookahead scan to 1000 chars to prevent catastrophic backtracking on pathological inputs
   const apostropheRegex = cachedRegExp(
-    `(?<=^|[^\\w])['](${apostropheWhitelist}|(?![^${LEFT_SINGLE_QUOTE}'\\n]{0,1000}${endQuoteNotContraction}))`,
+    `(?<=^|[^\\w])['](?:${apostropheWhitelist}|(?![^${LEFT_SINGLE_QUOTE}'\\n]{0,1000}${endQuoteNotContraction}))`,
     "gm"
   )
   text = text.replace(apostropheRegex, MODIFIER_LETTER_APOSTROPHE)
@@ -147,7 +147,7 @@ function convertDoubleQuotes(text: string, sep: string): string {
 
   text = text.replace(cachedRegExp(`(?<=\\{)(?<sepSpace>${escapedSep}? )?["]`, "g"), `$<sepSpace>${LEFT_DOUBLE_QUOTE}`)
 
-  const endingDouble = `(?<beforeQuote>[^\\s\\(])["]((?<sepAfter>${escapedSep})?)(?=${escapedSep}|[\\s/\\).,;${EM_DASH}:\\-\\}!?s]|$)`
+  const endingDouble = `(?<beforeQuote>[^\\s\\(])["](?<sepAfter>${escapedSep})?(?=${escapedSep}|[\\s/\\).,;${EM_DASH}:\\-\\}!?s]|$)`
   text = text.replace(cachedRegExp(endingDouble, "g"), `$<beforeQuote>${RIGHT_DOUBLE_QUOTE}$<sepAfter>`)
 
   text = text.replace(cachedRegExp(`["](?<sepEnd>${escapedSep}?)$`, "g"), `${RIGHT_DOUBLE_QUOTE}$<sepEnd>`)

--- a/src/symbols.ts
+++ b/src/symbols.ts
@@ -44,9 +44,10 @@ export function ellipsis(text: string, options: SymbolOptions = {}): string {
 
   // Convert consecutive or spaced dots: ... or . . . → …
   // Captures preserve any separators between dots
-  const pattern = cachedRegExp(`\\.[${SPACE_CHARS}]?(${chr})?\\.([${SPACE_CHARS}]?)(${chr})?\\.`, "g")
-  text = text.replace(pattern, (_match, sep1, _space, sep2) => {
-    return ELLIPSIS + (sep1 || "") + (sep2 || "")
+  const pattern = cachedRegExp(`\\.[${SPACE_CHARS}]?(?<sep1>${chr})?\\.(?:[${SPACE_CHARS}]?)(?<sep2>${chr})?\\.`, "g")
+  text = text.replace(pattern, (...args) => {
+    const { sep1, sep2 } = args.at(-1) as Record<string, string | undefined>
+    return ELLIPSIS + (sep1 ?? "") + (sep2 ?? "")
   })
 
   text = text.replace(cachedRegExp(`${ELLIPSIS}(?=[${LATIN_LETTERS}\\d])`, "gu"), `${ELLIPSIS} `)
@@ -61,20 +62,22 @@ export function multiplication(text: string, options: SymbolOptions = {}): strin
   // Match entire multiplication chains in one pass: "5 x 5 x 5" or "5x5x5"
   // Pattern matches: digit(s), then one or more (operator, digit(s)) groups
   const chainPattern = cachedRegExp(
-    `(?<!\\d)(\\d+)((?:${chr}?\\s*[xX*]\\s*${chr}?\\d+)+)`,
+    `(?<!\\d)(?<firstNum>\\d+)(?<rest>(?:${chr}?\\s*[xX*]\\s*${chr}?\\d+)+)`,
     "g"
   )
 
-  text = text.replace(chainPattern, (match, firstNum, rest) => {
+  text = text.replace(chainPattern, (...args) => {
+    const { firstNum, rest } = args.at(-1) as Record<string, string>
     // Skip hexadecimal: 0x... or 0X...
-    if (firstNum === "0" && /^x/i.test(rest)) return match
+    if (firstNum === "0" && /^x/i.test(rest)) return args[0] as string
 
     // Replace all operators in the chain, preserving spacing
     const converted = rest.replace(
-      cachedRegExp(`(${chr}?)(\\s*)[xX*](\\s*)(${chr}?)`, "g"),
-      (_: string, pre: string, spaceBefore: string, spaceAfter: string, post: string) => {
-        const space = spaceBefore || spaceAfter ? " " : ""
-        return `${pre}${space}${MULTIPLICATION}${space}${post}`
+      cachedRegExp(`(?<pre>${chr}?)(?<spaceBefore>\\s*)[xX*](?<spaceAfter>\\s*)(?<post>${chr}?)`, "g"),
+      (...innerArgs) => {
+        const g = innerArgs.at(-1) as Record<string, string>
+        const space = g.spaceBefore || g.spaceAfter ? " " : ""
+        return `${g.pre}${space}${MULTIPLICATION}${space}${g.post}`
       }
     )
     return `${firstNum}${converted}`
@@ -245,9 +248,13 @@ function balancedPrimeReplacer(primeChar: string, escapedSeparator: string) {
     : null
 
   let balance = 0
-  return (...args: unknown[]) => {
+
+  // Replace callback: (match, ...captures, offset, fullString, namedGroups)
+  // Named groups (.at(-1)) are always the last argument; offset and
+  // fullString are 3rd- and 2nd-from-last respectively.
+  return (...args: unknown[]): string => {
     const fullMatch = args[0] as string
-    const groups = args[args.length - 1] as Record<string, string | undefined>
+    const groups = args.at(-1) as Record<string, string | undefined>
 
     // Contraction (letter + quote + letter): skip entirely
     if (groups.contraction !== undefined) {
@@ -269,9 +276,9 @@ function balancedPrimeReplacer(primeChar: string, escapedSeparator: string) {
       // Inside balanced quotes: check if this is feet-inches notation
       // (e.g., 5′10" where ″ is inches, not a closing quote)
       if (feetInchesContext) {
-        const offset = args[args.length - 3] as number
-        const fullString = args[args.length - 2] as string
-        if (feetInchesContext.test(fullString.substring(0, offset))) {
+        const matchOffset = args.at(-3) as number
+        const fullString = args.at(-2) as string
+        if (feetInchesContext.test(fullString.substring(0, matchOffset))) {
           return `${digit}${sep}${primeChar}${afterSep}`
         }
       }
@@ -418,8 +425,11 @@ export function punctuationLigatures(text: string, options: SymbolOptions = {}):
   const chr = getEscapedSeparator(options)
 
   for (const [first, repeated, replacement] of PUNCTUATION_LIGATURE_MAP) {
-    const pattern = cachedRegExp(`${first}(${chr})?${repeated}(?:${chr}?${repeated})*`, "g")
-    text = text.replace(pattern, (_match, sep) => replacement + (sep || ""))
+    const pattern = cachedRegExp(`${first}(?<sep>${chr})?${repeated}(?:${chr}?${repeated})*`, "g")
+    text = text.replace(pattern, (...args) => {
+      const { sep } = (args.at(-1) as Record<string, string | undefined>)
+      return replacement + (sep ?? "")
+    })
   }
 
   return text

--- a/src/symbols.ts
+++ b/src/symbols.ts
@@ -250,8 +250,6 @@ function balancedPrimeReplacer(primeChar: string, escapedSeparator: string) {
   let balance = 0
 
   // Replace callback: (match, ...captures, offset, fullString, namedGroups)
-  // Named groups (.at(-1)) are always the last argument; offset and
-  // fullString are 3rd- and 2nd-from-last respectively.
   return (...args: unknown[]): string => {
     const fullMatch = args[0] as string
     const groups = args.at(-1) as Record<string, string | undefined>


### PR DESCRIPTION
## Summary

- **Name all unnamed regex capture groups** in dynamic `cachedRegExp()` patterns. The ESLint `regexp/prefer-named-capture-group` rule only catches regex literals; these string-built patterns slipped through. Seven groups across `quotes.ts` and `symbols.ts` are now named or converted to non-capturing where the capture was unused.
- **Replace brittle `args[args.length - N]` indexing** in `balancedPrimeReplacer` with `args.at(-N)` and add a comment explaining the `String.prototype.replace` callback layout (`match, ...captures, offset, fullString, namedGroups`).
- **Add `{ checkIdempotency: false }` hint** to the idempotency error message so users know how to suppress the check.

## Test plan
- [x] `pnpm run build` — clean
- [x] `pnpm run lint` — clean
- [x] `pnpm test` — all tests passing, 100% coverage

https://claude.ai/code/session_01QWcmeZiiod6HAKqoJsQLPC