### PR TITLE
Preserve leading whitespace in lines for indented code blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Changed
+- `collapseSpaces` now preserves runs of whitespace at the start of a line (after `\n` or start-of-string), so indented blocks like HN-style code survive `transform()`. Mid-line runs still collapse.
+
 ## [3.7.4] - 2026-05-10
 
 ### Fixed

--- a/src/index.ts
+++ b/src/index.ts
@@ -72,8 +72,10 @@ export interface TransformOptions {
   /**
    * Whether to collapse multiple consecutive spaces (including non-breaking
    * spaces) into a single space. Keeps the first space in the sequence.
+   * Runs at the start of a line (after `\n` or start-of-string) are preserved
+   * so indented blocks (e.g. HN-style code) survive.
    *
-   * - `true` (default): "hello  world" → "hello world"
+   * - `true` (default): "hello  world" → "hello world"; "  indented" → "  indented"
    * - `false`: Preserve multiple spaces
    *
    * Default: true

--- a/src/symbols.ts
+++ b/src/symbols.ts
@@ -456,9 +456,9 @@ export function superscriptOrdinal(text: string, options: SymbolOptions = {}): s
   })
 }
 
-/** Collapse multiple spaces (including tabs) to single space. Preserves the highest-priority space type present in the run: NBSP > NNBSP > regular. */
+/** Collapse multiple spaces (including tabs) to single space. Preserves the highest-priority space type present in the run: NBSP > NNBSP > regular. Leading whitespace at the start of a line (after `\n` or start-of-string) is preserved so indented blocks (e.g. HN-style code) survive. */
 export function collapseSpaces(text: string): string {
-  return text.replace(cachedRegExp(`[${SPACE_CHARS}]{2,}`, "g"), (match) => {
+  return text.replace(cachedRegExp(`(?<=[^\\n${SPACE_CHARS}])[${SPACE_CHARS}]{2,}`, "g"), (match) => {
     if (match.includes(NBSP)) return NBSP
     if (match.includes(UNICODE_SYMBOLS.NNBSP)) return UNICODE_SYMBOLS.NNBSP
     return " "

--- a/src/tests/index.test.ts
+++ b/src/tests/index.test.ts
@@ -315,8 +315,20 @@ describe("transform", () => {
       [" ", " "],
       ["\n", "\n"],
       ["\t", "\t"],
-      ["   ", " "],
+      ["   ", "   "],
     ])('handles empty/whitespace: "%s"', (input, expected) => {
+      expect(transform(input, { nbsp: false })).toBe(expected)
+    })
+  })
+
+  describe("leading-of-line whitespace preservation", () => {
+    it.each([
+      ["  hello world", "  hello world"],
+      ["    const x = 1;", "    const x = 1;"],
+      ["a  b\n   c  d", "a b\n   c d"],
+      ["line1\n\n  line2  word", "line1\n\n  line2 word"],
+      ["\n  code   line", "\n  code line"],
+    ])('preserves leading run on "%s"', (input, expected) => {
       expect(transform(input, { nbsp: false })).toBe(expected)
     })
   })

--- a/src/tests/rehype.test.ts
+++ b/src/tests/rehype.test.ts
@@ -155,7 +155,7 @@ describe("rehypePunctilio", () => {
   describe("edge cases", () => {
     it.each([
       ["empty paragraphs", "<p></p>", "<p></p>"],
-      ["whitespace-only", "<p>   </p>", "<p> </p>"],
+      ["whitespace-only", "<p>   </p>", "<p>   </p>"],
       ["special characters", "<p>Café &amp; résumé</p>", "<p>Café &#x26; résumé</p>"],
       ["emoji", '<p>"Hello 👋"</p>', `<p>${LDQ}Hello 👋${RDQ}</p>`],
       ["links", '<p><a href="https://example.com">"Link"</a></p>', `<p><a href="https://example.com">${LDQ}Link${RDQ}</a></p>`],

--- a/src/tests/symbols.test.ts
+++ b/src/tests/symbols.test.ts
@@ -446,11 +446,20 @@ describe("collapseSpaces", () => {
     [`a\t${NBSP}b`, `a${NBSP}b`],
     // Edge cases
     ["", ""],
-    ["  ", " "],
-    [`${NBSP}${NBSP}`, NBSP],
     ["no spaces", "no spaces"],
     // Single tab unchanged
     ["hello\tworld", "hello\tworld"],
+    // Leading-of-line runs preserved (HN-style indented code blocks)
+    ["  ", "  "],
+    [`${NBSP}${NBSP}`, `${NBSP}${NBSP}`],
+    ["    indented", "    indented"],
+    ["\n   second line", "\n   second line"],
+    ["a  b\n   c  d", "a b\n   c d"],
+    ["\n\n  block", "\n\n  block"],
+    // Mid-line runs still collapse even when line also has leading indent
+    ["  foo   bar", "  foo bar"],
+    [`  foo${NBSP}${NBSP}bar`, `  foo${NBSP}bar`],
+    [`\n  a${NBSP}${NBSP}${NBSP}b`, `\n  a${NBSP}b`],
   ])('converts "%s" to "%s"', (input, expected) => {
     expect(collapseSpaces(input)).toBe(expected)
   })


### PR DESCRIPTION
## Summary
This PR modifies the whitespace collapsing behavior to preserve leading whitespace at the start of lines (after newlines or at the beginning of strings). This is essential for maintaining indented code blocks, such as those used in Hacker News-style formatting, while still collapsing multiple spaces within lines.

## Key Changes
- **Updated `collapseSpaces()` regex pattern**: Changed from matching any sequence of 2+ spaces to only matching sequences that are preceded by a non-newline, non-space character. This uses a negative lookbehind `(?<=[^\n${SPACE_CHARS}])` to ensure leading whitespace runs are preserved.

- **Updated JSDoc**: Clarified that leading whitespace at the start of lines is now preserved to support indented code blocks.

- **Updated test cases**: 
  - Modified existing tests to expect leading whitespace to be preserved (e.g., `"   "` now stays as `"   "` instead of collapsing to `" "`)
  - Added comprehensive test suite "leading-of-line whitespace preservation" covering various scenarios including indented code, multiple lines, and mixed spacing
  - Added edge case tests demonstrating that mid-line runs still collapse correctly even when lines have leading indentation

## Implementation Details
The regex change uses a negative lookbehind assertion to only match space runs that follow a non-whitespace character. This means:
- `"a  b"` → `"a b"` (mid-line run collapses)
- `"  a"` → `"  a"` (leading run preserved)
- `"a  b\n   c"` → `"a b\n   c"` (leading run on second line preserved, mid-line run on first line collapses)

This approach maintains backward compatibility for normal text processing while enabling proper handling of code blocks and other indentation-sensitive content.

https://claude.ai/code/session_01JDcS5ai5gDFTnkjCu2aPtT