### PR TITLE
fix: harden flaky perf test, cache regex, and optimize rehype plugin

### DIFF
--- a/src/nbsp.ts
+++ b/src/nbsp.ts
@@ -102,6 +102,8 @@ export const REFERENCE_ABBREVIATIONS = [
 // Precomputed regex fragments — sorted longest-first so the regex alternation
 // matches the most specific unit before a shorter prefix (e.g. "mbar" before "m").
 const UNIT_PATTERN = [...UNITS].sort((a, b) => b.length - a.length).join("|")
+// Honorifics and abbreviations don't need longest-first sorting because
+// the mandatory trailing `\.` disambiguates prefix overlaps (e.g. Mr\. vs Mrs\.).
 const HONORIFIC_PATTERN = HONORIFICS.map((h) => `${h}\\.`).join("|")
 const ABBREVIATION_PATTERN = REFERENCE_ABBREVIATIONS.map((a) => `${a}\\.`).join("|")
 const PUNCTUATION_OR_QUOTE = `[.,!?:;)(${LEFT_DOUBLE_QUOTE}${RIGHT_DOUBLE_QUOTE}\u00AB\u00BB${LEFT_SINGLE_QUOTE}${RIGHT_SINGLE_QUOTE}"]`

--- a/src/nbsp.ts
+++ b/src/nbsp.ts
@@ -99,8 +99,9 @@ export const REFERENCE_ABBREVIATIONS = [
   "Cap",
 ]
 
-// Precomputed regex fragments
-const UNIT_PATTERN = UNITS.join("|")
+// Precomputed regex fragments — sorted longest-first so the regex alternation
+// matches the most specific unit before a shorter prefix (e.g. "mbar" before "m").
+const UNIT_PATTERN = [...UNITS].sort((a, b) => b.length - a.length).join("|")
 const HONORIFIC_PATTERN = HONORIFICS.map((h) => `${h}\\.`).join("|")
 const ABBREVIATION_PATTERN = REFERENCE_ABBREVIATIONS.map((a) => `${a}\\.`).join("|")
 const PUNCTUATION_OR_QUOTE = `[.,!?:;)(${LEFT_DOUBLE_QUOTE}${RIGHT_DOUBLE_QUOTE}\u00AB\u00BB${LEFT_SINGLE_QUOTE}${RIGHT_SINGLE_QUOTE}"]`

--- a/src/rehype.ts
+++ b/src/rehype.ts
@@ -76,21 +76,6 @@ export interface RehypePunctilioOptions
 const DEFAULT_SKIP_TAGS = ["code", "pre", "script", "style", "kbd", "var", "samp"]
 
 /**
- * Check if an element has a specific CSS class.
- */
-function hasClass(node: Element, className: string): boolean {
-  const classNames = node.properties?.className
-  if (Array.isArray(classNames)) {
-    return classNames.includes(className)
-  }
-  /* istanbul ignore next -- rehype-parse always produces arrays, but handle strings defensively */
-  if (typeof classNames === "string") {
-    return classNames.split(/\s+/).includes(className)
-  }
-  return false
-}
-
-/**
  * Check if any ancestor of a node matches a predicate.
  */
 function hasAncestor(
@@ -466,7 +451,8 @@ function hasTextDescendant(
 export function collectTransformableElements(
   node: Element,
   shouldSkip: ElementPredicate,
-  depth: number = 0
+  depth: number = 0,
+  alreadyTransformed?: ReadonlySet<Element>
 ): Element[] {
   /* istanbul ignore if -- defensive: prevents stack overflow from malicious HTML */
   if (depth > MAX_RECURSION_DEPTH) {
@@ -475,7 +461,7 @@ export function collectTransformableElements(
 
   const results: Element[] = []
 
-  if (shouldSkip(node)) {
+  if (shouldSkip(node) || alreadyTransformed?.has(node)) {
     return []
   }
 
@@ -498,7 +484,7 @@ export function collectTransformableElements(
     // children that should be independent, or has no text to transform.
     for (const child of node.children) {
       if (child.type === "element") {
-        const childResults = collectTransformableElements(child, shouldSkip, depth + 1)
+        const childResults = collectTransformableElements(child, shouldSkip, depth + 1, alreadyTransformed)
         for (const r of childResults) results.push(r)
       }
     }
@@ -565,13 +551,23 @@ export function rehypePunctilio(
   } = options
 
   const skipTagSet = new Set(skipTags)
+  const skipClassSet = new Set(skipClasses)
 
   const shouldSkip = (node: Element): boolean => {
     if (skipTagSet.has(node.tagName)) {
       return true
     }
-    if (skipClasses.some((cls) => hasClass(node, cls))) {
-      return true
+    if (skipClassSet.size > 0) {
+      const classNames = node.properties?.className
+      if (Array.isArray(classNames)) {
+        for (const cls of classNames) {
+          if (typeof cls === "string" && skipClassSet.has(cls)) return true
+        }
+      } else if (typeof classNames === "string") {
+        for (const cls of classNames.split(/\s+/)) {
+          if (skipClassSet.has(cls)) return true
+        }
+      }
     }
     return false
   }
@@ -615,7 +611,7 @@ export function rehypePunctilio(
       }
 
       // Collect and transform elements with text content
-      const elementsToTransform = collectTransformableElements(node, shouldSkip)
+      const elementsToTransform = collectTransformableElements(node, shouldSkip, 0, transformed)
       for (const elt of elementsToTransform) {
         if (!transformed.has(elt)) {
           transformElement(elt, transformFn, shouldSkip, separator, false, elementOptions)

--- a/src/rehype.ts
+++ b/src/rehype.ts
@@ -446,6 +446,7 @@ function hasTextDescendant(
  * @param node - The root element to search from
  * @param shouldSkip - Function to determine which elements to skip
  * @param depth - Current recursion depth (internal use)
+ * @param alreadyTransformed - Elements already processed; skipped during traversal to avoid redundant work
  * @returns Array of elements that contain transformable text
  */
 export function collectTransformableElements(
@@ -553,24 +554,17 @@ export function rehypePunctilio(
   const skipTagSet = new Set(skipTags)
   const skipClassSet = new Set(skipClasses)
 
-  const shouldSkip = (node: Element): boolean => {
-    if (skipTagSet.has(node.tagName)) {
-      return true
-    }
-    if (skipClassSet.size > 0) {
-      const classNames = node.properties?.className
-      if (Array.isArray(classNames)) {
-        for (const cls of classNames) {
-          if (typeof cls === "string" && skipClassSet.has(cls)) return true
-        }
-      } else if (typeof classNames === "string") {
-        for (const cls of classNames.split(/\s+/)) {
-          if (skipClassSet.has(cls)) return true
-        }
-      }
-    }
-    return false
+  const hasSkipClass = (node: Element): boolean => {
+    if (skipClassSet.size === 0) return false
+    const classNames = node.properties?.className
+    const classes = Array.isArray(classNames)
+      ? classNames.filter((c): c is string => typeof c === "string")
+      : typeof classNames === "string" ? classNames.split(/\s+/) : []
+    return classes.some((cls) => skipClassSet.has(cls))
   }
+
+  const shouldSkip = (node: Element): boolean =>
+    skipTagSet.has(node.tagName) || hasSkipClass(node)
 
   // Default idempotency check to false in plugin context — the separator
   // count check already guards against corruption, and the double-pass

--- a/src/symbols.ts
+++ b/src/symbols.ts
@@ -301,7 +301,7 @@ function balancedPrimeReplacer(primeChar: string, escapedSeparator: string) {
   // Matches when the text before a prime candidate ends with ′ followed by
   // any mix of digits and separators (e.g., "5′1" before the "0" in 5′10").
   const feetInchesContext = primeChar === DOUBLE_PRIME
-    ? new RegExp(`${PRIME}(?:${escapedSeparator}|\\d)*$`)
+    ? cachedRegExp(`${PRIME}(?:${escapedSeparator}|\\d)*$`, "")
     : null
 
   let balance = 0

--- a/src/tests/rehype.test.ts
+++ b/src/tests/rehype.test.ts
@@ -1,4 +1,4 @@
-import type { Element, Parent, Text, ElementContent } from "hast"
+import type { Element, Parent, Root, Text, ElementContent } from "hast"
 import { h } from "hastscript"
 import { unified } from "unified"
 import rehypeParse from "rehype-parse"
@@ -617,6 +617,28 @@ describe("rehypePunctilio", () => {
       expect(await processHtml('<div>"Before" <code>"Inside"</code> "After"</div>', { nbsp: false })).toEqual(
         `<div>${LDQ}Before${RDQ} <code>"Inside"</code> ${LDQ}After${RDQ}</div>`
       )
+    })
+
+    it("handles string className property (non-standard AST)", async () => {
+      // rehype-parse always produces array classNames, but hand-crafted ASTs
+      // may use strings. The plugin should handle both.
+      const tree: Root = {
+        type: "root",
+        children: [{
+          type: "element",
+          tagName: "p",
+          // Cast to bypass hast's typed className (which expects string[])
+          properties: { className: "no-transform" as unknown as string[] },
+          children: [{ type: "text", value: '"Hello"' }],
+        }],
+      }
+      const processor = unified()
+        .use(rehypePunctilio, { skipClasses: ["no-transform"] })
+        .use(rehypeStringify)
+      await processor.run(tree)
+      // Text should remain untransformed because the class matches
+      const textNode = (tree.children[0] as Element).children[0] as Text
+      expect(textNode.value).toBe('"Hello"')
     })
 
     it("handles mixed skip and non-skip siblings", async () => {

--- a/src/tests/test-helpers.ts
+++ b/src/tests/test-helpers.ts
@@ -89,8 +89,8 @@ export function assertLinearScaling(
   fn(input8x)
   linearBaseline(input8x)
 
-  const minTrials = 5
-  const minElapsedMs = 50
+  const minTrials = 8
+  const minElapsedMs = 200
   let bestRatio = Infinity
   let totalElapsed = 0
   let trials = 0


### PR DESCRIPTION
## Summary

- Fix flaky `assertLinearScaling` test that intermittently fails in CI due to environmental noise (observed ratio 1.947 on a provably O(n) algorithm)
- Eliminate uncached regex allocation, optimize rehype plugin class matching, and reduce redundant tree traversal

## Changes

- **`src/tests/test-helpers.ts`**: Increase `assertLinearScaling` minimum trials from 5→8 and minimum elapsed time from 50→200ms to give the best-ratio sampling more statistical power against CPU/GC noise
- **`src/symbols.ts`**: Replace `new RegExp(...)` with `cachedRegExp(...)` for the `feetInchesContext` pattern in `balancedPrimeReplacer`, consistent with the rest of the codebase's caching strategy
- **`src/nbsp.ts`**: Sort UNITS longest-first in regex alternation so the most specific unit matches before a shorter prefix (e.g. `mbar` before `m`); add comment explaining why honorific/abbreviation patterns don't need this treatment (trailing `\.` disambiguates)
- **`src/rehype.ts`**: Replace `Array.some(hasClass)` with `Set`-based lookup via extracted `hasSkipClass` helper; remove now-dead `hasClass` function; thread `transformed` set through `collectTransformableElements` to skip already-processed subtrees
- **`src/tests/rehype.test.ts`**: Add test for string `className` property edge case (non-standard AST nodes)

## Testing

- All 1657 tests pass with 100% branch/line/function/statement coverage
- ESLint clean
- TypeScript compiles without errors
- Ran full test suite 3 times to verify the flaky perf test no longer fails

https://claude.ai/code/session_014bi8T6RRwvkzBfi2RVQQyn

---
_Generated by [Claude Code](https://claude.ai/code/session_014bi8T6RRwvkzBfi2RVQQyn)_