### PR TITLE
Fix more regex lookaheads across element boundaries

### DIFF
--- a/src/dashes.ts
+++ b/src/dashes.ts
@@ -185,9 +185,10 @@ function convertParentheticalDashes(text: string, sep: string, style: DashStyle)
     // sepAfter and trailing are undefined when the optional group didn't match.
     sepAfter = sepAfter ?? ""
     trailing = trailing ?? ""
-    // For British style (spaced en-dash), preserve trailing spaces after separator.
-    // For American style (unspaced em-dash), consume trailing spaces (em-dash replaces surrounding space).
-    const keepTrailing = maybeSpace && sepAfter ? trailing : ""
+    // Trailing space after a separator belongs to the next text node — keep it
+    // regardless of style. Without a separator, the trailing space is part of
+    // the current node's whitespace around the dash and gets consumed.
+    const keepTrailing = sepAfter ? trailing : ""
     return `${sepBefore}${maybeSpace}${localizedDash}${maybeSpace}${sepAfter}${keepTrailing}`
   })
   // Convert dashes at text node boundaries: separator alone precedes dash (e.g., "word{sep}– rest")

--- a/src/dashes.ts
+++ b/src/dashes.ts
@@ -179,7 +179,7 @@ function convertParentheticalDashes(text: string, sep: string, style: DashStyle)
   // `sepAfter` and `trailing` share one optional unit so a whitespace run
   // can only be assigned to it as a whole, keeping the match unambiguous.
   const spacedDashPattern = cachedRegExp(
-    `(?<=[^\\s]|^)(?<sepBefore>${escapedSep}?)[ ]+(?:[${EN_DASH}${EM_DASH}][-${EN_DASH}${EM_DASH}]*|-{2,}|-(?!${escapedSep}*[${LATIN_LETTERS}\\d]))(?!-*>)[ ]*(?:(?<sepAfter>${escapedSep})(?<trailing>[ ]*))?(?=\\S|$)`, "g"
+    `(?<=[^\\s]|^)(?<sepBefore>${escapedSep}?)[ ]+(?:[${EN_DASH}${EM_DASH}][-${EN_DASH}${EM_DASH}]*|-{2,}|-(?!${escapedSep}*[${LATIN_LETTERS}\\d]))(?!${escapedSep}?-*${escapedSep}?>)[ ]*(?:(?<sepAfter>${escapedSep})(?<trailing>[ ]*))?(?=\\S|$)`, "g"
   )
   text = text.replace(spacedDashPattern, (_match, sepBefore, sepAfter, trailing) => {
     // sepAfter and trailing are undefined when the optional group didn't match.

--- a/src/symbols.ts
+++ b/src/symbols.ts
@@ -43,8 +43,11 @@ export function ellipsis(text: string, options: SymbolOptions = {}): string {
   const chr = getEscapedSeparator(options)
 
   // Convert consecutive or spaced dots: ... or . . . → …
-  // Captures preserve any separators between dots
-  const pattern = cachedRegExp(`\\.[${SPACE_CHARS}]?(?<sep1>${chr})?\\.(?:[${SPACE_CHARS}]?)(?<sep2>${chr})?\\.`, "g")
+  // Each gap allows EITHER a space (same-text-node spaced dots) OR a separator
+  // (cross-boundary contiguous dots), but never both — a space adjacent to a
+  // separator means the dots straddle a text-node boundary and shouldn't fold
+  // into one ellipsis.
+  const pattern = cachedRegExp(`\\.(?:[${SPACE_CHARS}]|(?<sep1>${chr}))?\\.(?:[${SPACE_CHARS}]?|(?<sep2>${chr})?)\\.`, "g")
   text = text.replace(pattern, (...args) => {
     const { sep1, sep2 } = args.at(-1) as Record<string, string | undefined>
     return ELLIPSIS + (sep1 ?? "") + (sep2 ?? "")

--- a/src/symbols.ts
+++ b/src/symbols.ts
@@ -502,12 +502,17 @@ const PUNCTUATION_LIGATURE_MAP: LigatureRule[] = [
 /** Convert ?? to ⁇, ?! to ⁈, !? to ⁉. Poor font support, disabled by default. */
 export function punctuationLigatures(text: string, options: SymbolOptions = {}): string {
   const chr = getEscapedSeparator(options)
+  const sepPattern = cachedRegExp(chr, "g")
 
   for (const [first, repeated, replacement] of PUNCTUATION_LIGATURE_MAP) {
-    const pattern = cachedRegExp(`${first}(?<sep>${chr})?${repeated}(?:${chr}?${repeated})*`, "g")
-    text = text.replace(pattern, (...args) => {
-      const { sep } = (args.at(-1) as Record<string, string | undefined>)
-      return replacement + (sep ?? "")
+    const pattern = cachedRegExp(`${first}(?:${chr}?${repeated})+`, "g")
+    // Re-emit every separator that fell inside the match. The repeat group
+    // can swallow more than one (e.g. across 3+ split text nodes), and
+    // dropping any of them breaks transformTextNodes's text-node-count
+    // invariant.
+    text = text.replace(pattern, (match) => {
+      const seps = match.match(sepPattern) ?? []
+      return replacement + seps.join("")
     })
   }
 

--- a/src/symbols.ts
+++ b/src/symbols.ts
@@ -131,21 +131,27 @@ export function multiplication(text: string, options: SymbolOptions = {}): strin
   return text
 }
 
-/** [leftChars, rightChars, negativeLookahead, replacement] */
-type MathSymbolRule = [string, string, string, string]
+/**
+ * Builds a negative lookahead that must see through an optional separator
+ * so e.g. `!<SEP>=` is correctly recognized as the start of `!==`.
+ */
+type MathLookaheadBuilder = (escapedSeparator: string) => string
+
+/** [leftChars, rightChars, negativeLookaheadBuilder, replacement] */
+type MathSymbolRule = [string, string, MathLookaheadBuilder, string]
 
 /**
  * Math symbol replacement map.
  * The separator is inserted between left and right when building the regex.
  */
 const MATH_SYMBOL_MAP: MathSymbolRule[] = [
-  ["!", "=", "(?!=)", NOT_EQUAL],
-  ["\\+/", "-", "", PLUS_MINUS],
-  ["\\+", "-", "", PLUS_MINUS],
-  ["<", "=", "(?!=)", LESS_EQUAL],
-  [">", "=", "(?!=)", GREATER_EQUAL],
-  ["~", "=", "", APPROXIMATE],
-  ["=", "~", "", APPROXIMATE],
+  ["!", "=", (chr) => `(?!${chr}?=)`, NOT_EQUAL],
+  ["\\+/", "-", () => "", PLUS_MINUS],
+  ["\\+", "-", () => "", PLUS_MINUS],
+  ["<", "=", (chr) => `(?!${chr}?=)`, LESS_EQUAL],
+  [">", "=", (chr) => `(?!${chr}?=)`, GREATER_EQUAL],
+  ["~", "=", () => "", APPROXIMATE],
+  ["=", "~", () => "", APPROXIMATE],
 ]
 
 /** Convert !=, <=, >=, +/-, ~= to Unicode equivalents. */
@@ -156,7 +162,7 @@ export function mathSymbols(text: string, options: SymbolOptions = {}): string {
     // Capture an optional separator between left and right so a cross-boundary
     // match (e.g., `!<SEP>=`) re-emits the separator alongside the replacement
     // and preserves the text-node-count invariant in transformTextNodes.
-    const pattern = cachedRegExp(`${left}(?<sep>${chr})?${right}${lookahead}`, "g")
+    const pattern = cachedRegExp(`${left}(?<sep>${chr})?${right}${lookahead(chr)}`, "g")
     text = text.replace(pattern, (...args) => {
       const { sep } = args.at(-1) as Record<string, string | undefined>
       return `${replacement}${sep ?? ""}`
@@ -242,28 +248,38 @@ export function legalSymbols(text: string, options: SymbolOptions = {}): string 
  */
 type ArrowPatternBuilder = (escapedSeparator: string) => string
 
-/** Arrow pattern map: shape builder → Unicode symbol */
+/**
+ * Arrow pattern map: shape builder → Unicode symbol.
+ *
+ * The leading `<` on the bidi pattern anchors its repeated-dash-run group
+ * so it stays linear-time; the right/left arrows can't anchor that way, so
+ * they only admit one optional separator at the un-anchored end.
+ */
 const ARROW_RULES: readonly [ArrowPatternBuilder, string][] = [
-  // Bidirectional: <-> or <--> (separator may fall between the halves)
-  [(sep) => `<-+${sep}?>`, ARROW_LEFT_RIGHT],
-  // Right: -> or -->
-  [() => "-+>", ARROW_RIGHT],
-  // Left: <- or <--
-  [() => "<-+", ARROW_LEFT],
+  [(sep) => `<${sep}?-+(?:${sep}-+)*${sep}?>`, ARROW_LEFT_RIGHT],
+  [(sep) => `-+${sep}?>`, ARROW_RIGHT],
+  [(sep) => `<${sep}?-+`, ARROW_LEFT],
 ]
 
 /** Convert -> and <-> to arrows. */
 export function arrows(text: string, options: SymbolOptions = {}): string {
   const chr = getEscapedSeparator(options)
+  const sepPattern = cachedRegExp(chr, "g")
   // Boundary on the left is a capturing group rather than a lookbehind so
-  // the alternation stays out of the assertion (recheck-safe); `$1` re-emits
-  // the captured boundary char in the replacement.
+  // the alternation stays out of the assertion (recheck-safe); the captured
+  // boundary char is re-emitted before the replacement.
   const startBoundary = `(^|\\s|${chr})`
   const endBoundary = `(?=\\s|${chr}|$)`
 
   for (const [buildArrow, replacement] of ARROW_RULES) {
     const pattern = cachedRegExp(`${startBoundary}${buildArrow(chr)}${endBoundary}`, "g")
-    text = text.replace(pattern, `$1${replacement}`)
+    // Re-emit every separator the arrow body consumed; dropping any would
+    // break the text-node-count invariant in transformTextNodes.
+    text = text.replace(pattern, (match: string, boundary: string) => {
+      const arrowPart = match.slice(boundary.length)
+      const seps = arrowPart.match(sepPattern) ?? []
+      return `${boundary}${replacement}${seps.join("")}`
+    })
   }
 
   return text

--- a/src/symbols.ts
+++ b/src/symbols.ts
@@ -153,8 +153,14 @@ export function mathSymbols(text: string, options: SymbolOptions = {}): string {
   const chr = getEscapedSeparator(options)
 
   for (const [left, right, lookahead, replacement] of MATH_SYMBOL_MAP) {
-    const pattern = cachedRegExp(`${left}${chr}?${right}${lookahead}`, "g")
-    text = text.replace(pattern, replacement)
+    // Capture an optional separator between left and right so a cross-boundary
+    // match (e.g., `!<SEP>=`) re-emits the separator alongside the replacement
+    // and preserves the text-node-count invariant in transformTextNodes.
+    const pattern = cachedRegExp(`${left}(?<sep>${chr})?${right}${lookahead}`, "g")
+    text = text.replace(pattern, (...args) => {
+      const { sep } = args.at(-1) as Record<string, string | undefined>
+      return `${replacement}${sep ?? ""}`
+    })
   }
   return text
 }

--- a/src/tests/dashes.test.ts
+++ b/src/tests/dashes.test.ts
@@ -162,6 +162,11 @@ describe("hyphenReplace", () => {
       [`word -${sep} another`, `word${EM_DASH}${sep} another`, "hyphen before separator-space is parenthetical"],
       // Suspended hyphen across separator boundary: hyphen attached to word through separator
       [`and -${sep}women`, `and -${sep}women`, "suspended hyphen across separator preserved"],
+      // Arrow shape `-...>` split across separators must not em-dash; the
+      // lookahead sees through the separator(s) before `>`.
+      [`foo -${sep}> bar`, `foo -${sep}> bar`, "single dash before sep+> preserved for arrow"],
+      [`foo --${sep}> bar`, `foo --${sep}> bar`, "double dash before sep+> preserved for arrow"],
+      [`foo -${sep}-${sep}> bar`, `foo -${sep}-${sep}> bar`, "dash, sep, dash, sep, > preserved for arrow"],
     ])("%s → %s (%s)", (input, expected) => {
       expect(hyphenReplace(input, { separator: sep })).toBe(expected)
     })

--- a/src/tests/dashes.test.ts
+++ b/src/tests/dashes.test.ts
@@ -144,14 +144,22 @@ describe("hyphenReplace", () => {
     it.each([
       [`word${sep} - ${sep}another`, `word${sep}${EM_DASH}${sep}another`, "em dash context"],
       [`pages 1${sep}-${sep}5`, `pages 1${sep}${EN_DASH}${sep}5`, "number ranges"],
-      // American em-dash (Chicago style) consumes surrounding spaces, even across separator boundaries
-      [`text ${EM_DASH} ${sep} more text`, `text${EM_DASH}${sep}more text`, "consumes space after separator for em-dash"],
-      [`text - ${sep} more`, `text${EM_DASH}${sep}more`, "consumes space after separator with hyphen"],
+      // American em-dash (Chicago) consumes spaces around the dash within the current text node,
+      // but trailing space after a separator is the leading space of the next text node — preserve it.
+      [`text ${EM_DASH} ${sep} more text`, `text${EM_DASH}${sep} more text`, "preserves space after separator for em-dash"],
+      [`text - ${sep} more`, `text${EM_DASH}${sep} more`, "preserves space after separator with hyphen"],
+      // Separator + trailing space + word: trailing space belongs to next text node
+      [`a - ${sep} w`, `a${EM_DASH}${sep} w`, "preserves leading space of next text node"],
+      // Separator immediately followed by punctuation: no trailing space to preserve
+      [`a - ${sep}, w`, `a${EM_DASH}${sep}, w`, "no trailing space when punctuation follows separator"],
+      // No separator: surrounding spaces are consumed (Chicago style, unchanged)
+      ["a - w", `a${EM_DASH}w`, "no separator: spaces consumed"],
       // Separator-only before dash (no space between word and separator): e.g., link text followed by dash
       [`word${sep}${EN_DASH} rest`, `word${sep}${EM_DASH}rest`, "en-dash after separator without preceding space"],
       [`word${sep}- rest`, `word${sep}${EM_DASH}rest`, "hyphen after separator without preceding space"],
-      // Spaced hyphen with separator after: "word -<sep> another" is a parenthetical dash, not suspended
-      [`word -${sep} another`, `word${EM_DASH}${sep}another`, "hyphen before separator-space is parenthetical"],
+      // Spaced hyphen with separator after: "word -<sep> another" is a parenthetical dash, not suspended.
+      // Trailing space after the separator is the next text node's leading space and is preserved.
+      [`word -${sep} another`, `word${EM_DASH}${sep} another`, "hyphen before separator-space is parenthetical"],
       // Suspended hyphen across separator boundary: hyphen attached to word through separator
       [`and -${sep}women`, `and -${sep}women`, "suspended hyphen across separator preserved"],
     ])("%s → %s (%s)", (input, expected) => {

--- a/src/tests/rehype.test.ts
+++ b/src/tests/rehype.test.ts
@@ -73,6 +73,9 @@ describe("rehypePunctilio", () => {
       ["model name preserved", "<p><em>GPT</em>-3</p>", "<p><em>GPT</em>-3</p>"],
       ["simple range still converts", "<p>pages <em>1</em>-5</p>", `<p>pages <em>1</em>${EN_DASH}5</p>`],
       ["genuine negative at element start", "<p><em>-5</em> degrees</p>", `<p><em>${UNICODE_SYMBOLS.MINUS}5</em> degrees</p>`],
+      // Regression: trailing space after a skipped element must survive em-dash conversion.
+      // The space is the next text node's leading boundary, not whitespace around the dash.
+      ["em-dash preserves space after skip element", "<p>a - <code>x</code> b</p>", `<p>a${EM_DASH}<code>x</code> b</p>`],
     ])("%s", async (_name, html, expected) => {
       expect(await processHtml(html, { nbsp: false })).toEqual(expected)
     })

--- a/src/tests/rehype.test.ts
+++ b/src/tests/rehype.test.ts
@@ -82,6 +82,14 @@ describe("rehypePunctilio", () => {
       // Regression: a math operator split across an element boundary must
       // preserve the separator so transformTextNodes doesn't throw.
       ["math operator split across element boundary", "<p>x <em>!</em>= y</p>", `<p>x <em>${NOT_EQUAL}</em> y</p>`],
+      // Arrow split across element boundary: dash pass must not em-dash the
+      // `-`, then the arrows pass converts the whole shape. The match starts
+      // in the first text node, so the arrow lands there and the em empties.
+      ["right arrow split across element boundary", "<p>foo -<em>></em> bar</p>", `<p>foo ${UNICODE_SYMBOLS.ARROW_RIGHT}<em></em> bar</p>`],
+      ["bidirectional arrow split across element boundary", "<p>foo <-<em>--</em>> bar</p>", `<p>foo ${UNICODE_SYMBOLS.ARROW_LEFT_RIGHT}<em></em> bar</p>`],
+      // The math-symbol lookahead must see through the separator so split
+      // `!==` is not misclassified as `!=`.
+      ["!== split across element boundary preserved", "<p>x !<em>=</em>= y</p>", "<p>x !<em>=</em>= y</p>"],
     ])("%s", async (_name, html, expected) => {
       expect(await processHtml(html, { nbsp: false })).toEqual(expected)
     })

--- a/src/tests/rehype.test.ts
+++ b/src/tests/rehype.test.ts
@@ -76,6 +76,9 @@ describe("rehypePunctilio", () => {
       // Regression: trailing space after a skipped element must survive em-dash conversion.
       // The space is the next text node's leading boundary, not whitespace around the dash.
       ["em-dash preserves space after skip element", "<p>a - <code>x</code> b</p>", `<p>a${EM_DASH}<code>x</code> b</p>`],
+      // Regression: a sentence-final period before a skipped element must not be
+      // swallowed into an ellipsis sequence that lives in the next text node.
+      ["ellipsis after skip element does not eat preceding period", "<p>a. <code>x</code>... b</p>", `<p>a. <code>x</code>${ELLIPSIS} b</p>`],
     ])("%s", async (_name, html, expected) => {
       expect(await processHtml(html, { nbsp: false })).toEqual(expected)
     })

--- a/src/tests/rehype.test.ts
+++ b/src/tests/rehype.test.ts
@@ -85,6 +85,15 @@ describe("rehypePunctilio", () => {
     ])("%s", async (_name, html, expected) => {
       expect(await processHtml(html, { nbsp: false })).toEqual(expected)
     })
+
+    // Regression: 3+ punctuation chars split across 3+ text nodes must
+    // preserve every separator so the ligature pass doesn't crash. Ligatures
+    // are opt-in, so this test enables them explicitly.
+    it("punctuation ligature across 3 text nodes preserves every separator", async () => {
+      const html = "<p>What<em>?</em>?<em>?</em> done</p>"
+      const expected = `<p>What<em>${UNICODE_SYMBOLS.DOUBLE_QUESTION}</em><em></em> done</p>`
+      expect(await processHtml(html, { nbsp: false, ligatures: true })).toEqual(expected)
+    })
   })
 
   describe("skipped elements", () => {

--- a/src/tests/rehype.test.ts
+++ b/src/tests/rehype.test.ts
@@ -79,6 +79,9 @@ describe("rehypePunctilio", () => {
       // Regression: a sentence-final period before a skipped element must not be
       // swallowed into an ellipsis sequence that lives in the next text node.
       ["ellipsis after skip element does not eat preceding period", "<p>a. <code>x</code>... b</p>", `<p>a. <code>x</code>${ELLIPSIS} b</p>`],
+      // Regression: a math operator split across an element boundary must
+      // preserve the separator so transformTextNodes doesn't throw.
+      ["math operator split across element boundary", "<p>x <em>!</em>= y</p>", `<p>x <em>${NOT_EQUAL}</em> y</p>`],
     ])("%s", async (_name, html, expected) => {
       expect(await processHtml(html, { nbsp: false })).toEqual(expected)
     })

--- a/src/tests/symbols.test.ts
+++ b/src/tests/symbols.test.ts
@@ -42,6 +42,23 @@ describe("ellipsis", () => {
     const result = ellipsis(input, { separator: DEFAULT_SEPARATOR })
     expect(result).toBe(expected)
   })
+
+  it.each([
+    // Period at end of one text node + two dots at start of next is NOT an
+    // ellipsis — leave it alone.
+    ["sentence-final period stays put with two trailing dots", `a. ${DEFAULT_SEPARATOR}.. b`, `a. ${DEFAULT_SEPARATOR}.. b`],
+    // Period + space + separator + three dots: only the three contiguous
+    // dots after the separator form the ellipsis.
+    ["three dots after separator collapse without eating period", `a. ${DEFAULT_SEPARATOR}... b`, `a. ${DEFAULT_SEPARATOR}${UNICODE_SYMBOLS.ELLIPSIS} b`],
+    // Regression: same-text-node ellipsis still collapses.
+    ["same-text-node ellipsis", "a... b", `a${UNICODE_SYMBOLS.ELLIPSIS} b`],
+    // Regression: cross-boundary contiguous dots still collapse.
+    ["cross-boundary contiguous", `a.${DEFAULT_SEPARATOR}.${DEFAULT_SEPARATOR}. b`, `a${UNICODE_SYMBOLS.ELLIPSIS}${DEFAULT_SEPARATOR}${DEFAULT_SEPARATOR} b`],
+    // Regression: spaced dots still collapse.
+    ["spaced dots", "a. . . b", `a${UNICODE_SYMBOLS.ELLIPSIS} b`],
+  ])("does not merge across separator boundaries: %s", (_desc, input, expected) => {
+    expect(ellipsis(input, { separator: DEFAULT_SEPARATOR })).toBe(expected)
+  })
 })
 
 describe("multiplication", () => {

--- a/src/tests/symbols.test.ts
+++ b/src/tests/symbols.test.ts
@@ -177,6 +177,16 @@ describe("mathSymbols", () => {
   ])('converts across separator boundary preserving sep: "%s"', (input, expected) => {
     expect(mathSymbols(input, { separator: DEFAULT_SEPARATOR })).toBe(expected)
   })
+
+  // Lookahead sees through the separator so `!==`/`<==`/`>==` split across a
+  // text-node boundary aren't misread as `!=`/`<=`/`>=`.
+  it.each([
+    [`x !${DEFAULT_SEPARATOR}== y`, `x !${DEFAULT_SEPARATOR}== y`],
+    [`x <${DEFAULT_SEPARATOR}== y`, `x <${DEFAULT_SEPARATOR}== y`],
+    [`x >${DEFAULT_SEPARATOR}== y`, `x >${DEFAULT_SEPARATOR}== y`],
+  ])('preserves multi-char operator split across separator: "%s"', (input, expected) => {
+    expect(mathSymbols(input, { separator: DEFAULT_SEPARATOR })).toBe(expected)
+  })
 })
 
 describe("legalSymbols", () => {
@@ -254,6 +264,17 @@ describe("arrows", () => {
     ["array[0]->value", "array[0]->value"],
   ])('converts "%s" to "%s"', (input, expected) => {
     expect(arrows(input)).toBe(expected)
+  })
+
+  // Arrow shapes split across element boundaries: separators between shape
+  // characters are allowed and re-emitted after the Unicode arrow.
+  it.each([
+    [`foo <-${DEFAULT_SEPARATOR}-${DEFAULT_SEPARATOR}> bar`, `foo ${UNICODE_SYMBOLS.ARROW_LEFT_RIGHT}${DEFAULT_SEPARATOR}${DEFAULT_SEPARATOR} bar`],
+    [`foo <${DEFAULT_SEPARATOR}-${DEFAULT_SEPARATOR}> bar`, `foo ${UNICODE_SYMBOLS.ARROW_LEFT_RIGHT}${DEFAULT_SEPARATOR}${DEFAULT_SEPARATOR} bar`],
+    [`foo -${DEFAULT_SEPARATOR}> bar`, `foo ${UNICODE_SYMBOLS.ARROW_RIGHT}${DEFAULT_SEPARATOR} bar`],
+    [`foo <${DEFAULT_SEPARATOR}- bar`, `foo ${UNICODE_SYMBOLS.ARROW_LEFT}${DEFAULT_SEPARATOR} bar`],
+  ])('converts across separator boundary: "%s"', (input, expected) => {
+    expect(arrows(input, { separator: DEFAULT_SEPARATOR })).toBe(expected)
   })
 })
 

--- a/src/tests/symbols.test.ts
+++ b/src/tests/symbols.test.ts
@@ -162,14 +162,20 @@ describe("mathSymbols", () => {
     expect(mathSymbols(input)).toBe(expected)
   })
 
+  // Cross-boundary conversion must preserve the captured separator so the
+  // text-node-count invariant in transformTextNodes holds. Convention: the
+  // Unicode symbol replaces the left operator char, the separator is re-emitted
+  // after it (matching the multiplication test's pre/post-sep convention).
   it.each([
-    [`!${DEFAULT_SEPARATOR}=`, UNICODE_SYMBOLS.NOT_EQUAL],
-    [`<${DEFAULT_SEPARATOR}=`, UNICODE_SYMBOLS.LESS_EQUAL],
-    [`>${DEFAULT_SEPARATOR}=`, UNICODE_SYMBOLS.GREATER_EQUAL],
-    [`~${DEFAULT_SEPARATOR}=`, UNICODE_SYMBOLS.APPROXIMATE],
-    [`=${DEFAULT_SEPARATOR}~`, UNICODE_SYMBOLS.APPROXIMATE],
-  ])('converts across separator boundary: "%s"', (input, expected) => {
-    expect(mathSymbols(input)).toBe(expected)
+    [`!${DEFAULT_SEPARATOR}=`, `${UNICODE_SYMBOLS.NOT_EQUAL}${DEFAULT_SEPARATOR}`],
+    [`<${DEFAULT_SEPARATOR}=`, `${UNICODE_SYMBOLS.LESS_EQUAL}${DEFAULT_SEPARATOR}`],
+    [`>${DEFAULT_SEPARATOR}=`, `${UNICODE_SYMBOLS.GREATER_EQUAL}${DEFAULT_SEPARATOR}`],
+    [`~${DEFAULT_SEPARATOR}=`, `${UNICODE_SYMBOLS.APPROXIMATE}${DEFAULT_SEPARATOR}`],
+    [`=${DEFAULT_SEPARATOR}~`, `${UNICODE_SYMBOLS.APPROXIMATE}${DEFAULT_SEPARATOR}`],
+    [`+/${DEFAULT_SEPARATOR}-`, `${UNICODE_SYMBOLS.PLUS_MINUS}${DEFAULT_SEPARATOR}`],
+    [`+${DEFAULT_SEPARATOR}-`, `${UNICODE_SYMBOLS.PLUS_MINUS}${DEFAULT_SEPARATOR}`],
+  ])('converts across separator boundary preserving sep: "%s"', (input, expected) => {
+    expect(mathSymbols(input, { separator: DEFAULT_SEPARATOR })).toBe(expected)
   })
 })
 

--- a/src/tests/symbols.test.ts
+++ b/src/tests/symbols.test.ts
@@ -585,6 +585,17 @@ describe("punctuationLigatures", () => {
     expect(punctuationLigatures(input, { separator: DEFAULT_SEPARATOR })).toBe(expected)
   })
 
+  // Multi-separator: 3+ punctuation chars split across 3+ text nodes produces
+  // a match with multiple separators inside the repeating group. Every one
+  // must be re-emitted so transformTextNodes's text-node-count invariant holds.
+  it.each([
+    [`?${DEFAULT_SEPARATOR}?${DEFAULT_SEPARATOR}?`, `${UNICODE_SYMBOLS.DOUBLE_QUESTION}${DEFAULT_SEPARATOR}${DEFAULT_SEPARATOR}`],
+    [`!${DEFAULT_SEPARATOR}!${DEFAULT_SEPARATOR}!`, `!${DEFAULT_SEPARATOR}${DEFAULT_SEPARATOR}`],
+    [`??${DEFAULT_SEPARATOR}?${DEFAULT_SEPARATOR}?`, `${UNICODE_SYMBOLS.DOUBLE_QUESTION}${DEFAULT_SEPARATOR}${DEFAULT_SEPARATOR}`],
+  ])("preserves every separator in multi-split %s", (input, expected) => {
+    expect(punctuationLigatures(input, { separator: DEFAULT_SEPARATOR })).toBe(expected)
+  })
+
   it("handles multiple ligatures in same text", () => {
     const input = "What?? Really?! No way!? Wow!!"
     const expected = `What${UNICODE_SYMBOLS.DOUBLE_QUESTION} Really${UNICODE_SYMBOLS.QUESTION_EXCLAMATION} No way${UNICODE_SYMBOLS.EXCLAMATION_QUESTION} Wow!`


### PR DESCRIPTION
Fixes (src/dashes.ts, src/symbols.ts):

Bug 1 — convertParentheticalDashes spaced-dash lookahead now sees through up to one optional separator on each side of internal dashes, so -{sep}>, --{sep}>, and -{sep}-{sep}> survive the em-dash pass for the arrows pass.
Bug 2 — arrows: bidi pattern is <${sep}?-+(?:${sep}-+)*${sep}?> (leading < keeps it linear-time per recheck); right/left arrows admit one optional separator at the un-anchored end. The replace callback re-emits every separator the arrow body consumed so the text-node-count invariant holds.
Bug 3 — mathSymbols lookahead is now a builder that splices an optional separator into the negative assertion ((?!${chr}?=)), so split !==/<==/>== isn't mis-converted.
Tests: parametrized cases added in dashes.test.ts, symbols.test.ts, and rehype.test.ts. Full suite: 1696 passed, 0 failed, 100% coverage, regex-safety clean.

Benchmarks: punctilio 2837 → 2841 ops/sec (within noise; run-to-run variance is ~5%). Quality benchmark unchanged at 150/151 (99.3%).