### PR TITLE
Improve token validation for workflow file pushes

### DIFF
--- a/.github/workflows/template-sync.yaml
+++ b/.github/workflows/template-sync.yaml
@@ -66,17 +66,24 @@ jobs:
         env:
           TOKEN: ${{ secrets.TEMPLATE_SYNC_TOKEN || secrets.GITHUB_TOKEN }}
         run: |
-          # GitHub requires 'workflow' scope on PATs to push .github/workflows/ changes.
-          # Check the x-oauth-scopes response header from the GitHub API.
-          SCOPES=$(curl -sS -I -H "Authorization: token $TOKEN" \
-            https://api.github.com/user 2>/dev/null \
-            | grep -i '^x-oauth-scopes:' | sed 's/^[^:]*: //' | tr -d '\r\n' || true)
+          # GitHub requires permission to write .github/workflows/ files:
+          # - Classic PATs: 'workflow' scope (advertised via x-oauth-scopes header)
+          # - Fine-grained PATs: 'Workflows: Read and write' permission (no scope header)
+          # - GITHUB_TOKEN: governed by job-level permissions (no scope header)
+          # Only classic PATs expose scopes, so we only fail-fast for that case.
+          HEADERS=$(curl -sS -I -H "Authorization: token $TOKEN" \
+            https://api.github.com/user 2>/dev/null || true)
+          SCOPES=$(echo "$HEADERS" | grep -i '^x-oauth-scopes:' | sed 's/^[^:]*: //' | tr -d '\r\n' || true)
 
-          if echo "$SCOPES" | tr ',' '\n' | sed 's/^ *//' | grep -qx 'workflow'; then
-            echo "Token has 'workflow' scope."
+          if echo "$HEADERS" | grep -qi '^x-oauth-scopes:'; then
+            if echo "$SCOPES" | tr ',' '\n' | sed 's/^ *//' | grep -qx 'workflow'; then
+              echo "Classic PAT has 'workflow' scope."
+            else
+              echo "::error::TEMPLATE_SYNC_TOKEN is a classic PAT and lacks the 'workflow' scope, which GitHub requires to push changes to .github/workflows/ files. Add the 'workflow' scope to your PAT at https://github.com/settings/tokens and update the TEMPLATE_SYNC_TOKEN repository secret."
+              exit 1
+            fi
           else
-            echo "::error::TEMPLATE_SYNC_TOKEN lacks the 'workflow' scope, which GitHub requires to push changes to .github/workflows/ files. Add the 'workflow' scope to your PAT at https://github.com/settings/tokens and update the TEMPLATE_SYNC_TOKEN repository secret."
-            exit 1
+            echo "Token does not expose OAuth scopes (fine-grained PAT or GITHUB_TOKEN); skipping scope check. Ensure 'Workflows: Read and write' is granted."
           fi
 
       - name: Sync template files with conflict detection

--- a/.github/workflows/template-sync.yaml
+++ b/.github/workflows/template-sync.yaml
@@ -66,25 +66,42 @@ jobs:
         env:
           TOKEN: ${{ secrets.TEMPLATE_SYNC_TOKEN || secrets.GITHUB_TOKEN }}
         run: |
-          # GitHub requires permission to write .github/workflows/ files:
-          # - Classic PATs: 'workflow' scope (advertised via x-oauth-scopes header)
-          # - Fine-grained PATs: 'Workflows: Read and write' permission (no scope header)
-          # - GITHUB_TOKEN: governed by job-level permissions (no scope header)
-          # Only classic PATs expose scopes, so we only fail-fast for that case.
+          # Pushing changes to .github/workflows/ requires a token with workflow-edit
+          # permission. The default GITHUB_TOKEN (installation token, prefix 'ghs_')
+          # CANNOT modify workflow files regardless of the job's permissions block --
+          # GitHub blocks this for security. So TEMPLATE_SYNC_TOKEN must be set to a
+          # PAT.
+          #
+          # - Classic PAT (prefix 'ghp_'): introspect 'workflow' scope via
+          #   x-oauth-scopes header on GET /user.
+          # - Fine-grained PAT (prefix 'github_pat_'): granted permissions are not
+          #   exposed via API, so we trust the configuration and let GitHub return
+          #   the real error at push time if it's wrong.
           HEADERS=$(curl -sS -I -H "Authorization: token $TOKEN" \
             https://api.github.com/user 2>/dev/null || true)
           SCOPES=$(echo "$HEADERS" | grep -i '^x-oauth-scopes:' | sed 's/^[^:]*: //' | tr -d '\r\n' || true)
 
-          if echo "$HEADERS" | grep -qi '^x-oauth-scopes:'; then
-            if echo "$SCOPES" | tr ',' '\n' | sed 's/^ *//' | grep -qx 'workflow'; then
-              echo "Classic PAT has 'workflow' scope."
-            else
-              echo "::error::TEMPLATE_SYNC_TOKEN is a classic PAT and lacks the 'workflow' scope, which GitHub requires to push changes to .github/workflows/ files. Add the 'workflow' scope to your PAT at https://github.com/settings/tokens and update the TEMPLATE_SYNC_TOKEN repository secret."
+          case "$TOKEN" in
+            ghp_*)
+              if echo "$SCOPES" | tr ',' '\n' | sed 's/^ *//' | grep -qx 'workflow'; then
+                echo "Classic PAT has 'workflow' scope."
+              else
+                echo "::error::TEMPLATE_SYNC_TOKEN is a classic PAT and lacks the 'workflow' scope, which GitHub requires to push changes to .github/workflows/ files. Add the 'workflow' scope to your PAT at https://github.com/settings/tokens and update the TEMPLATE_SYNC_TOKEN repository secret."
+                exit 1
+              fi
+              ;;
+            github_pat_*)
+              echo "Fine-grained PAT detected; granted permissions are not introspectable via API. Ensure 'Workflows: Read and write' is granted at https://github.com/settings/personal-access-tokens."
+              ;;
+            ghs_*)
+              echo "::error::TEMPLATE_SYNC_TOKEN is unset and the workflow fell back to GITHUB_TOKEN, which cannot push changes to .github/workflows/ files. Create a PAT with workflow-edit permission and set it as the TEMPLATE_SYNC_TOKEN repository secret."
               exit 1
-            fi
-          else
-            echo "Token does not expose OAuth scopes (fine-grained PAT or GITHUB_TOKEN); skipping scope check. Ensure 'Workflows: Read and write' is granted."
-          fi
+              ;;
+            *)
+              echo "::error::TEMPLATE_SYNC_TOKEN has an unrecognized token type. Use a classic PAT (ghp_*) with the 'workflow' scope or a fine-grained PAT (github_pat_*) with 'Workflows: Read and write'."
+              exit 1
+              ;;
+          esac
 
       - name: Sync template files with conflict detection
         id: sync


### PR DESCRIPTION
## Summary
Enhanced the token validation logic in the template sync workflow to properly handle different GitHub token types (classic PATs, fine-grained PATs, and installation tokens) with appropriate error messages and validation strategies for each.

## Key Changes
- **Token type detection**: Added pattern matching to distinguish between:
  - Classic PATs (`ghp_*`) - validates 'workflow' scope via API introspection
  - Fine-grained PATs (`github_pat_*`) - trusts configuration, defers validation to push time
  - Installation tokens (`ghs_*`) - explicitly rejects with clear error message

- **Improved error messages**: Each token type now has a specific, actionable error message explaining:
  - Why the token is insufficient
  - What permissions/scopes are needed
  - Where to configure the token

- **Better documentation**: Added inline comments explaining:
  - Why GITHUB_TOKEN cannot modify workflow files (security restriction)
  - Why different token types require different validation approaches
  - The limitations of API introspection for fine-grained PATs

## Implementation Details
- Refactored the validation from a simple scope check into a case statement handling all token types
- Maintained backward compatibility with existing classic PAT configurations
- Added support for fine-grained PATs which don't expose permissions via API
- Provides clear guidance when TEMPLATE_SYNC_TOKEN is unset and falls back to GITHUB_TOKEN

https://claude.ai/code/session_01VkEt8sNa3aFXqthEaAB3bF