### PR TITLE
feat(cli): replace --stdin with '-' and --stdin-filepath

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ npm install punctilio
 ```bash
 punctilio README.md docs/*.md       # format files in place
 punctilio --check README.md         # exit 1 if it would change anything
-echo '"Hi" -- there' | punctilio --stdin --type md
+echo '"Hi" -- there' | punctilio - --type md
 ```
 
 To wire it into the [pre-commit framework](https://pre-commit.com), add to `.pre-commit-config.yaml`:

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -45,7 +45,7 @@ const HTML_EXTENSIONS = new Set([".html", ".htm"])
  */
 interface ParsedFlags {
   check?: boolean
-  stdin?: boolean
+  stdinFilepath?: string
   type?: FileType
   punctuationStyle?: PunctuationStyle
   dashStyle?: DashStyle
@@ -71,9 +71,9 @@ function buildProgram(version: string, io: CliIO): Command {
     .name("punctilio")
     .description("Apply typographic improvements to Markdown and HTML files.")
     .version(version, "-V, --version", "show version")
-    .argument("[files...]", "files to format; pair with --check for a dry run")
+    .argument("[files...]", "files to format (pass '-' to read from stdin)")
     .option("--check", "exit 1 if any file would change; write nothing")
-    .option("--stdin", "read content from stdin and write to stdout")
+    .option("--stdin-filepath <path>", "treat stdin as if it were this filename (infers type from extension)")
     .addOption(new Option("--type <type>", "force file type (otherwise inferred from extension)").choices(FILE_TYPES))
     .addOption(new Option("--punctuation-style <style>", "quote and punctuation style").choices(PUNCTUATION_STYLES))
     .addOption(new Option("--dash-style <style>", "dash style").choices(DASH_STYLES))
@@ -200,6 +200,11 @@ export async function runCli(args: string[], io: CliIO): Promise<number> {
   }
 }
 
+function readsStdin(positionals: string[], flags: ParsedFlags): boolean {
+  if (positionals.includes("-")) return true
+  return flags.stdinFilepath !== undefined && positionals.length === 0
+}
+
 async function runValidated(
   flags: ParsedFlags,
   positionals: string[],
@@ -209,15 +214,18 @@ async function runValidated(
   const opts = buildOptions(flags)
   const check = flags.check === true
 
-  if (flags.stdin) {
-    if (positionals.length > 0) {
-      throw new UsageError("--stdin cannot be combined with file arguments.")
+  if (readsStdin(positionals, flags)) {
+    const fileArgs = positionals.filter((p) => p !== "-")
+    if (fileArgs.length > 0) {
+      throw new UsageError("'-' cannot be combined with file arguments.")
     }
-    if (flags.type === undefined) {
-      throw new UsageError("--stdin requires --type md|html.")
+    const type: FileType | undefined =
+      flags.type ?? (flags.stdinFilepath !== undefined ? inferFileType(flags.stdinFilepath) : undefined)
+    if (type === undefined) {
+      throw new UsageError("Reading from stdin requires --type md|html or --stdin-filepath <path>.")
     }
     const input = await readStdin(io.stdin)
-    const output = matchTrailingNewline(input, await transformContent(input, flags.type, opts))
+    const output = matchTrailingNewline(input, await transformContent(input, type, opts))
     if (check) return input === output ? 0 : 1
     io.stdout.write(output)
     return 0

--- a/src/tests/cli.test.ts
+++ b/src/tests/cli.test.ts
@@ -111,16 +111,30 @@ describe("runCli", () => {
     },
   )
 
-  it("reads stdin and writes stdout when --stdin --type md", async () => {
+  it("reads stdin when positional is '-'", async () => {
     const cap = captureIO('"Hello."')
-    const code = await runCli(["--stdin", "--type", "md", "--no-nbsp"], cap.io)
+    const code = await runCli(["-", "--type", "md", "--no-nbsp"], cap.io)
     expect(code).toBe(0)
     expect(cap.stdout()).toContain(`${LDQ}Hello.${RDQ}`)
   })
 
+  it("reads stdin when --stdin-filepath is set (no positional)", async () => {
+    const cap = captureIO('"Hello."')
+    const code = await runCli(["--stdin-filepath", "doc.md", "--no-nbsp"], cap.io)
+    expect(code).toBe(0)
+    expect(cap.stdout()).toContain(`${LDQ}Hello.${RDQ}`)
+  })
+
+  it("--stdin-filepath infers type from extension", async () => {
+    const cap = captureIO('<p>"Hello"</p>')
+    const code = await runCli(["--stdin-filepath", "page.html", "--no-nbsp"], cap.io)
+    expect(code).toBe(0)
+    expect(cap.stdout()).toContain(`${LDQ}Hello${RDQ}`)
+  })
+
   it("handles string-typed stdin chunks", async () => {
     const cap = captureIO('"Hello."', /* stdinAsString */ true)
-    const code = await runCli(["--stdin", "--type", "md", "--no-nbsp"], cap.io)
+    const code = await runCli(["-", "--type", "md", "--no-nbsp"], cap.io)
     expect(code).toBe(0)
     expect(cap.stdout()).toContain(`${LDQ}Hello.${RDQ}`)
   })
@@ -128,7 +142,7 @@ describe("runCli", () => {
   it("--stdin --check returns 1 when input would change", async () => {
     const cap = captureIO('"Hello."')
     const code = await runCli(
-      ["--stdin", "--type", "md", "--check", "--no-nbsp"],
+      ["-", "--type", "md", "--check", "--no-nbsp"],
       cap.io,
     )
     expect(code).toBe(1)
@@ -137,28 +151,28 @@ describe("runCli", () => {
   it("--stdin --check returns 0 when input is already clean", async () => {
     const cap = captureIO(`${LDQ}Hello.${RDQ}`)
     const code = await runCli(
-      ["--stdin", "--type", "md", "--check", "--no-nbsp"],
+      ["-", "--type", "md", "--check", "--no-nbsp"],
       cap.io,
     )
     expect(code).toBe(0)
   })
 
-  it("--stdin rejects file arguments", async () => {
+  it("'-' rejects file arguments alongside it", async () => {
     const path = tmpFile("x", "doc.md")
     const cap = captureIO("x")
-    const code = await runCli(["--stdin", "--type", "md", path], cap.io)
+    const code = await runCli(["-", "--type", "md", path], cap.io)
     expect(code).toBe(2)
     expect(cap.stderr()).toContain("cannot be combined")
   })
 
-  it("--stdin requires --type", async () => {
+  it("'-' without --type or --stdin-filepath errors", async () => {
     const cap = captureIO("x")
-    const code = await runCli(["--stdin"], cap.io)
+    const code = await runCli(["-"], cap.io)
     expect(code).toBe(2)
-    expect(cap.stderr()).toContain("requires --type")
+    expect(cap.stderr()).toMatch(/--type/)
   })
 
-  it("errors when no positional and no --stdin", async () => {
+  it("errors when no positional and no stdin signal", async () => {
     const cap = captureIO()
     const code = await runCli([], cap.io)
     expect(code).toBe(2)
@@ -237,7 +251,7 @@ describe("runCli", () => {
   it("applies --punctuation-style british", async () => {
     const cap = captureIO('"Hello."')
     const code = await runCli(
-      ["--stdin", "--type", "md", "--punctuation-style", "british", "--no-nbsp"],
+      ["-", "--type", "md", "--punctuation-style", "british", "--no-nbsp"],
       cap.io,
     )
     expect(code).toBe(0)
@@ -247,7 +261,7 @@ describe("runCli", () => {
   it("--fractions enables fraction transforms", async () => {
     const cap = captureIO("Add 1/2 cup.")
     const code = await runCli(
-      ["--stdin", "--type", "md", "--fractions", "--no-nbsp"],
+      ["-", "--type", "md", "--fractions", "--no-nbsp"],
       cap.io,
     )
     expect(code).toBe(0)
@@ -257,7 +271,7 @@ describe("runCli", () => {
   it("--degrees enables degree transforms", async () => {
     const cap = captureIO("It is 20 C today.")
     const code = await runCli(
-      ["--stdin", "--type", "md", "--degrees", "--no-nbsp"],
+      ["-", "--type", "md", "--degrees", "--no-nbsp"],
       cap.io,
     )
     expect(code).toBe(0)
@@ -267,7 +281,7 @@ describe("runCli", () => {
   it("--superscript enables superscript ordinals", async () => {
     const cap = captureIO("1st place")
     const code = await runCli(
-      ["--stdin", "--type", "md", "--superscript", "--no-nbsp"],
+      ["-", "--type", "md", "--superscript", "--no-nbsp"],
       cap.io,
     )
     expect(code).toBe(0)
@@ -277,7 +291,7 @@ describe("runCli", () => {
   it("--ligatures enables punctuation ligatures", async () => {
     const cap = captureIO("Wait!?")
     const code = await runCli(
-      ["--stdin", "--type", "md", "--ligatures", "--no-nbsp"],
+      ["-", "--type", "md", "--ligatures", "--no-nbsp"],
       cap.io,
     )
     expect(code).toBe(0)
@@ -287,7 +301,7 @@ describe("runCli", () => {
   it("--no-symbols disables symbol transforms", async () => {
     const cap = captureIO("Wait... done.")
     const code = await runCli(
-      ["--stdin", "--type", "md", "--no-symbols", "--no-nbsp"],
+      ["-", "--type", "md", "--no-symbols", "--no-nbsp"],
       cap.io,
     )
     expect(code).toBe(0)
@@ -297,7 +311,7 @@ describe("runCli", () => {
   it("--no-arrows disables arrow transforms", async () => {
     const cap = captureIO("Go -> back")
     const code = await runCli(
-      ["--stdin", "--type", "md", "--no-arrows", "--no-nbsp"],
+      ["-", "--type", "md", "--no-arrows", "--no-nbsp"],
       cap.io,
     )
     expect(code).toBe(0)
@@ -307,7 +321,7 @@ describe("runCli", () => {
   it("--no-collapse-spaces preserves multiple spaces", async () => {
     const cap = captureIO("two  spaces.")
     const code = await runCli(
-      ["--stdin", "--type", "md", "--no-collapse-spaces", "--no-nbsp"],
+      ["-", "--type", "md", "--no-collapse-spaces", "--no-nbsp"],
       cap.io,
     )
     expect(code).toBe(0)


### PR DESCRIPTION
## Summary

Adopts the prettier/POSIX-idiomatic stdin convention for the CLI:

- **`-` positional** signals stdin: `cat foo.md | punctilio - --type md`
- **`--stdin-filepath <path>`** signals stdin (when no positional files) *and* infers the file type from the path's extension: `cat foo.md | punctilio --stdin-filepath foo.md`
- The dedicated `--stdin` flag is removed; `-` replaces it.

No deprecation shim needed — the CLI hasn't shipped yet (PR #185 is its first appearance, and this PR stacks on top of it).

## Before / after

```bash
# Before
cat foo.md | punctilio --stdin --type md

# After (explicit type)
cat foo.md | punctilio - --type md

# After (infer type from filename)
cat foo.md | punctilio --stdin-filepath foo.md
```

The second form matches prettier's `--stdin-filepath`, which is the dominant Node-CLI idiom for piping content with format-by-name semantics.

## Test plan

- [x] `pnpm test` — 1768 passing (added two cases for `--stdin-filepath`), 100% coverage
- [x] `pnpm lint`, `pnpm exec tsc --noEmit` — clean
- [x] Smoke tests of built `dist/cli.js`:
  - `echo '"Hi"' | punctilio - --type md` → smart quotes ✓
  - `echo '<p>"Hi"</p>' | punctilio --stdin-filepath foo.html` → smart quotes in HTML ✓
  - `punctilio -` without `--type` or `--stdin-filepath` → exit 2 with usage hint ✓

Targets `claude/punctilio-auto-formatter-4Xx96`; will retarget to `main` once #185 merges.

---
_Generated by [Claude Code](https://claude.ai/code/session_01629Ysss8k29mY7PqFfmMYa)_