### PR TITLE
refactor(cli): use commander for parsing, help, and choice validation

### DIFF
--- a/package.json
+++ b/package.json
@@ -143,6 +143,7 @@
     }
   },
   "dependencies": {
+    "commander": "14.0.3",
     "escape-string-regexp": "5.0.0",
     "quick-lru": "7.3.0",
     "unist-util-visit-parents": "6.0.2"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      commander:
+        specifier: 14.0.3
+        version: 14.0.3
       escape-string-regexp:
         specifier: 5.0.0
         version: 5.0.0

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -34,30 +34,30 @@ class UsageError extends Error {}
  * all derived from this table. To add or rename a flag, edit exactly
  * one row here.
  */
-type OptionSpec =
-  | {
-      kind: "flag"
-      flag: string
-      section: Section
-      summary: string
-      apply: (opts: CliOptions) => void
-    }
-  | {
-      kind: "string"
-      flag: string
-      section: Section
-      summary: string
-      choices: readonly string[]
-      apply: (opts: CliOptions, value: string) => void
-    }
-  | {
-      kind: "multi"
-      flag: string
-      section: Section
-      summary: string
-      placeholder: string
-      apply: (opts: CliOptions, value: string[]) => void
-    }
+interface OptionSpecBase {
+  flag: string
+  section: Section
+  summary: string
+}
+
+interface FlagSpec extends OptionSpecBase {
+  kind: "flag"
+  apply: (opts: CliOptions) => void
+}
+
+interface StringSpec extends OptionSpecBase {
+  kind: "string"
+  choices: readonly string[]
+  apply: (opts: CliOptions, value: string) => void
+}
+
+interface MultiSpec extends OptionSpecBase {
+  kind: "multi"
+  placeholder: string
+  apply: (opts: CliOptions, value: string[]) => void
+}
+
+type OptionSpec = FlagSpec | StringSpec | MultiSpec
 
 const OPTIONS: readonly OptionSpec[] = [
   // ── Transform options (apply to both Markdown and HTML) ────────────

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -9,7 +9,8 @@
 import { readFile, writeFile } from "node:fs/promises"
 import { extname } from "node:path"
 import { fileURLToPath } from "node:url"
-import { parseArgs } from "node:util"
+
+import { Command, CommanderError, Option } from "commander"
 
 import { transformMarkdown, type MarkdownOptions } from "./markdown.js"
 import { transformHtml, type HtmlOptions } from "./html.js"
@@ -18,7 +19,6 @@ import type { DashStyle } from "./dashes.js"
 
 type CliOptions = MarkdownOptions & HtmlOptions
 type FileType = "md" | "html"
-type Section = "transform" | "markdown" | "html"
 
 interface CliIO {
   stdin: AsyncIterable<string | Buffer>
@@ -28,234 +28,108 @@ interface CliIO {
 
 class UsageError extends Error {}
 
-/**
- * Single source of truth for every CLI flag that maps onto a library
- * option. `parseArgs` config, `buildOptions`, and the HELP string are
- * all derived from this table. To add or rename a flag, edit exactly
- * one row here.
- */
-interface OptionSpecBase {
-  flag: string
-  section: Section
-  summary: string
-}
-
-interface FlagSpec extends OptionSpecBase {
-  kind: "flag"
-  apply: (opts: CliOptions) => void
-}
-
-interface StringSpec extends OptionSpecBase {
-  kind: "string"
-  choices: readonly string[]
-  apply: (opts: CliOptions, value: string) => void
-}
-
-interface MultiSpec extends OptionSpecBase {
-  kind: "multi"
-  placeholder: string
-  apply: (opts: CliOptions, value: string[]) => void
-}
-
-type OptionSpec = FlagSpec | StringSpec | MultiSpec
-
-const OPTIONS: readonly OptionSpec[] = [
-  // ── Transform options (apply to both Markdown and HTML) ────────────
-  {
-    kind: "string", flag: "punctuation-style", section: "transform",
-    choices: ["american", "british", "german", "french", "none"] satisfies readonly PunctuationStyle[],
-    summary: "Quote/punctuation style",
-    apply: (o, v) => { o.punctuationStyle = v as PunctuationStyle },
-  },
-  {
-    kind: "string", flag: "dash-style", section: "transform",
-    choices: ["american", "british", "none"] satisfies readonly DashStyle[],
-    summary: "Dash style",
-    apply: (o, v) => { o.dashStyle = v as DashStyle },
-  },
-  {
-    kind: "flag", flag: "no-symbols", section: "transform",
-    summary: "Disable symbol transforms (ellipsis, ×, ©, etc.)",
-    apply: (o) => { o.symbols = false },
-  },
-  {
-    kind: "flag", flag: "no-nbsp", section: "transform",
-    summary: "Disable non-breaking space insertion",
-    apply: (o) => { o.nbsp = false },
-  },
-  {
-    kind: "flag", flag: "no-collapse-spaces", section: "transform",
-    summary: "Preserve runs of consecutive spaces",
-    apply: (o) => { o.collapseSpaces = false },
-  },
-  {
-    kind: "flag", flag: "no-arrows", section: "transform",
-    summary: "Disable -> → and friends",
-    apply: (o) => { o.includeArrows = false },
-  },
-  {
-    kind: "flag", flag: "fractions", section: "transform",
-    summary: "Enable 1/2 → ½",
-    apply: (o) => { o.fractions = true },
-  },
-  {
-    kind: "flag", flag: "degrees", section: "transform",
-    summary: "Enable 20 C → 20 °C",
-    apply: (o) => { o.degrees = true },
-  },
-  {
-    kind: "flag", flag: "superscript", section: "transform",
-    summary: "Enable 1st → 1ˢᵗ",
-    apply: (o) => { o.superscript = true },
-  },
-  {
-    kind: "flag", flag: "ligatures", section: "transform",
-    summary: "Enable !? → ⁉",
-    apply: (o) => { o.ligatures = true },
-  },
-  // ── Markdown-only options ──────────────────────────────────────────
-  {
-    kind: "string", flag: "emphasis-marker", section: "markdown",
-    choices: ["*", "_"], summary: "Emphasis character",
-    apply: (o, v) => { o.emphasisMarker = v as "*" | "_" },
-  },
-  {
-    kind: "string", flag: "strong-marker", section: "markdown",
-    choices: ["*", "_"], summary: "Strong emphasis character",
-    apply: (o, v) => { o.strongMarker = v as "*" | "_" },
-  },
-  {
-    kind: "string", flag: "bullet-marker", section: "markdown",
-    choices: ["-", "*", "+"], summary: "List bullet character",
-    apply: (o, v) => { o.bulletMarker = v as "-" | "*" | "+" },
-  },
-  {
-    kind: "string", flag: "rule-marker", section: "markdown",
-    choices: ["-", "*", "_"], summary: "Thematic break character",
-    apply: (o, v) => { o.ruleMarker = v as "-" | "*" | "_" },
-  },
-  // ── HTML-only options ──────────────────────────────────────────────
-  {
-    kind: "multi", flag: "skip-tag", section: "html",
-    placeholder: "<tag>",
-    summary: "Tags whose contents are left alone (repeatable)",
-    apply: (o, v) => { o.skipTags = v },
-  },
-  {
-    kind: "multi", flag: "skip-class", section: "html",
-    placeholder: "<class>",
-    summary: "Class names whose elements are skipped (repeatable)",
-    apply: (o, v) => { o.skipClasses = v },
-  },
-  {
-    kind: "flag", flag: "no-fragment", section: "html",
-    summary: "Parse input as a full HTML document",
-    apply: (o) => { o.fragment = false },
-  },
-]
+const FILE_TYPES = ["md", "html"] as const satisfies readonly FileType[]
+const PUNCTUATION_STYLES = ["american", "british", "german", "french", "none"] as const satisfies readonly PunctuationStyle[]
+const DASH_STYLES = ["american", "british", "none"] as const satisfies readonly DashStyle[]
+const EMPHASIS_MARKERS = ["*", "_"] as const
+const BULLET_MARKERS = ["-", "*", "+"] as const
+const RULE_MARKERS = ["-", "*", "_"] as const
 
 const MARKDOWN_EXTENSIONS = new Set([".md", ".markdown"])
 const HTML_EXTENSIONS = new Set([".html", ".htm"])
 
-function inferFileType(path: string, override?: string): FileType {
-  if (override !== undefined) {
-    if (override !== "md" && override !== "html") {
-      throw new UsageError(`Invalid --type "${override}". Use "md" or "html".`)
-    }
-    return override
-  }
+/**
+ * Shape of `program.opts()` after parsing. Fields named after their CLI
+ * flags (camelCased by commander). `commander.choices()` guarantees the
+ * literal types at runtime; we assert them at the boundary.
+ */
+interface ParsedFlags {
+  check?: boolean
+  stdin?: boolean
+  type?: FileType
+  punctuationStyle?: PunctuationStyle
+  dashStyle?: DashStyle
+  symbols?: boolean
+  nbsp?: boolean
+  collapseSpaces?: boolean
+  arrows?: boolean
+  fractions?: boolean
+  degrees?: boolean
+  superscript?: boolean
+  ligatures?: boolean
+  emphasisMarker?: "*" | "_"
+  strongMarker?: "*" | "_"
+  bulletMarker?: "-" | "*" | "+"
+  ruleMarker?: "-" | "*" | "_"
+  skipTag?: string[]
+  skipClass?: string[]
+  fragment?: boolean
+}
+
+function buildProgram(version: string, io: CliIO): Command {
+  return new Command()
+    .name("punctilio")
+    .description("Apply typographic improvements to Markdown and HTML files.")
+    .version(version, "-V, --version", "show version")
+    .argument("[files...]", "files to format; pair with --check for a dry run")
+    .option("--check", "exit 1 if any file would change; write nothing")
+    .option("--stdin", "read content from stdin and write to stdout")
+    .addOption(new Option("--type <type>", "force file type (otherwise inferred from extension)").choices(FILE_TYPES))
+    .addOption(new Option("--punctuation-style <style>", "quote and punctuation style").choices(PUNCTUATION_STYLES))
+    .addOption(new Option("--dash-style <style>", "dash style").choices(DASH_STYLES))
+    .option("--no-symbols", "disable symbol transforms (ellipsis, ×, ©, etc.)")
+    .option("--no-nbsp", "disable non-breaking space insertion")
+    .option("--no-collapse-spaces", "preserve runs of consecutive spaces")
+    .option("--no-arrows", "disable -> → arrow transforms")
+    .option("--fractions", "enable 1/2 → ½")
+    .option("--degrees", "enable 20 C → 20 °C")
+    .option("--superscript", "enable 1st → 1ˢᵗ")
+    .option("--ligatures", "enable !? → ⁉")
+    .addOption(new Option("--emphasis-marker <char>", "markdown emphasis character").choices(EMPHASIS_MARKERS))
+    .addOption(new Option("--strong-marker <char>", "markdown strong emphasis character").choices(EMPHASIS_MARKERS))
+    .addOption(new Option("--bullet-marker <char>", "markdown list bullet character").choices(BULLET_MARKERS))
+    .addOption(new Option("--rule-marker <char>", "markdown thematic break character").choices(RULE_MARKERS))
+    .option("--skip-tag <tag...>", "HTML tags whose contents are left alone (repeatable)")
+    .option("--skip-class <class...>", "HTML class names whose elements are skipped (repeatable)")
+    .option("--no-fragment", "parse input as a full HTML document")
+    .exitOverride()
+    .configureOutput({
+      writeOut: (str) => { io.stdout.write(str) },
+      writeErr: (str) => { io.stderr.write(str) },
+    })
+}
+
+function inferFileType(path: string, override?: FileType): FileType {
+  if (override !== undefined) return override
   const ext = extname(path).toLowerCase()
   if (MARKDOWN_EXTENSIONS.has(ext)) return "md"
   if (HTML_EXTENSIONS.has(ext)) return "html"
   throw new UsageError(
-    `Cannot infer file type from extension "${ext}" for ${path}. Pass --type md|html.`
+    `Cannot infer file type from extension "${ext}" for ${path}. Pass --type md|html.`,
   )
 }
 
-function parseArgsOptions(): Record<string, { type: "string" | "boolean"; short?: string; multiple?: boolean }> {
-  const out: Record<string, { type: "string" | "boolean"; short?: string; multiple?: boolean }> = {
-    help:    { type: "boolean", short: "h" },
-    version: { type: "boolean", short: "V" },
-    check:   { type: "boolean" },
-    stdin:   { type: "boolean" },
-    type:    { type: "string" },
-  }
-  for (const spec of OPTIONS) {
-    out[spec.flag] = spec.kind === "multi"
-      ? { type: "string", multiple: true }
-      : { type: spec.kind === "flag" ? "boolean" : "string" }
-  }
-  return out
-}
-
-function buildOptions(values: Record<string, unknown>): CliOptions {
+function buildOptions(flags: ParsedFlags): CliOptions {
   const opts: CliOptions = {}
-  for (const spec of OPTIONS) {
-    const value = values[spec.flag]
-    if (value === undefined) continue
-    switch (spec.kind) {
-      case "flag":
-        if (value === true) spec.apply(opts)
-        break
-      case "multi":
-        spec.apply(opts, value as string[])
-        break
-      case "string": {
-        const v = value as string
-        if (!spec.choices.includes(v)) {
-          throw new UsageError(
-            `Invalid value "${v}" for --${spec.flag}. Choose from: ${spec.choices.join(", ")}`,
-          )
-        }
-        spec.apply(opts, v)
-        break
-      }
-    }
-  }
+  if (flags.punctuationStyle) opts.punctuationStyle = flags.punctuationStyle
+  if (flags.dashStyle) opts.dashStyle = flags.dashStyle
+  if (flags.symbols === false) opts.symbols = false
+  if (flags.nbsp === false) opts.nbsp = false
+  if (flags.collapseSpaces === false) opts.collapseSpaces = false
+  if (flags.arrows === false) opts.includeArrows = false
+  if (flags.fractions) opts.fractions = true
+  if (flags.degrees) opts.degrees = true
+  if (flags.superscript) opts.superscript = true
+  if (flags.ligatures) opts.ligatures = true
+  if (flags.emphasisMarker) opts.emphasisMarker = flags.emphasisMarker
+  if (flags.strongMarker) opts.strongMarker = flags.strongMarker
+  if (flags.bulletMarker) opts.bulletMarker = flags.bulletMarker
+  if (flags.ruleMarker) opts.ruleMarker = flags.ruleMarker
+  if (flags.skipTag) opts.skipTags = flags.skipTag
+  if (flags.skipClass) opts.skipClasses = flags.skipClass
+  if (flags.fragment === false) opts.fragment = false
   return opts
 }
-
-const HELP_COL = 28
-
-function formatHelpLine(spec: OptionSpec): string {
-  let lhs = `  --${spec.flag}`
-  let suffix = ""
-  if (spec.kind === "multi") lhs += ` ${spec.placeholder}`
-  if (spec.kind === "string") suffix = ` (${spec.choices.join("|")})`
-  return `${lhs.padEnd(HELP_COL)}${spec.summary}${suffix}`
-}
-
-function buildHelp(): string {
-  const sections: Array<[Section, string]> = [
-    ["transform", "Transform options:"],
-    ["markdown", "Markdown-only options:"],
-    ["html", "HTML-only options:"],
-  ]
-  const lines = [
-    "Usage:",
-    "  punctilio [options] <files...>           Format files in place",
-    "  punctilio --check <files...>             Exit 1 if any file would change",
-    "  punctilio --stdin --type <md|html>       Read stdin, write stdout",
-    "",
-    "File-type detection (override with --type):",
-    "  .md, .markdown       markdown",
-    "  .html, .htm          html",
-    "",
-  ]
-  for (const [section, header] of sections) {
-    lines.push(header)
-    for (const spec of OPTIONS) {
-      if (spec.section === section) lines.push(formatHelpLine(spec))
-    }
-    lines.push("")
-  }
-  lines.push("Other:")
-  lines.push("  -h, --help                  Show this help")
-  lines.push("  -V, --version               Show version")
-  return lines.join("\n") + "\n"
-}
-
-const HELP = buildHelp()
 
 async function transformContent(input: string, type: FileType, opts: CliOptions): Promise<string> {
   return type === "md" ? transformMarkdown(input, opts) : transformHtml(input, opts)
@@ -283,6 +157,17 @@ async function readStdin(stdin: AsyncIterable<string | Buffer>): Promise<string>
   return Buffer.concat(chunks).toString("utf8")
 }
 
+async function readPackageVersion(): Promise<string> {
+  const pkgPath = new URL("../package.json", import.meta.url)
+  /* istanbul ignore next -- the catch only fires when package.json is missing or unreadable */
+  try {
+    const raw = await readFile(pkgPath, "utf8")
+    return JSON.parse(raw).version ?? "unknown"
+  } catch {
+    return "unknown"
+  }
+}
+
 /**
  * Runs the CLI with the given arguments and I/O streams.
  *
@@ -290,26 +175,22 @@ async function readStdin(stdin: AsyncIterable<string | Buffer>): Promise<string>
  * 1 if `--check` saw a file that would change, 2 for usage errors.
  */
 export async function runCli(args: string[], io: CliIO): Promise<number> {
-  let parsed
+  const program = buildProgram(await readPackageVersion(), io)
+
   try {
-    parsed = parseArgs({ args, allowPositionals: true, strict: true, options: parseArgsOptions() })
+    program.parse(args, { from: "user" })
   } catch (err) {
-    io.stderr.write(`Error: ${(err as Error).message}\n`)
+    /* istanbul ignore if -- commander only throws CommanderError from parse */
+    if (!(err instanceof CommanderError)) throw err
+    if (err.code === "commander.helpDisplayed" || err.code === "commander.version") return 0
     return 2
   }
-  const { values, positionals } = parsed
 
-  if (values.help) {
-    io.stdout.write(HELP)
-    return 0
-  }
-  if (values.version) {
-    io.stdout.write(`${await readPackageVersion()}\n`)
-    return 0
-  }
+  const flags = program.opts() as ParsedFlags
+  const positionals = program.args
 
   try {
-    return await runValidated(values, positionals as string[], io)
+    return await runValidated(flags, positionals, io, program)
   } catch (err) {
     if (err instanceof UsageError) {
       io.stderr.write(`Error: ${err.message}\n`)
@@ -320,37 +201,36 @@ export async function runCli(args: string[], io: CliIO): Promise<number> {
 }
 
 async function runValidated(
-  values: Record<string, unknown>,
+  flags: ParsedFlags,
   positionals: string[],
   io: CliIO,
+  program: Command,
 ): Promise<number> {
-  const opts = buildOptions(values)
-  const typeOverride = values.type as string | undefined
-  const check = values.check === true
+  const opts = buildOptions(flags)
+  const check = flags.check === true
 
-  if (values.stdin) {
+  if (flags.stdin) {
     if (positionals.length > 0) {
       throw new UsageError("--stdin cannot be combined with file arguments.")
     }
-    if (typeOverride === undefined) {
+    if (flags.type === undefined) {
       throw new UsageError("--stdin requires --type md|html.")
     }
-    const type = inferFileType("<stdin>", typeOverride)
     const input = await readStdin(io.stdin)
-    const output = matchTrailingNewline(input, await transformContent(input, type, opts))
+    const output = matchTrailingNewline(input, await transformContent(input, flags.type, opts))
     if (check) return input === output ? 0 : 1
     io.stdout.write(output)
     return 0
   }
 
   if (positionals.length === 0) {
-    io.stderr.write(HELP)
+    io.stderr.write(program.helpInformation())
     return 2
   }
 
   let anyChanged = false
   for (const path of positionals) {
-    const type = inferFileType(path, typeOverride)
+    const type = inferFileType(path, flags.type)
     const original = await readFile(path, "utf8")
     const formatted = matchTrailingNewline(original, await transformContent(original, type, opts))
     if (original === formatted) continue
@@ -363,17 +243,6 @@ async function runValidated(
     }
   }
   return check && anyChanged ? 1 : 0
-}
-
-async function readPackageVersion(): Promise<string> {
-  const pkgPath = new URL("../package.json", import.meta.url)
-  /* istanbul ignore next -- the catch only fires when package.json is missing or unreadable */
-  try {
-    const raw = await readFile(pkgPath, "utf8")
-    return JSON.parse(raw).version ?? "unknown"
-  } catch {
-    return "unknown"
-  }
 }
 
 /* istanbul ignore next -- entry-point bootstrap; logic is covered via runCli */

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -16,18 +16,9 @@ import { transformHtml, type HtmlOptions } from "./html.js"
 import type { PunctuationStyle } from "./quotes.js"
 import type { DashStyle } from "./dashes.js"
 
-const VALID_PUNCTUATION_STYLES: readonly PunctuationStyle[] = [
-  "american", "british", "german", "french", "none",
-]
-const VALID_DASH_STYLES: readonly DashStyle[] = ["american", "british", "none"]
-const VALID_EMPHASIS_MARKERS = ["*", "_"] as const
-const VALID_BULLET_MARKERS = ["-", "*", "+"] as const
-const VALID_RULE_MARKERS = ["-", "*", "_"] as const
-
-const MARKDOWN_EXTENSIONS = new Set([".md", ".markdown"])
-const HTML_EXTENSIONS = new Set([".html", ".htm"])
-
+type CliOptions = MarkdownOptions & HtmlOptions
 type FileType = "md" | "html"
+type Section = "transform" | "markdown" | "html"
 
 interface CliIO {
   stdin: AsyncIterable<string | Buffer>
@@ -37,42 +28,134 @@ interface CliIO {
 
 class UsageError extends Error {}
 
-const HELP = `Usage:
-  punctilio [options] <files...>           Format files in place
-  punctilio --check <files...>             Exit 1 if any file would change
-  punctilio --stdin --type <md|html>       Read stdin, write stdout
+/**
+ * Single source of truth for every CLI flag that maps onto a library
+ * option. `parseArgs` config, `buildOptions`, and the HELP string are
+ * all derived from this table. To add or rename a flag, edit exactly
+ * one row here.
+ */
+type OptionSpec =
+  | {
+      kind: "flag"
+      flag: string
+      section: Section
+      summary: string
+      apply: (opts: CliOptions) => void
+    }
+  | {
+      kind: "string"
+      flag: string
+      section: Section
+      summary: string
+      choices: readonly string[]
+      apply: (opts: CliOptions, value: string) => void
+    }
+  | {
+      kind: "multi"
+      flag: string
+      section: Section
+      summary: string
+      placeholder: string
+      apply: (opts: CliOptions, value: string[]) => void
+    }
 
-File-type detection (override with --type):
-  .md, .markdown       markdown
-  .html, .htm          html
+const OPTIONS: readonly OptionSpec[] = [
+  // ── Transform options (apply to both Markdown and HTML) ────────────
+  {
+    kind: "string", flag: "punctuation-style", section: "transform",
+    choices: ["american", "british", "german", "french", "none"] satisfies readonly PunctuationStyle[],
+    summary: "Quote/punctuation style",
+    apply: (o, v) => { o.punctuationStyle = v as PunctuationStyle },
+  },
+  {
+    kind: "string", flag: "dash-style", section: "transform",
+    choices: ["american", "british", "none"] satisfies readonly DashStyle[],
+    summary: "Dash style",
+    apply: (o, v) => { o.dashStyle = v as DashStyle },
+  },
+  {
+    kind: "flag", flag: "no-symbols", section: "transform",
+    summary: "Disable symbol transforms (ellipsis, ×, ©, etc.)",
+    apply: (o) => { o.symbols = false },
+  },
+  {
+    kind: "flag", flag: "no-nbsp", section: "transform",
+    summary: "Disable non-breaking space insertion",
+    apply: (o) => { o.nbsp = false },
+  },
+  {
+    kind: "flag", flag: "no-collapse-spaces", section: "transform",
+    summary: "Preserve runs of consecutive spaces",
+    apply: (o) => { o.collapseSpaces = false },
+  },
+  {
+    kind: "flag", flag: "no-arrows", section: "transform",
+    summary: "Disable -> → and friends",
+    apply: (o) => { o.includeArrows = false },
+  },
+  {
+    kind: "flag", flag: "fractions", section: "transform",
+    summary: "Enable 1/2 → ½",
+    apply: (o) => { o.fractions = true },
+  },
+  {
+    kind: "flag", flag: "degrees", section: "transform",
+    summary: "Enable 20 C → 20 °C",
+    apply: (o) => { o.degrees = true },
+  },
+  {
+    kind: "flag", flag: "superscript", section: "transform",
+    summary: "Enable 1st → 1ˢᵗ",
+    apply: (o) => { o.superscript = true },
+  },
+  {
+    kind: "flag", flag: "ligatures", section: "transform",
+    summary: "Enable !? → ⁉",
+    apply: (o) => { o.ligatures = true },
+  },
+  // ── Markdown-only options ──────────────────────────────────────────
+  {
+    kind: "string", flag: "emphasis-marker", section: "markdown",
+    choices: ["*", "_"], summary: "Emphasis character",
+    apply: (o, v) => { o.emphasisMarker = v as "*" | "_" },
+  },
+  {
+    kind: "string", flag: "strong-marker", section: "markdown",
+    choices: ["*", "_"], summary: "Strong emphasis character",
+    apply: (o, v) => { o.strongMarker = v as "*" | "_" },
+  },
+  {
+    kind: "string", flag: "bullet-marker", section: "markdown",
+    choices: ["-", "*", "+"], summary: "List bullet character",
+    apply: (o, v) => { o.bulletMarker = v as "-" | "*" | "+" },
+  },
+  {
+    kind: "string", flag: "rule-marker", section: "markdown",
+    choices: ["-", "*", "_"], summary: "Thematic break character",
+    apply: (o, v) => { o.ruleMarker = v as "-" | "*" | "_" },
+  },
+  // ── HTML-only options ──────────────────────────────────────────────
+  {
+    kind: "multi", flag: "skip-tag", section: "html",
+    placeholder: "<tag>",
+    summary: "Tags whose contents are left alone (repeatable)",
+    apply: (o, v) => { o.skipTags = v },
+  },
+  {
+    kind: "multi", flag: "skip-class", section: "html",
+    placeholder: "<class>",
+    summary: "Class names whose elements are skipped (repeatable)",
+    apply: (o, v) => { o.skipClasses = v },
+  },
+  {
+    kind: "flag", flag: "no-fragment", section: "html",
+    summary: "Parse input as a full HTML document",
+    apply: (o) => { o.fragment = false },
+  },
+]
 
-Transform options:
-  --punctuation-style <american|british|german|french|none>
-  --dash-style <american|british|none>
-  --no-symbols              Disable symbol transforms (ellipsis, ×, ©, etc.)
-  --no-nbsp                 Disable non-breaking space insertion
-  --no-collapse-spaces      Preserve runs of consecutive spaces
-  --no-arrows               Disable -> → → and friends
-  --fractions               Enable 1/2 → ½
-  --degrees                 Enable 20 C → 20 °C
-  --superscript             Enable 1st → 1ˢᵗ
-  --ligatures               Enable !? → ⁉
-
-Markdown-only options:
-  --emphasis-marker <*|_>
-  --strong-marker <*|_>
-  --bullet-marker <-|*|+>
-  --rule-marker <-|*|_>
-
-HTML-only options:
-  --skip-tag <tag>          (repeatable) Tags whose contents are left alone
-  --skip-class <class>      (repeatable) Class names whose elements are skipped
-  --no-fragment             Parse input as a full HTML document
-
-Other:
-  -h, --help                Show this help
-  -V, --version             Show version
-`
+const MARKDOWN_EXTENSIONS = new Set([".md", ".markdown"])
+const HTML_EXTENSIONS = new Set([".html", ".htm"])
 
 function inferFileType(path: string, override?: string): FileType {
   if (override !== undefined) {
@@ -89,87 +172,93 @@ function inferFileType(path: string, override?: string): FileType {
   )
 }
 
-function validateChoice<T extends readonly string[]>(
-  value: string | undefined,
-  choices: T,
-  flag: string,
-): T[number] | undefined {
-  if (value === undefined) return undefined
-  if (!choices.includes(value)) {
-    throw new UsageError(`Invalid value "${value}" for --${flag}. Choose from: ${choices.join(", ")}`)
+function parseArgsOptions(): Record<string, { type: "string" | "boolean"; short?: string; multiple?: boolean }> {
+  const out: Record<string, { type: "string" | "boolean"; short?: string; multiple?: boolean }> = {
+    help:    { type: "boolean", short: "h" },
+    version: { type: "boolean", short: "V" },
+    check:   { type: "boolean" },
+    stdin:   { type: "boolean" },
+    type:    { type: "string" },
   }
-  return value as T[number]
+  for (const spec of OPTIONS) {
+    out[spec.flag] = spec.kind === "multi"
+      ? { type: "string", multiple: true }
+      : { type: spec.kind === "flag" ? "boolean" : "string" }
+  }
+  return out
 }
 
-type ParsedValues = {
-  "punctuation-style"?: string
-  "dash-style"?: string
-  "no-symbols"?: boolean
-  "no-nbsp"?: boolean
-  "no-collapse-spaces"?: boolean
-  "no-arrows"?: boolean
-  fractions?: boolean
-  degrees?: boolean
-  superscript?: boolean
-  ligatures?: boolean
-  "emphasis-marker"?: string
-  "strong-marker"?: string
-  "bullet-marker"?: string
-  "rule-marker"?: string
-  "skip-tag"?: string[]
-  "skip-class"?: string[]
-  "no-fragment"?: boolean
+function buildOptions(values: Record<string, unknown>): CliOptions {
+  const opts: CliOptions = {}
+  for (const spec of OPTIONS) {
+    const value = values[spec.flag]
+    if (value === undefined) continue
+    switch (spec.kind) {
+      case "flag":
+        if (value === true) spec.apply(opts)
+        break
+      case "multi":
+        spec.apply(opts, value as string[])
+        break
+      case "string": {
+        const v = value as string
+        if (!spec.choices.includes(v)) {
+          throw new UsageError(
+            `Invalid value "${v}" for --${spec.flag}. Choose from: ${spec.choices.join(", ")}`,
+          )
+        }
+        spec.apply(opts, v)
+        break
+      }
+    }
+  }
+  return opts
 }
 
-interface BuiltOptions {
-  markdown: MarkdownOptions
-  html: HtmlOptions
+const HELP_COL = 28
+
+function formatHelpLine(spec: OptionSpec): string {
+  let lhs = `  --${spec.flag}`
+  let suffix = ""
+  if (spec.kind === "multi") lhs += ` ${spec.placeholder}`
+  if (spec.kind === "string") suffix = ` (${spec.choices.join("|")})`
+  return `${lhs.padEnd(HELP_COL)}${spec.summary}${suffix}`
 }
 
-function buildOptions(values: ParsedValues): BuiltOptions {
-  const shared: HtmlOptions & MarkdownOptions = {}
-
-  const punctuationStyle = validateChoice(values["punctuation-style"], VALID_PUNCTUATION_STYLES, "punctuation-style")
-  if (punctuationStyle) shared.punctuationStyle = punctuationStyle
-
-  const dashStyle = validateChoice(values["dash-style"], VALID_DASH_STYLES, "dash-style")
-  if (dashStyle) shared.dashStyle = dashStyle
-
-  if (values["no-symbols"]) shared.symbols = false
-  if (values["no-nbsp"]) shared.nbsp = false
-  if (values["no-collapse-spaces"]) shared.collapseSpaces = false
-  if (values["no-arrows"]) shared.includeArrows = false
-  if (values.fractions) shared.fractions = true
-  if (values.degrees) shared.degrees = true
-  if (values.superscript) shared.superscript = true
-  if (values.ligatures) shared.ligatures = true
-
-  const markdown: MarkdownOptions = { ...shared }
-  const emphasisMarker = validateChoice(values["emphasis-marker"], VALID_EMPHASIS_MARKERS, "emphasis-marker")
-  if (emphasisMarker) markdown.emphasisMarker = emphasisMarker
-  const strongMarker = validateChoice(values["strong-marker"], VALID_EMPHASIS_MARKERS, "strong-marker")
-  if (strongMarker) markdown.strongMarker = strongMarker
-  const bulletMarker = validateChoice(values["bullet-marker"], VALID_BULLET_MARKERS, "bullet-marker")
-  if (bulletMarker) markdown.bulletMarker = bulletMarker
-  const ruleMarker = validateChoice(values["rule-marker"], VALID_RULE_MARKERS, "rule-marker")
-  if (ruleMarker) markdown.ruleMarker = ruleMarker
-
-  const html: HtmlOptions = { ...shared }
-  if (values["skip-tag"]) html.skipTags = values["skip-tag"]
-  if (values["skip-class"]) html.skipClasses = values["skip-class"]
-  if (values["no-fragment"]) html.fragment = false
-
-  return { markdown, html }
+function buildHelp(): string {
+  const sections: Array<[Section, string]> = [
+    ["transform", "Transform options:"],
+    ["markdown", "Markdown-only options:"],
+    ["html", "HTML-only options:"],
+  ]
+  const lines = [
+    "Usage:",
+    "  punctilio [options] <files...>           Format files in place",
+    "  punctilio --check <files...>             Exit 1 if any file would change",
+    "  punctilio --stdin --type <md|html>       Read stdin, write stdout",
+    "",
+    "File-type detection (override with --type):",
+    "  .md, .markdown       markdown",
+    "  .html, .htm          html",
+    "",
+  ]
+  for (const [section, header] of sections) {
+    lines.push(header)
+    for (const spec of OPTIONS) {
+      if (spec.section === section) lines.push(formatHelpLine(spec))
+    }
+    lines.push("")
+  }
+  lines.push("Other:")
+  lines.push("  -h, --help                  Show this help")
+  lines.push("  -V, --version               Show version")
+  return lines.join("\n") + "\n"
 }
 
-async function transformContent(
-  input: string,
-  type: FileType,
-  opts: BuiltOptions,
-): Promise<string> {
-  return type === "md"
-    ? transformMarkdown(input, opts.markdown)
-    : transformHtml(input, opts.html)
+const HELP = buildHelp()
+
+async function transformContent(input: string, type: FileType, opts: CliOptions): Promise<string> {
+  return type === "md" ? transformMarkdown(input, opts) : transformHtml(input, opts)
 }
 
 /**
@@ -203,35 +292,7 @@ async function readStdin(stdin: AsyncIterable<string | Buffer>): Promise<string>
 export async function runCli(args: string[], io: CliIO): Promise<number> {
   let parsed
   try {
-    parsed = parseArgs({
-      args,
-      allowPositionals: true,
-      strict: true,
-      options: {
-        help: { type: "boolean", short: "h" },
-        version: { type: "boolean", short: "V" },
-        check: { type: "boolean" },
-        stdin: { type: "boolean" },
-        type: { type: "string" },
-        "punctuation-style": { type: "string" },
-        "dash-style": { type: "string" },
-        "no-symbols": { type: "boolean" },
-        "no-nbsp": { type: "boolean" },
-        "no-collapse-spaces": { type: "boolean" },
-        "no-arrows": { type: "boolean" },
-        fractions: { type: "boolean" },
-        degrees: { type: "boolean" },
-        superscript: { type: "boolean" },
-        ligatures: { type: "boolean" },
-        "emphasis-marker": { type: "string" },
-        "strong-marker": { type: "string" },
-        "bullet-marker": { type: "string" },
-        "rule-marker": { type: "string" },
-        "skip-tag": { type: "string", multiple: true },
-        "skip-class": { type: "string", multiple: true },
-        "no-fragment": { type: "boolean" },
-      },
-    })
+    parsed = parseArgs({ args, allowPositionals: true, strict: true, options: parseArgsOptions() })
   } catch (err) {
     io.stderr.write(`Error: ${(err as Error).message}\n`)
     return 2
@@ -263,7 +324,7 @@ async function runValidated(
   positionals: string[],
   io: CliIO,
 ): Promise<number> {
-  const opts = buildOptions(values as ParsedValues)
+  const opts = buildOptions(values)
   const typeOverride = values.type as string | undefined
   const check = values.check === true
 
@@ -277,9 +338,7 @@ async function runValidated(
     const type = inferFileType("<stdin>", typeOverride)
     const input = await readStdin(io.stdin)
     const output = matchTrailingNewline(input, await transformContent(input, type, opts))
-    if (check) {
-      return input === output ? 0 : 1
-    }
+    if (check) return input === output ? 0 : 1
     io.stdout.write(output)
     return 0
   }

--- a/src/tests/cli.test.ts
+++ b/src/tests/cli.test.ts
@@ -200,7 +200,8 @@ describe("runCli", () => {
     const cap = captureIO()
     const code = await runCli(["--type", "rtf", path], cap.io)
     expect(code).toBe(2)
-    expect(cap.stderr()).toMatch(/Invalid --type/)
+    expect(cap.stderr()).toContain("--type")
+    expect(cap.stderr()).toMatch(/invalid/i)
   })
 
   it.each([
@@ -229,7 +230,8 @@ describe("runCli", () => {
     const cap = captureIO()
     const code = await runCli([`--${flag}`, value, path], cap.io)
     expect(code).toBe(2)
-    expect(cap.stderr()).toMatch(/Invalid value/)
+    expect(cap.stderr()).toContain(`--${flag}`)
+    expect(cap.stderr()).toMatch(/invalid/i)
   })
 
   it("applies --punctuation-style british", async () => {
@@ -363,7 +365,7 @@ describe("runCli", () => {
     const cap = captureIO()
     const code = await runCli(["--bogus"], cap.io)
     expect(code).toBe(2)
-    expect(cap.stderr()).toContain("Error:")
+    expect(cap.stderr()).toMatch(/unknown option/i)
   })
 
   it("propagates unexpected errors instead of swallowing them", async () => {


### PR DESCRIPTION
## Summary

Follow-up to #185. Replaces the hand-rolled CLI plumbing with `commander` for parsing, choice validation, and help-text generation — the idiomatic Node CLI library choice.

The PR went through two iterations on this branch:

1. **Spec-table refactor** (commits `3f901d9`, `a6a73f6`): consolidated `parseArgs` options, `buildOptions`, and the HELP string into a single `OPTION_SPEC` table with a base interface + three discriminated variants. Reduced internal drift but kept the homemade parser.
2. **Commander migration** (commit `51e88c8`): swapped the whole thing for `commander@14.0.3` (pinned exact). Drops `OPTION_SPEC` and the custom HELP generator; commander handles option parsing, `--no-X` negation, repeatable `<value...>` args, enum choice validation, and help layout. `src/cli.ts` goes from 391 lines to 260.

The final state is the commander version.

## What changes for users

- **Help format**: now uses commander's layout (the one familiar from `gh`, `npm`, `pnpm`). Choices render inline as `(choices: "a", "b", ...)`.
- **`-h` works** alongside `--help` (commander auto-registers the short form).
- **Error wording**: invalid options and bad enum values use commander's messages — e.g. `error: option '--punctuation-style <style>' argument 'klingon' is invalid. Allowed choices are american, british, german, french, none.`

## Implementation notes

- `exitOverride()` + `configureOutput()` so commander's exits and writes flow through the test-friendly `CliIO` interface instead of `process.exit` / direct stdio.
- `satisfies readonly PunctuationStyle[]` / `readonly DashStyle[]` on the choices arrays catches typos in the choices list at compile time.
- `ParsedFlags` narrows the type at the `program.opts()` boundary; commander's runtime `.choices()` validation guarantees the literal types match.
- The few CLI flag names that don't match the library field names (`--no-arrows` → `includeArrows`, `--skip-tag` → `skipTags`, `--skip-class` → `skipClasses`) are handled in one `buildOptions` function.

## Dependency

Pinned `commander@14.0.3` as a runtime `dependency`. ~140 KB on disk. Per discussion: not worrying about saving deps for this one.

## Test plan

- [x] `pnpm test` — 1766 passing, 100% coverage
- [x] `pnpm lint`, `pnpm exec tsc --noEmit` — clean
- [x] Smoke tested built `dist/cli.js`: `--help`, `--version`, in-place format, `--check`, `--stdin`, invalid choice (rejected with exit 2)
- [x] Updated test expectations to match commander's error message format

Targets `claude/punctilio-auto-formatter-4Xx96`; will retarget to `main` once #185 merges.