### PR TITLE
Use OIDC trusted publishing for npm instead of token auth

### DIFF
--- a/.github/workflows/auto-version.yml
+++ b/.github/workflows/auto-version.yml
@@ -30,4 +30,3 @@ jobs:
         run: bash scripts/version-bump.sh
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/scripts/version-bump.sh
+++ b/scripts/version-bump.sh
@@ -10,14 +10,12 @@ set -e
 log() { echo "$@" >&2; }
 
 # Validate required environment variables upfront so failures are obvious,
-# not buried after minutes of commit analysis and API calls.
-missing_vars=()
-[ -z "$ANTHROPIC_API_KEY" ] && missing_vars+=("ANTHROPIC_API_KEY")
-[ -z "$NODE_AUTH_TOKEN" ] && missing_vars+=("NODE_AUTH_TOKEN")
-if [ ${#missing_vars[@]} -gt 0 ]; then
-  log "Error: Missing required environment variable(s): ${missing_vars[*]}"
+# not buried after minutes of commit analysis and API calls. npm authentication
+# uses OIDC trusted publishing (id-token: write in the workflow), so no
+# NODE_AUTH_TOKEN / NPM_TOKEN is required.
+if [ -z "$ANTHROPIC_API_KEY" ]; then
+  log "Error: Missing required environment variable: ANTHROPIC_API_KEY"
   log "ANTHROPIC_API_KEY is needed for Claude API version analysis."
-  log "NODE_AUTH_TOKEN is needed for npm registry authentication (set from secrets.NPM_TOKEN in the workflow)."
   exit 1
 fi
 


### PR DESCRIPTION
## Summary
Migrate npm authentication from token-based authentication to OIDC trusted publishing, eliminating the need for `NODE_AUTH_TOKEN` / `NPM_TOKEN` secrets.

## Key Changes
- Removed `NODE_AUTH_TOKEN` environment variable requirement from the version bump script
- Updated environment variable validation to only require `ANTHROPIC_API_KEY`
- Removed `NODE_AUTH_TOKEN` from the auto-version workflow
- Updated validation error messages and comments to reflect that npm authentication now uses OIDC trusted publishing via the workflow's `id-token: write` permission

## Implementation Details
The script previously validated both `ANTHROPIC_API_KEY` and `NODE_AUTH_TOKEN` as required environment variables. With OIDC trusted publishing enabled in the GitHub Actions workflow, npm registry authentication is handled automatically through OpenID Connect tokens rather than explicit secret tokens, simplifying the authentication setup and improving security.

https://claude.ai/code/session_01Vddp2FKhuJbtfvaH5vJH7f