### PR TITLE
fix: handle single-quoted negatives, hoist legal regexes, exclude tests from package

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   "files": [
     "dist",
     "src",
+    "!src/tests",
     "tsconfig.json"
   ],
   "scripts": {

--- a/src/dashes.ts
+++ b/src/dashes.ts
@@ -35,6 +35,7 @@ const DISALLOWED_PREFIX_CLASS_FRAGMENT = numberRangeDisallowedPrefixes
 export const months = [
   "January", "February", "March", "April", "May", "June",
   "July", "August", "September", "October", "November", "December",
+  // "May" omitted — it's already 3 letters (the full name IS the abbreviation)
   "Jan", "Feb", "Mar", "Apr", "Jun",
   "Jul", "Aug", "Sep", "Oct", "Nov", "Dec",
 ].join("|")
@@ -141,7 +142,7 @@ export function minusReplace(text: string, options: DashOptions = {}): string {
   // Match after: start of line, whitespace, (, or quotes (straight or curly)
   // No space allowed between hyphen and digit
   text = text.replace(
-    cachedRegExp(`(?<before>^|[\\s\\("${LEFT_DOUBLE_QUOTE}${RIGHT_DOUBLE_QUOTE}])-(?<num>\\d*\\.?\\d+)`, "gm"),
+    cachedRegExp(`(?<before>^|[\\s\\("'${LEFT_DOUBLE_QUOTE}${RIGHT_DOUBLE_QUOTE}${LEFT_SINGLE_QUOTE}${RIGHT_SINGLE_QUOTE}])-(?<num>\\d*\\.?\\d+)`, "gm"),
     `$<before>${MINUS}$<num>`
   )
 

--- a/src/symbols.ts
+++ b/src/symbols.ts
@@ -190,24 +190,28 @@ function contextAwareLegalReplace(
   })
 }
 
+const LEGAL_COPYRIGHT_RE = /\(c\)/gi
+const LEGAL_REGISTERED_RE = /\(r\)/gi
+const LEGAL_TRADEMARK_RE = /\(tm\)/gi
+
 /** Convert (c), (r), (tm) to ©, ®, ™. */
 export function legalSymbols(text: string, options: SymbolOptions = {}): string {
   const separator = options.separator ?? DEFAULT_SEPARATOR
   // (c) → © only with positive copyright evidence (year or "copyright" keyword)
   // and not in a path context (e.g., example.com/path(c))
-  text = contextAwareLegalReplace(text, /\(c\)/gi, COPYRIGHT, (before, after) =>
+  text = contextAwareLegalReplace(text, LEGAL_COPYRIGHT_RE, COPYRIGHT, (before, after) =>
     !isPathContext(before) && (/^\s*(?:19|20)\d{2}\b/.test(after) || /\bcopyright\s*$/i.test(before)),
     separator
   )
 
   // (r) → ® unless in enumeration "(q), (r)", legal citation "(r)(1)", or path context
-  text = contextAwareLegalReplace(text, /\(r\)/gi, REGISTERED, (before, after) =>
+  text = contextAwareLegalReplace(text, LEGAL_REGISTERED_RE, REGISTERED, (before, after) =>
     !/\([a-z]\)[,;]\s*$/i.test(before) && !/^\(\d/.test(after) && !isPathContext(before),
     separator
   )
 
   // (tm) → ™ unless in a path context
-  text = contextAwareLegalReplace(text, /\(tm\)/gi, TRADEMARK, (before) =>
+  text = contextAwareLegalReplace(text, LEGAL_TRADEMARK_RE, TRADEMARK, (before) =>
     !isPathContext(before),
     separator
   )

--- a/src/tests/dashes.test.ts
+++ b/src/tests/dashes.test.ts
@@ -311,6 +311,10 @@ describe("minusReplace", () => {
     ["The value is -10", `The value is ${MINUS}10`],
     [" -3", ` ${MINUS}3`],
     ['"-5"', `"${MINUS}5"`],
+    ["'-5'", `'${MINUS}5'`],
+    // Curly quotes (pre-transformed text)
+    [`${LEFT_DOUBLE_QUOTE}-5${RIGHT_DOUBLE_QUOTE}`, `${LEFT_DOUBLE_QUOTE}${MINUS}5${RIGHT_DOUBLE_QUOTE}`],
+    [`${LEFT_SINGLE_QUOTE}-5${RIGHT_SINGLE_QUOTE}`, `${LEFT_SINGLE_QUOTE}${MINUS}5${RIGHT_SINGLE_QUOTE}`],
     // Spaced math subtraction (digit before)
     ["5 - 3", `5 ${MINUS} 3`],
     ["10 - 5 = 5", `10 ${MINUS} 5 = 5`],

--- a/src/tests/index.test.ts
+++ b/src/tests/index.test.ts
@@ -6,6 +6,7 @@ import { assertLinearScaling, buildMixedContent } from "./test-helpers.js"
 const {
   LEFT_DOUBLE_QUOTE,
   RIGHT_DOUBLE_QUOTE,
+  LEFT_SINGLE_QUOTE,
   RIGHT_SINGLE_QUOTE,
   EM_DASH,
   EN_DASH,
@@ -218,6 +219,7 @@ describe("transform", () => {
         // Minus signs - most competitors fail
         ["-5", `${MINUS}5`],
         ["(-5)", `(${MINUS}5)`],
+        ["'-5'", `${LEFT_SINGLE_QUOTE}${MINUS}5${RIGHT_SINGLE_QUOTE}`],
         // Prime marks - smartypants/typograf fail
         ['5\'10"', `5${PRIME}10${DOUBLE_PRIME}`],
         ['He is 6\'2" tall', `He is 6${PRIME}2${DOUBLE_PRIME} tall`],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,5 +16,5 @@
     "isolatedModules": true
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist", "**/*.test.ts"]
+  "exclude": ["node_modules", "dist", "**/*.test.ts", "src/tests"]
 }


### PR DESCRIPTION
## Summary

Thorough codebase audit found four issues across correctness, performance, packaging, and clarity.

### Bug — `minusReplace` missing single-quote context
`minusReplace` Pattern 2 recognized negative numbers after double quotes (`"-5"` → `"−5"`) but not after single quotes. `'-5'` kept its hyphen while `"-5"` was correctly converted. Added straight `'` and curly `'`/`'` to the before-context character class, with tests through both `minusReplace` directly and the full `transform()` pipeline.

### Bug — npm package ships test files
The `files` field in `package.json` included all of `src/`, bundling ~3000 lines of test code. Additionally, `test-helpers.ts` (not matching `*.test.ts`) was compiled into `dist/tests/`. Fixed by adding `!src/tests` to the files array and `src/tests` to tsconfig's exclude list.

### Perf — legal symbol regexes compiled per call
`legalSymbols()` created 3 fresh `RegExp` objects (`/\(c\)/gi`, `/\(r\)/gi`, `/\(tm\)/gi`) on every invocation. Every other symbol transform in the codebase hoists patterns to module-level constants. Hoisted these three to match the existing convention.

### Clarity — "May" abbreviation omission unexplained
The abbreviated months list in `dashes.ts` omits "May" because it IS its own abbreviation (3 letters = full name). Without a comment, this looks like an accidental omission. Added a one-line comment.

## What was NOT changed (and why)

- **Verbose JSDoc comments**: The existing JSDoc serves as API documentation for library consumers. While CLAUDE.md prefers minimal comments, public API docs are a different category.
- **`escape-string-regexp` dual import**: `quotes.ts` needs the raw escaped separator (without `(?:...)` wrapping) for character-class embedding. A separate utility wasn't worth the API surface.
- **`MODIFIER_LETTER_APOSTROPHE` re-export in `index.ts`**: Likely exists for backwards compatibility. Removing it could break consumers.

## Test plan

- [x] All 1680 tests pass (4 new), 100% coverage maintained
- [x] Lint clean
- [x] `npm pack --dry-run` confirms no test files in published package
- [x] Clean build (`rm -rf dist && tsc`) produces no `dist/tests/` artifacts

https://claude.ai/code/session_01WyUi3EPP2ANXxB6YEdGp8v

---
_Generated by [Claude Code](https://claude.ai/code/session_01WyUi3EPP2ANXxB6YEdGp8v)_