### PR TITLE
fix: optimize rehype visitor, fix NNBSP collapse, add missing auth token

### DIFF
--- a/.github/workflows/auto-version.yml
+++ b/.github/workflows/auto-version.yml
@@ -30,3 +30,4 @@ jobs:
         run: bash scripts/version-bump.sh
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     timeout-minutes: 15
     strategy:
       matrix:
-        node-version: [18, 20, 24]
+        node-version: [18, 20, 22, 24]
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/scripts/version-bump.sh
+++ b/scripts/version-bump.sh
@@ -9,6 +9,18 @@ set -e
 
 log() { echo "$@" >&2; }
 
+# Validate required environment variables upfront so failures are obvious,
+# not buried after minutes of commit analysis and API calls.
+missing_vars=()
+[ -z "$ANTHROPIC_API_KEY" ] && missing_vars+=("ANTHROPIC_API_KEY")
+[ -z "$NODE_AUTH_TOKEN" ] && missing_vars+=("NODE_AUTH_TOKEN")
+if [ ${#missing_vars[@]} -gt 0 ]; then
+  log "Error: Missing required environment variable(s): ${missing_vars[*]}"
+  log "ANTHROPIC_API_KEY is needed for Claude API version analysis."
+  log "NODE_AUTH_TOKEN is needed for npm registry authentication (set from secrets.NPM_TOKEN in the workflow)."
+  exit 1
+fi
+
 # Get the latest published version from npm (source of truth)
 PACKAGE_NAME=$(node -p "require('./package.json').name")
 CURRENT_VERSION=$(npm view "$PACKAGE_NAME" version 2>/dev/null || echo "0.0.0")

--- a/src/rehype.ts
+++ b/src/rehype.ts
@@ -75,7 +75,6 @@ export interface RehypePunctilioOptions
 
 const DEFAULT_SKIP_TAGS = ["code", "pre", "script", "style", "kbd", "var", "samp"]
 
-
 /**
  * Flattens text nodes from an element tree into a single array.
  *

--- a/src/rehype.ts
+++ b/src/rehype.ts
@@ -10,7 +10,7 @@
 import type { Root, Element, Text, ElementContent, Parent, RootContent } from "hast"
 import type { Transformer } from "unified"
 
-import { visitParents } from "unist-util-visit-parents"
+import { visitParents, SKIP } from "unist-util-visit-parents"
 
 import { transform, type TransformOptions } from "./index.js"
 import { DEFAULT_SEPARATOR, MAX_RECURSION_DEPTH } from "./constants.js"
@@ -75,20 +75,6 @@ export interface RehypePunctilioOptions
 
 const DEFAULT_SKIP_TAGS = ["code", "pre", "script", "style", "kbd", "var", "samp"]
 
-/**
- * Check if any ancestor of a node matches a predicate.
- */
-function hasAncestor(
-  ancestors: Parent[],
-  predicate: ElementPredicate
-): boolean {
-  return ancestors.some((ancestor) => {
-    if (ancestor.type === "element") {
-      return predicate(ancestor as Element)
-    }
-    return false
-  })
-}
 
 /**
  * Flattens text nodes from an element tree into a single array.
@@ -590,18 +576,14 @@ export function rehypePunctilio(
     // Track transformed elements to avoid double-processing
     const transformed = new Set<Element>()
 
-    visitParents(tree, "element", (node, ancestors) => {
-      // Skip if already transformed
+    visitParents(tree, "element", (node) => {
+      // Skip subtree if already transformed
       if (transformed.has(node)) {
-        return
+        return SKIP
       }
 
-      // Check if this node or any ancestor should be skipped
       if (shouldSkip(node)) {
-        return
-      }
-      if (hasAncestor(ancestors as Parent[], shouldSkip)) {
-        return
+        return SKIP
       }
 
       // Collect and transform elements with text content

--- a/src/symbols.ts
+++ b/src/symbols.ts
@@ -452,10 +452,12 @@ export function superscriptOrdinal(text: string, options: SymbolOptions = {}): s
   })
 }
 
-/** Collapse multiple spaces (including tabs) to single space. Prefers nbsp if any nbsp is present. */
+/** Collapse multiple spaces (including tabs) to single space. Preserves the highest-priority space type present in the run: NBSP > NNBSP > regular. */
 export function collapseSpaces(text: string): string {
   return text.replace(cachedRegExp(`[${SPACE_CHARS}]{2,}`, "g"), (match) => {
-    return match.includes(NBSP) ? NBSP : " "
+    if (match.includes(NBSP)) return NBSP
+    if (match.includes(UNICODE_SYMBOLS.NNBSP)) return UNICODE_SYMBOLS.NNBSP
+    return " "
   })
 }
 

--- a/src/tests/rehype.test.ts
+++ b/src/tests/rehype.test.ts
@@ -646,6 +646,24 @@ describe("rehypePunctilio", () => {
         `<article><p>${LDQ}Hello${RDQ}</p><pre>"Code"</pre><p>${LDQ}World${RDQ}</p></article>`
       )
     })
+
+    it("skipClasses with elements that have no className property", async () => {
+      const tree: Root = {
+        type: "root",
+        children: [{
+          type: "element",
+          tagName: "p",
+          properties: {},
+          children: [{ type: "text", value: '"Hello"' }],
+        }],
+      }
+      const processor = unified()
+        .use(rehypePunctilio, { skipClasses: ["no-transform"] })
+        .use(rehypeStringify)
+      await processor.run(tree)
+      const textNode = (tree.children[0] as Element).children[0] as Text
+      expect(textNode.value).toBe(`${LDQ}Hello${RDQ}`)
+    })
   })
 
   describe("stress tests", () => {

--- a/src/tests/symbols.test.ts
+++ b/src/tests/symbols.test.ts
@@ -407,7 +407,7 @@ describe("fractions", () => {
 })
 
 describe("collapseSpaces", () => {
-  const { NBSP } = UNICODE_SYMBOLS
+  const { NBSP, NNBSP } = UNICODE_SYMBOLS
 
   it.each([
     // Multiple regular spaces → single space
@@ -424,6 +424,13 @@ describe("collapseSpaces", () => {
     [`x${NBSP}  y`, `x${NBSP}y`],
     [`a ${NBSP} b`, `a${NBSP}b`],
     [`x${NBSP} ${NBSP}y`, `x${NBSP}y`],
+    // NNBSP: preserved when no NBSP is present
+    [`a${NNBSP} b`, `a${NNBSP}b`],
+    [`a ${NNBSP}b`, `a${NNBSP}b`],
+    [`a${NNBSP}${NNBSP}b`, `a${NNBSP}b`],
+    // NNBSP + NBSP: NBSP wins (higher priority)
+    [`a${NNBSP}${NBSP}b`, `a${NBSP}b`],
+    [`a${NBSP}${NNBSP}b`, `a${NBSP}b`],
     // Single spaces unchanged
     ["hello world", "hello world"],
     [`foo${NBSP}bar`, `foo${NBSP}bar`],

--- a/src/tests/test-helpers.ts
+++ b/src/tests/test-helpers.ts
@@ -89,27 +89,31 @@ export function assertLinearScaling(
   fn(input8x)
   linearBaseline(input8x)
 
-  const minTrials = 8
-  const minElapsedMs = 200
+  // Batch calls until at least minBatchMs elapse, so that even sub-ms
+  // functions produce reliable per-call timings.
+  const minBatchMs = 4
+  function timedBatch(f: (s: string) => unknown, input: string): number {
+    let iterations = 0
+    const start = performance.now()
+    let elapsed = 0
+    while (elapsed < minBatchMs) {
+      f(input)
+      iterations++
+      elapsed = performance.now() - start
+    }
+    return elapsed / iterations
+  }
+
+  const minTrials = 12
+  const minElapsedMs = 400
   let bestRatio = Infinity
   let totalElapsed = 0
   let trials = 0
   while (trials < minTrials || totalElapsed < minElapsedMs) {
-    const startFn4 = performance.now()
-    fn(input4x)
-    const fnTime4 = performance.now() - startFn4
-
-    const startBase4 = performance.now()
-    linearBaseline(input4x)
-    const baseTime4 = performance.now() - startBase4
-
-    const startFn8 = performance.now()
-    fn(input8x)
-    const fnTime8 = performance.now() - startFn8
-
-    const startBase8 = performance.now()
-    linearBaseline(input8x)
-    const baseTime8 = performance.now() - startBase8
+    const fnTime4 = timedBatch(fn, input4x)
+    const baseTime4 = timedBatch(linearBaseline, input4x)
+    const fnTime8 = timedBatch(fn, input8x)
+    const baseTime8 = timedBatch(linearBaseline, input8x)
 
     const fnRatio = (fnTime8 / input8x.length) / (fnTime4 / input4x.length)
     const baseRatio = (baseTime8 / input8x.length) / (baseTime4 / input4x.length)


### PR DESCRIPTION
## Summary

- **Fix missing `NODE_AUTH_TOKEN`** in `auto-version.yml` — `pnpm publish --provenance` cannot authenticate to the npm registry without it, meaning every publish attempt silently fails
- **Optimize rehype plugin visitor** — use `SKIP` return from `visitParents` to prune already-transformed and skipped subtrees, eliminating redundant O(n×depth) `hasAncestor` ancestor walks on every descendant node. Removes the now-dead `hasAncestor` helper entirely
- **Fix `collapseSpaces` destroying NNBSP** (U+202F) — when a narrow no-break space was adjacent to a regular space, it collapsed to a regular space, corrupting French guillemet padding (`« text »`)
- **Add Node 22** (current LTS since Oct 2024) to CI test matrix

## Test plan

- [x] All 1663 tests pass (up from 1657 — added 6 new test cases)
- [x] 100% branch/line/function/statement coverage maintained
- [x] ESLint clean
- [x] TypeScript type check passes
- [ ] Verify CI passes on Node 18, 20, 22, 24 matrix
- [ ] Verify `auto-version.yml` has correct secret name for npm token (`NPM_TOKEN`)

https://claude.ai/code/session_01GSuY37iepMhEeUSPwoYYLr

---
_Generated by [Claude Code](https://claude.ai/code/session_01GSuY37iepMhEeUSPwoYYLr)_