### PR TITLE
fix(regex): resolve 2 ReDoS-vulnerable patterns flagged by recheck

### DIFF
--- a/src/dashes.ts
+++ b/src/dashes.ts
@@ -198,6 +198,7 @@ function convertParentheticalDashes(text: string, sep: string, style: DashStyle)
     `$<sepBefore>${maybeSpace}${localizedDash}${maybeSpace}$<sepAfter>`
   )
   // Convert multiple dashes: "word--word" or "word---word" or "quote"--"quote"
+  // Upper bound of 50 prevents ReDoS on pathological runs of dashes.
   const quoteChars = `"'${LEFT_DOUBLE_QUOTE}${RIGHT_DOUBLE_QUOTE}${LEFT_SINGLE_QUOTE}${RIGHT_SINGLE_QUOTE}`
   text = text.replace(
     cachedRegExp(`(?<=[${LATIN_LETTERS}\\d${quoteChars}])(?<sepBefore>${escapedSep}?)[${EN_DASH}${EM_DASH}-]{2,50}(?<sepAfter>${escapedSep}?)(?=[${LATIN_LETTERS}${quoteChars} ])`, "g"),

--- a/src/dashes.ts
+++ b/src/dashes.ts
@@ -200,7 +200,7 @@ function convertParentheticalDashes(text: string, sep: string, style: DashStyle)
   // Convert multiple dashes: "word--word" or "word---word" or "quote"--"quote"
   const quoteChars = `"'${LEFT_DOUBLE_QUOTE}${RIGHT_DOUBLE_QUOTE}${LEFT_SINGLE_QUOTE}${RIGHT_SINGLE_QUOTE}`
   text = text.replace(
-    cachedRegExp(`(?<=[${LATIN_LETTERS}\\d${quoteChars}])(?<sepBefore>${escapedSep}?)[${EN_DASH}${EM_DASH}-]{2,}(?<sepAfter>${escapedSep}?)(?=[${LATIN_LETTERS}${quoteChars} ])`, "g"),
+    cachedRegExp(`(?<=[${LATIN_LETTERS}\\d${quoteChars}])(?<sepBefore>${escapedSep}?)[${EN_DASH}${EM_DASH}-]{2,50}(?<sepAfter>${escapedSep}?)(?=[${LATIN_LETTERS}${quoteChars} ])`, "g"),
     `$<sepBefore>${maybeSpace}${localizedDash}${maybeSpace}$<sepAfter>`
   )
   // Convert dashes at start of line

--- a/src/quotes.ts
+++ b/src/quotes.ts
@@ -119,24 +119,23 @@ function convertUnmatchedPluralPossessives(text: string, sep: string): string {
  * Build the beginning-double-quote regex pattern from named fragments.
  */
 function buildBeginningDoublePattern(escapedSep: string, rawEscSep: string): string {
-  const lookbehind = `(?<=^|[\\s\\(\\/\\[\\{\\-${EM_DASH}]|${escapedSep})`
+  // Consuming boundary group: re-emitted in the replacement string.
+  const boundary = `(?<boundary>^|[\\s\\(\\/\\[\\{\\-${EM_DASH}]|${escapedSep})`
   const beforeCapture = `(?<beforeChr>${escapedSep}?)`
 
   // Characters that signal an ending-quote position (not valid openers)
   const endingChars = `\\s\\)${EM_DASH},!?;:.\\}${rawEscSep}`
 
-  const afterAlternatives = [
-    // Separator followed by space/period/comma (consumed into afterChr)
-    `(?<sepWithPunct>${escapedSep}[ .,])`,
-    // Three-period ellipsis or a character that isn't ending punctuation
+  const afterConditions = [
+    `(?=${escapedSep}[ .,])`,
     `(?=${escapedSep}?\\.{3}|${escapedSep}?[^${endingChars}])`,
-    // Content followed by a matching closing straight quote — handles
+    // Lookahead for a closing straight quote within 50 chars — handles
     // quoted punctuation like "?" and "!" where the first char after the
     // opening quote would otherwise look like an ending-quote context
     `(?=[^"]{1,50}")`,
   ]
 
-  return `${lookbehind}${beforeCapture}["](?<afterChr>${afterAlternatives.join("|")})`
+  return `${boundary}${beforeCapture}["](?:${afterConditions.join("|")})`
 }
 
 /** Convert straight double quotes to curly quotes */
@@ -151,7 +150,7 @@ function convertDoubleQuotes(text: string, sep: string): string {
   text = text.replace(/(?<=^|[\s([{])"(?<whitespace>\s+)"(?=$|[\s)\]}.!?,;:])/g, `${LEFT_DOUBLE_QUOTE}$<whitespace>${RIGHT_DOUBLE_QUOTE}`)
 
   const beginningDouble = cachedRegExp(buildBeginningDoublePattern(escapedSep, rawEscSep), "gm")
-  text = text.replace(beginningDouble, `$<beforeChr>${LEFT_DOUBLE_QUOTE}$<afterChr>`)
+  text = text.replace(beginningDouble, `$<boundary>$<beforeChr>${LEFT_DOUBLE_QUOTE}`)
 
   text = text.replace(cachedRegExp(`(?<=\\{)(?<sepSpace>${escapedSep}? )?["]`, "g"), `$<sepSpace>${LEFT_DOUBLE_QUOTE}`)
 

--- a/src/quotes.ts
+++ b/src/quotes.ts
@@ -119,7 +119,8 @@ function convertUnmatchedPluralPossessives(text: string, sep: string): string {
  * Build the beginning-double-quote regex pattern from named fragments.
  */
 function buildBeginningDoublePattern(escapedSep: string, rawEscSep: string): string {
-  // Consuming boundary group: re-emitted in the replacement string.
+  // Consuming boundary (not a lookbehind): variable-width lookbehinds
+  // with alternation cause ReDoS. Re-emitted via $<boundary> in the replacement.
   const boundary = `(?<boundary>^|[\\s\\(\\/\\[\\{\\-${EM_DASH}]|${escapedSep})`
   const beforeCapture = `(?<beforeChr>${escapedSep}?)`
 


### PR DESCRIPTION
## Summary

- Fix two dynamically-composed regex patterns that `recheck` intermittently flags as ReDoS-vulnerable, causing flaky `regex-safety.test.ts` failures
- Both fixes make the patterns provably linear under static analysis without changing observable behavior (verified by all 1702 existing tests at 100% branch coverage)

## Changes

### 1. Multi-dash pattern (`src/dashes.ts:203`)

Bounded the unbounded `[–—-]{2,}` quantifier to `{2,50}` in `convertParentheticalDashes`. The unbounded quantifier combined with adjacent optional separator groups created a pattern that `recheck`'s static analyzer could not prove safe. No functional change — no real text contains 50+ consecutive dashes.

### 2. Beginning-double-quote pattern (`src/quotes.ts:121-140, 153`)

Two structural changes to `buildBeginningDoublePattern`:

- **Lookbehind → consuming boundary**: Replaced the variable-width lookbehind `(?<=^|[\s...]|SEP)` with a consuming boundary group `(?<boundary>^|[\s...]|SEP)` that is re-emitted in the replacement string via `$<boundary>`. The variable-width lookbehind (alternating between zero-width `^`, 1-char `[\s...]`, and 2-char `SEP`) was one source of the ReDoS flag.

- **Mixed alternatives → all-lookahead**: The old `afterChr` group mixed a consuming alternative (`(?<sepWithPunct>SEP[ .,])`) with two zero-width lookaheads. Converted all three alternatives to lookaheads and replaced the named capturing group with a non-capturing group. The previously-consumed separator and punctuation character now remain in place (they were always re-emitted via `$<afterChr>` anyway, so the output is identical).

## Testing

- All 1702 tests pass with 100% statement/branch/function/line coverage
- `regex-safety.test.ts` now passes deterministically (the old patterns passed intermittently — `recheck` uses heuristic analysis that sometimes flags and sometimes doesn't)
- ESLint passes cleanly
- Benchmark results unchanged (150/151)

## Analysis of broader codebase

Beyond the regex fix, I conducted a thorough review. The codebase is high quality:

- **Coverage**: 100% across all metrics with 1702 meaningful tests
- **Security**: ReDoS was the only concern; all other patterns are safe per `recheck` and the ESLint `redos`/`regexp` plugins
- **Documentation**: README examples are accurate, feature tables match benchmark results
- **Architecture**: Clean separation of concerns across modules, effective LRU caching for regex and processor objects
- **Known limitation**: The single benchmark miss (`'Twas a 5' board` — prime vs. apostrophe ambiguity) is correctly documented in the README

---
_Generated by [Claude Code](https://claude.ai/code/session_01CrXCxVw4KqSkWgg6HSfJ69)_