### PR TITLE
docs(readme): unwrap prime mark example from code font

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ rehypePunctilio({
 
 ## Notes 
 
-- Fully general prime mark conversion (e.g. `5'10"` → `5′10″`) requires semantic understanding to distinguish from closing quotes (e.g. `"Term 1"` should produce closing quotes). `punctilio` tracks quote balance to heuristically determine whether a quote after a number is a closing quote or a prime mark. Other libraries like `tipograph` 0.7.4 use simpler patterns that make more mistakes.
+- Fully general prime mark conversion (e.g. <span class="no-formatting">5'10" → 5′10″</span>) requires semantic understanding to distinguish from closing quotes (e.g. `"Term 1"` should produce closing quotes). `punctilio` tracks quote balance to heuristically determine whether a quote after a number is a closing quote or a prime mark. Other libraries like `tipograph` 0.7.4 use simpler patterns that make more mistakes.
 - The `american` style follows the [Chicago Manual of Style](https://www.chicagomanualofstyle.org/):
   - Periods and commas go inside quotation marks (“Hello,” she said.)
   - Unspaced em-dashes between words (word—word)


### PR DESCRIPTION
The code font in GitHub's renderer doesn't distinguish ' from ′ or " from ″,
which made the 5'10" → 5′10″ example in the Notes section visually identical
on both sides. Switch to the no-formatting span used by the comparison table
so the prime glyphs render in a proportional font.