### PR TITLE
refactor: consolidate SPACE_CHARS, use named groups, DRY CI

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -2,6 +2,10 @@ name: Setup
 description: Setup Node.js, pnpm, and install dependencies
 
 inputs:
+  node-version:
+    description: Node.js version to install
+    required: false
+    default: "24"
   registry-url:
     description: npm registry URL (for publishing)
     required: false
@@ -16,7 +20,7 @@ runs:
     - name: Setup Node.js
       uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
       with:
-        node-version: "24"
+        node-version: ${{ inputs.node-version }}
         cache: "pnpm"
         registry-url: ${{ inputs.registry-url }}
 

--- a/.github/workflows/security-vulnerability-scan.yaml
+++ b/.github/workflows/security-vulnerability-scan.yaml
@@ -25,17 +25,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - name: Set up pnpm
-        uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
-
-      - name: Set up Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
-        with:
-          node-version: "24"
-          cache: "pnpm"
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+      - name: Setup
+        uses: ./.github/actions/setup
 
       - name: Check for existing security PR branch
         id: existing-pr

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,17 +16,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
-
-      - name: Setup Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+      - name: Setup
+        uses: ./.github/actions/setup
         with:
           node-version: ${{ matrix.node-version }}
-          cache: "pnpm"
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
 
       - name: Type check
         run: pnpm build --noEmit

--- a/benchmark.mjs
+++ b/benchmark.mjs
@@ -204,11 +204,17 @@ async function runBenchmark() {
   // Performance benchmark
   console.log('\n\n=== PERFORMANCE BENCHMARK ===\n');
   const sampleText = `"Hello," she said. "It's a beautiful day -- isn't it?" The temperature was 20 C and he was 5'10" tall. Pages 1-5 contain important info... See section 1/2 for details.`;
+  const warmupIterations = 100;
   const iterations = 1000;
 
-  console.log(`Sample text (${sampleText.length} chars), ${iterations} iterations:\n`);
+  console.log(`Sample text (${sampleText.length} chars), ${warmupIterations} warmup + ${iterations} timed iterations:\n`);
 
   for (const pkg of packages) {
+    // Warmup: let JIT compile hot paths before timing
+    for (let i = 0; i < warmupIterations; i++) {
+      await runPackage(pkg, sampleText, 'test');
+    }
+
     const start = performance.now();
     for (let i = 0; i < iterations; i++) {
       await runPackage(pkg, sampleText, 'test');

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -196,10 +196,10 @@ export function wordBoundaryEnd(escapedSeparator: string): string {
 }
 
 /**
- * Pattern string for space characters (regular space and non-breaking space).
+ * Pattern string for space characters (regular space, tab, and non-breaking space).
  * Use inside regex character classes: `[${SPACE_CHARS}]`
  */
-export const SPACE_CHARS = ` ${UNICODE_SYMBOLS.NBSP}`
+export const SPACE_CHARS = ` \t${UNICODE_SYMBOLS.NBSP}`
 
 /**
  * Creates a lookbehind pattern that matches after whitespace, separator, or start of string.

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -196,10 +196,10 @@ export function wordBoundaryEnd(escapedSeparator: string): string {
 }
 
 /**
- * Pattern string for space characters (regular space, tab, and non-breaking space).
- * Use inside regex character classes: `[${SPACE_CHARS}]`
+ * Pattern string for space characters (regular space, tab, non-breaking space,
+ * and narrow no-break space). Use inside regex character classes: `[${SPACE_CHARS}]`
  */
-export const SPACE_CHARS = ` \t${UNICODE_SYMBOLS.NBSP}`
+export const SPACE_CHARS = ` \t${UNICODE_SYMBOLS.NBSP}${UNICODE_SYMBOLS.NNBSP}`
 
 /**
  * Creates a lookbehind pattern that matches after whitespace, separator, or start of string.

--- a/src/dashes.ts
+++ b/src/dashes.ts
@@ -64,22 +64,23 @@ export function enDashNumberRange(text: string, options: DashOptions = {}): stri
 
   text = text.replace(
     cachedRegExp(positiveRangePattern, "g"),
-    (match, precedingAreaCode, start, end, following, suffix = "") => {
-      if (following) return match
-      const startNum = start.replace(cachedRegExp(chr, "g"), "")
-      const endNum = end.replace(cachedRegExp(chr, "g"), "")
-      if (/^(?:19|20)\d{2}$/.test(startNum) && /^(?:0[1-9]|1[0-2])$/.test(endNum)) return match
+    (...args) => {
+      const g = args.at(-1) as Record<string, string>
+      if (g.following) return args[0] as string
+      const startNum = g.start.replace(cachedRegExp(chr, "g"), "")
+      const endNum = g.end.replace(cachedRegExp(chr, "g"), "")
+      if (/^(?:19|20)\d{2}$/.test(startNum) && /^(?:0[1-9]|1[0-2])$/.test(endNum)) return args[0] as string
       // Skip 3+4 digit phone-shaped patterns (555-1234, or the second half of
       // 555-123-4567). Thousands-grouped endings (1,234 / 1.234) keep their
       // internal separator and so fail /^\d{4}$/, falling through to convert
       // as ranges. Space/NNBSP/thin-space grouping isn't captured by the outer
       // range regex, so those variants currently aren't affected here.
-      if (/^\d{3}$/.test(startNum) && /^\d{4}$/.test(endNum)) return match
+      if (/^\d{3}$/.test(startNum) && /^\d{4}$/.test(endNum)) return args[0] as string
       // Skip US toll-free prefix pattern: 1-800, 1-888, 1-877, etc.
       // All US toll-free area codes start with 8 (800, 888, 877, 866, 855, 844, 833).
       // We only block 1-8XX to avoid false negatives on legitimate ranges like 1-100.
-      if (/^1$/.test(startNum) && /^8\d{2}$/.test(endNum)) return match
-      return `${precedingAreaCode || ""}${start}${EN_DASH}${end}${suffix || ""}`
+      if (/^1$/.test(startNum) && /^8\d{2}$/.test(endNum)) return args[0] as string
+      return `${g.precedingAreaCode ?? ""}${g.start}${EN_DASH}${g.end}${g.suffix ?? ""}`
     }
   )
 
@@ -90,9 +91,10 @@ export function enDashNumberRange(text: string, options: DashOptions = {}): stri
       `(?<![${LATIN_LETTERS}])(?<start>${MINUS}\\d[\\d.,]*${chr}?)-{1,3}?(?<neg>-)?(?<end>${chr}?\\d[\\d.,]*)(?<following>(?:${chr}?-${chr}?\\d+)*)(?<suffix>${chr}?[xKBTM])?${wbe}`,
       "g"
     ),
-    (match, start, neg, end, following, suffix = "") => {
-      if (following) return match
-      return `${start}${EN_DASH}${neg ? MINUS : ""}${end}${suffix || ""}`
+    (...args) => {
+      const g = args.at(-1) as Record<string, string>
+      if (g.following) return args[0] as string
+      return `${g.start}${EN_DASH}${g.neg ? MINUS : ""}${g.end}${g.suffix ?? ""}`
     }
   )
 

--- a/src/dashes.ts
+++ b/src/dashes.ts
@@ -65,10 +65,10 @@ export function enDashNumberRange(text: string, options: DashOptions = {}): stri
   text = text.replace(
     cachedRegExp(positiveRangePattern, "g"),
     (...args) => {
-      const g = args.at(-1) as Record<string, string>
-      if (g.following) return args[0] as string
-      const startNum = g.start.replace(cachedRegExp(chr, "g"), "")
-      const endNum = g.end.replace(cachedRegExp(chr, "g"), "")
+      const groups = args.at(-1) as Record<string, string>
+      if (groups.following) return args[0] as string
+      const startNum = groups.start.replace(cachedRegExp(chr, "g"), "")
+      const endNum = groups.end.replace(cachedRegExp(chr, "g"), "")
       if (/^(?:19|20)\d{2}$/.test(startNum) && /^(?:0[1-9]|1[0-2])$/.test(endNum)) return args[0] as string
       // Skip 3+4 digit phone-shaped patterns (555-1234, or the second half of
       // 555-123-4567). Thousands-grouped endings (1,234 / 1.234) keep their
@@ -80,7 +80,7 @@ export function enDashNumberRange(text: string, options: DashOptions = {}): stri
       // All US toll-free area codes start with 8 (800, 888, 877, 866, 855, 844, 833).
       // We only block 1-8XX to avoid false negatives on legitimate ranges like 1-100.
       if (/^1$/.test(startNum) && /^8\d{2}$/.test(endNum)) return args[0] as string
-      return `${g.precedingAreaCode ?? ""}${g.start}${EN_DASH}${g.end}${g.suffix ?? ""}`
+      return `${groups.precedingAreaCode ?? ""}${groups.start}${EN_DASH}${groups.end}${groups.suffix ?? ""}`
     }
   )
 
@@ -92,9 +92,9 @@ export function enDashNumberRange(text: string, options: DashOptions = {}): stri
       "g"
     ),
     (...args) => {
-      const g = args.at(-1) as Record<string, string>
-      if (g.following) return args[0] as string
-      return `${g.start}${EN_DASH}${g.neg ? MINUS : ""}${g.end}${g.suffix ?? ""}`
+      const groups = args.at(-1) as Record<string, string>
+      if (groups.following) return args[0] as string
+      return `${groups.start}${EN_DASH}${groups.neg ? MINUS : ""}${groups.end}${groups.suffix ?? ""}`
     }
   )
 
@@ -112,9 +112,9 @@ export function enDashDateRange(text: string, options: DashOptions = {}): string
   return text.replace(
     cachedRegExp(`${wb}(?<startMonth>${months})(?<startYear>${chr}? \\d{4})?(?<preSep>${chr}?)(?<preSpace> ?)-(?<postSpace> ?)(?<postSep>${chr}?)(?<endMonth>${months})(?<endYear> \\d{4})?${wbe}`, "g"),
     (...args) => {
-      const g = args.at(-1) as Record<string, string>
+      const groups = args.at(-1) as Record<string, string>
       const [pre, post] = dashStyle === "british" ? [" ", " "] : ["", ""]
-      return `${g.startMonth}${g.startYear || ""}${g.preSep}${pre}${EN_DASH}${post}${g.postSep}${g.endMonth}${g.endYear || ""}`
+      return `${groups.startMonth}${groups.startYear || ""}${groups.preSep}${pre}${EN_DASH}${post}${groups.postSep}${groups.endMonth}${groups.endYear || ""}`
     }
   )
 }

--- a/src/nbsp.ts
+++ b/src/nbsp.ts
@@ -25,7 +25,7 @@ const {
 export type NbspOptions = Pick<SymbolOptions, "separator">
 
 /** Space pattern matching regular space, tab, and nbsp. */
-const SPACE = `[ \\t${NBSP}]`
+const SPACE = `[${SPACE_CHARS}]`
 
 const UNICODE_UPPERCASE = "\\p{Lu}"
 
@@ -258,7 +258,7 @@ const NBSP_TRANSFORMS: NbspFn[] = [
 export function nbspTransform(text: string, options: NbspOptions = {}): string {
   // All nbsp patterns require a space, tab, or existing nbsp to match.
   // Short-circuit if the text contains none of these.
-  if (!cachedRegExp(`[${SPACE_CHARS}\\t]`, "").test(text)) return text
+  if (!cachedRegExp(`[${SPACE_CHARS}]`, "").test(text)) return text
 
   for (const fn of NBSP_TRANSFORMS) {
     text = fn(text, options)

--- a/src/symbols.ts
+++ b/src/symbols.ts
@@ -100,9 +100,9 @@ export function multiplication(text: string, options: SymbolOptions = {}): strin
         "g"
       ),
       (...innerArgs) => {
-        const g = innerArgs.at(-1) as Record<string, string>
-        const space = g.spaceBefore || g.spaceAfter ? " " : ""
-        return `${g.pre}${space}${MULTIPLICATION}${space}${g.post}${g.num}`
+        const groups = innerArgs.at(-1) as Record<string, string>
+        const space = groups.spaceBefore || groups.spaceAfter ? " " : ""
+        return `${groups.pre}${space}${MULTIPLICATION}${space}${groups.post}${groups.num}`
       }
     )
     return `${firstNum}${converted}`

--- a/src/symbols.ts
+++ b/src/symbols.ts
@@ -440,7 +440,7 @@ export function superscriptOrdinal(text: string, options: SymbolOptions = {}): s
 
 /** Collapse multiple spaces (including tabs) to single space. Prefers nbsp if any nbsp is present. */
 export function collapseSpaces(text: string): string {
-  return text.replace(cachedRegExp(`[${SPACE_CHARS}\\t]{2,}`, "g"), (match) => {
+  return text.replace(cachedRegExp(`[${SPACE_CHARS}]{2,}`, "g"), (match) => {
     return match.includes(NBSP) ? NBSP : " "
   })
 }


### PR DESCRIPTION
## Summary

Thorough codebase audit found no bugs (1631 tests pass at 100% coverage, zero lint errors), but identified several code quality and infrastructure improvements:

- **`SPACE_CHARS` incomplete** — The constant was missing tab and NNBSP (U+202F), forcing callers in `collapseSpaces` and `nbspTransform` to manually append `\\t`. Added both characters to the constant and removed all manual workarounds. NNBSP is used by French guillemet padding and should be treated as space-like for collapsing.
- **Fragile positional regex callback args in `enDashNumberRange`** — Both range callbacks destructured capture groups by position (`match, start, end, ...`) instead of using the named groups already defined in the regex (`?<start>`, `?<end>`, etc.). Reordering or adding a group would silently break the callback. Converted to `args.at(-1)` named-group access, matching the pattern already used by `enDashDateRange`.
- **Short variable name `g`** — Renamed `g` → `groups` in all regex callback destructuring across `dashes.ts` and `symbols.ts`, per project style guide ("Use descriptive variable names; don't shorten for brevity").
- **CI setup duplication** — `test.yml` and `security-vulnerability-scan.yaml` duplicated pnpm/node/install steps instead of using the shared `.github/actions/setup` action. Added a `node-version` input (default `"24"`) to the setup action and migrated both workflows.
- **Benchmark warmup** — the performance section in `benchmark.mjs` timed iterations immediately, so the first package's results included JIT compilation overhead. Added 100 warmup iterations per package before the timed loop.

## Audit findings (no-fix needed)

These items were reviewed and found to be either intentional or not worth changing:

| Finding | Assessment |
|---|---|
| `getTextContent`, `getFirstTextNode`, `assertSmartQuotesMatch` exported from rehype but not called internally | Part of public API for consumers doing manual DOM walking (documented in README) |
| `formatErrorString` writes to stderr as a side effect | Useful for build-log debugging when error messages are truncated; isolated behind try/catch |
| `MODIFIER_LETTER_APOSTROPHE` re-export in index.ts | Convenience alias for a commonly-needed constant |
| Raw regex literals in `legalSymbols` and `convertDoubleQuotes` | Static patterns — `cachedRegExp` overhead not justified; patterns are simple and readable |
| `clearRegexCache` / `clearProcessorCache` exported as `@internal` | Needed for test isolation; `@internal` tag signals non-public |
| Node 18 in test matrix despite EOL | `engines: ">=18"` in package.json; removing would be a breaking change |

## Test plan

- [x] All 1631 tests pass
- [x] 100% branch/function/line/statement coverage maintained
- [x] ESLint passes with zero warnings
- [x] TypeScript compiles cleanly
- [x] Verified CI workflow YAML is valid (setup action inputs are backward-compatible)

https://claude.ai/code/session_01W9pxJCufSKLiAbCCQBG7m8