### PR TITLE
feat(cli): config, glob, ignore, and cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,53 +21,6 @@ transform(`"It's a beautiful thing, the destruction of words..." -- 1984`);
 npm install punctilio
 ```
 
-### Command-line / pre-commit usage
-
-`punctilio` ships a CLI that formats Markdown (`.md`, `.markdown`) and HTML (`.html`, `.htm`) files in place. `--check` exits non-zero if any file would change, making it suitable as a pre-commit hook.
-
-```bash
-punctilio README.md 'docs/**/*.md'   # globs expand internally
-punctilio --check README.md          # exit 1 if it would change anything
-echo '"Hi" -- there' | punctilio - --type md
-punctilio --cache 'docs/**/*.md'     # skip files unchanged since last run
-```
-
-#### Config file
-
-Drop a `.punctiliorc.json` (or `.punctiliorc.yaml` / `.punctiliorc.js` / a `"punctilio"` key in `package.json`) in your project root:
-
-```json
-{
-  "punctuationStyle": "british",
-  "dashStyle": "american",
-  "skipTags": ["pre", "code"]
-}
-```
-
-Auto-discovered via [`cosmiconfig`](https://github.com/cosmiconfig/cosmiconfig); use `--config <path>` to point at a specific file or `--no-config` to skip discovery. CLI flags override config-file values.
-
-#### Ignore file
-
-A `.punctilioignore` (gitignore syntax) in cwd excludes matching files from glob results:
-
-```
-CHANGELOG.md
-docs/generated/
-```
-
-Use `--ignore-path <path>` to point at a different file.
-
-#### Pre-commit framework
-
-```yaml
-- repo: https://github.com/alexander-turner/punctilio
-  rev: v3.9.1
-  hooks:
-    - id: punctilio-check    # or `punctilio` to rewrite in place
-```
-
-Run `punctilio -h` for the full option list (style flags, marker overrides, skip tags/classes).
-
 ## Why punctilio?
 
 As far as I can tell, `punctilio` is the most reliable and feature-complete. I built `punctilio` for [my website](https://turntrout.com/design). I wrote[^wrote] and sharpened the core regexes sporadically over several months, exhaustively testing edge cases. Eventually, I decided to spin off the functionality into its own package.
@@ -208,9 +161,23 @@ rehypePunctilio({
 ```
 
 
+## CLI and editor integration
+
+```bash
+punctilio README.md 'docs/**/*.md'   # format in place; globs expand internally
+punctilio --check README.md          # exit 1 if it would change anything
+punctilio --cache 'docs/**/*.md'     # skip files unchanged since last run
+echo '"Hi" -- there' | punctilio - --type md
+```
+
+Config is loaded from `.punctiliorc[.json|.yaml|.js]`, `punctilio.config.js`, or a `"punctilio"` key in `package.json` (via [`cosmiconfig`](https://github.com/cosmiconfig/cosmiconfig)); CLI flags override. A `.punctilioignore` (gitignore syntax) in cwd excludes matching files. A `.pre-commit-hooks.yaml` ships in the package for [pre-commit](https://pre-commit.com) integration. For prettier users, add `punctilio/prettier-plugin` to `.prettierrc` `plugins`; it reads the same `.punctiliorc`.
+
+Run `punctilio -h` for the full flag list.
+
+
 ## Notes 
 
-- Fully general prime mark conversion (e.g. <span class="no-formatting">5'10" → 5′10″</span>) requires semantic understanding to distinguish from closing quotes (e.g. `"Term 1"` should produce closing quotes). `punctilio` tracks quote balance to heuristically determine whether a quote after a number is a closing quote or a prime mark. Other libraries like `tipograph` 0.7.4 use simpler patterns that make more mistakes.
+- Prime-mark detection (<span class="no-formatting">5'10" → 5′10″</span>) is heuristic: `punctilio` tracks quote balance to distinguish a prime after a number from a closing quote (`"Term 1"`). Simpler libraries like `tipograph` 0.7.4 make more mistakes here.
 - The `american` style follows the [Chicago Manual of Style](https://www.chicagomanualofstyle.org/):
   - Periods and commas go inside quotation marks (“Hello,” she said.)
   - Unspaced em-dashes between words (word—word)

--- a/README.md
+++ b/README.md
@@ -26,12 +26,38 @@ npm install punctilio
 `punctilio` ships a CLI that formats Markdown (`.md`, `.markdown`) and HTML (`.html`, `.htm`) files in place. `--check` exits non-zero if any file would change, making it suitable as a pre-commit hook.
 
 ```bash
-punctilio README.md docs/*.md       # format files in place
-punctilio --check README.md         # exit 1 if it would change anything
+punctilio README.md 'docs/**/*.md'   # globs expand internally
+punctilio --check README.md          # exit 1 if it would change anything
 echo '"Hi" -- there' | punctilio - --type md
+punctilio --cache 'docs/**/*.md'     # skip files unchanged since last run
 ```
 
-To wire it into the [pre-commit framework](https://pre-commit.com), add to `.pre-commit-config.yaml`:
+#### Config file
+
+Drop a `.punctiliorc.json` (or `.punctiliorc.yaml` / `.punctiliorc.js` / a `"punctilio"` key in `package.json`) in your project root:
+
+```json
+{
+  "punctuationStyle": "british",
+  "dashStyle": "american",
+  "skipTags": ["pre", "code"]
+}
+```
+
+Auto-discovered via [`cosmiconfig`](https://github.com/cosmiconfig/cosmiconfig); use `--config <path>` to point at a specific file or `--no-config` to skip discovery. CLI flags override config-file values.
+
+#### Ignore file
+
+A `.punctilioignore` (gitignore syntax) in cwd excludes matching files from glob results:
+
+```
+CHANGELOG.md
+docs/generated/
+```
+
+Use `--ignore-path <path>` to point at a different file.
+
+#### Pre-commit framework
 
 ```yaml
 - repo: https://github.com/alexander-turner/punctilio

--- a/package.json
+++ b/package.json
@@ -144,8 +144,11 @@
   },
   "dependencies": {
     "commander": "14.0.3",
+    "cosmiconfig": "9.0.1",
     "escape-string-regexp": "5.0.0",
+    "ignore": "7.0.5",
     "quick-lru": "7.3.0",
+    "tinyglobby": "0.2.16",
     "unist-util-visit-parents": "6.0.2"
   },
   "lint-staged": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,12 +11,21 @@ importers:
       commander:
         specifier: 14.0.3
         version: 14.0.3
+      cosmiconfig:
+        specifier: 9.0.1
+        version: 9.0.1(typescript@5.9.3)
       escape-string-regexp:
         specifier: 5.0.0
         version: 5.0.0
+      ignore:
+        specifier: 7.0.5
+        version: 7.0.5
       quick-lru:
         specifier: 7.3.0
         version: 7.3.0
+      tinyglobby:
+        specifier: 0.2.16
+        version: 0.2.16
       unist-util-visit-parents:
         specifier: 6.0.2
         version: 6.0.2
@@ -938,6 +947,15 @@ packages:
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
+  cosmiconfig@9.0.1:
+    resolution: {integrity: sha512-hr4ihw+DBqcvrsEDioRO31Z17x71pUYoNe/4h6Z0wB72p7MU7/9gH8Q3s12NFhHPfYBBOV3qyfUxmr/Yn3shnQ==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      typescript: '>=4.9.5'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   create-jest@29.7.0:
     resolution: {integrity: sha512-Adz2bdH0Vq3F53KEMJOoftQFutWCukm6J24wbPWRO4k1kMY7gS7ds/uoJkNuV8wDCtWWnuwGcJwpWcih+zEW1Q==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -1009,6 +1027,10 @@ packages:
   entities@6.0.1:
     resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
     engines: {node: '>=0.12'}
+
+  env-paths@2.2.1:
+    resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
+    engines: {node: '>=6'}
 
   environment@1.1.0:
     resolution: {integrity: sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==}
@@ -3252,6 +3274,15 @@ snapshots:
 
   convert-source-map@2.0.0: {}
 
+  cosmiconfig@9.0.1(typescript@5.9.3):
+    dependencies:
+      env-paths: 2.2.1
+      import-fresh: 3.3.1
+      js-yaml: 4.1.1
+      parse-json: 5.2.0
+    optionalDependencies:
+      typescript: 5.9.3
+
   create-jest@29.7.0(@types/node@20.19.30):
     dependencies:
       '@jest/types': 29.6.3
@@ -3308,6 +3339,8 @@ snapshots:
   emoji-regex@8.0.0: {}
 
   entities@6.0.1: {}
+
+  env-paths@2.2.1: {}
 
   environment@1.1.0: {}
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -123,19 +123,8 @@ function inferFileType(path: string, override?: FileType): FileType {
   )
 }
 
-/**
- * Loads a punctilio config file via cosmiconfig.
- *
- * Search names tried (in order): `.punctiliorc`, `.punctiliorc.json`,
- * `.punctiliorc.yaml`, `.punctiliorc.yml`, `.punctiliorc.js`,
- * `.punctiliorc.cjs`, `punctilio.config.js`, `punctilio.config.cjs`,
- * and a `"punctilio"` key in `package.json`.
- *
- * Returns `{}` when no config is found, the file is empty, or
- * `--no-config` was passed. Keys in the loaded config must match the
- * library's option names (`punctuationStyle`, `skipTags`, etc.), not
- * the kebab-cased CLI flag names.
- */
+// Config keys must match library option names (punctuationStyle, skipTags, …),
+// not the kebab-cased CLI flag names.
 async function loadConfig(
   cwd: string,
   configPath: string | undefined,
@@ -148,11 +137,6 @@ async function loadConfig(
   return result.config as CliOptions
 }
 
-/**
- * Loads a .punctilioignore-style file into an `ignore` matcher.
- * Falls back to the empty matcher (matches nothing) when the file
- * doesn't exist.
- */
 function loadIgnore(cwd: string, ignorePath: string | undefined): Ignore {
   const ig = ignore()
   const effective = ignorePath ?? join(cwd, ".punctilioignore")
@@ -164,12 +148,8 @@ function isGlobPattern(pattern: string): boolean {
   return /[*?[\]{}]/.test(pattern)
 }
 
-/**
- * Expands glob patterns and applies ignore rules. Non-glob positionals
- * are passed through as literal file paths so they error loudly if
- * missing (preserving the prior behavior of `punctilio file.md`); only
- * literal paths matching an ignore rule are dropped silently.
- */
+// Non-glob positionals pass through as literal paths so they error loudly
+// if missing, matching the prior behavior of `punctilio file.md`.
 async function discoverFiles(
   patterns: string[],
   cwd: string,
@@ -183,8 +163,7 @@ async function discoverFiles(
   const all = [...literals.map((p) => resolve(cwd, p)), ...expanded]
   return all.filter((file) => {
     const rel = relative(cwd, file)
-    if (rel.startsWith("..") || rel === "") return true
-    return !ig.ignores(rel)
+    return rel.startsWith("..") || !ig.ignores(rel)
   })
 }
 
@@ -224,20 +203,6 @@ function loadCache(location: string): Cache {
 function saveCache(location: string, cache: Cache): void {
   mkdirSync(dirname(location), { recursive: true })
   writeFileSync(location, JSON.stringify(cache))
-}
-
-function cacheHit(
-  cache: Cache,
-  filepath: string,
-  contentHash: string,
-  optionsHash: string,
-  version: string,
-): boolean {
-  const entry = cache.files[filepath]
-  if (!entry) return false
-  return entry.contentHash === contentHash
-    && entry.optionsHash === optionsHash
-    && entry.version === version
 }
 
 function buildOptions(flags: ParsedFlags): CliOptions {
@@ -306,7 +271,8 @@ async function readPackageVersion(): Promise<string> {
  * 1 if `--check` saw a file that would change, 2 for usage errors.
  */
 export async function runCli(args: string[], io: CliIO): Promise<number> {
-  const program = buildProgram(await readPackageVersion(), io)
+  const version = await readPackageVersion()
+  const program = buildProgram(version, io)
 
   try {
     program.parse(args, { from: "user" })
@@ -321,7 +287,7 @@ export async function runCli(args: string[], io: CliIO): Promise<number> {
   const positionals = program.args
 
   try {
-    return await runValidated(flags, positionals, io, program)
+    return await runValidated(flags, positionals, io, program, version)
   } catch (err) {
     if (err instanceof UsageError) {
       io.stderr.write(`Error: ${err.message}\n`)
@@ -341,14 +307,16 @@ async function runValidated(
   positionals: string[],
   io: CliIO,
   program: Command,
+  version: string,
 ): Promise<number> {
+  const cwd = process.cwd()
   const config = await loadConfig(
-    process.cwd(),
+    cwd,
     typeof flags.config === "string" ? flags.config : undefined,
     flags.config === false,
   )
   const opts: CliOptions = { ...config, ...buildOptions(flags) }
-  const check = flags.check === true
+  const check = flags.check ?? false
 
   if (readsStdin(positionals, flags)) {
     const fileArgs = positionals.filter((p) => p !== "-")
@@ -372,40 +340,43 @@ async function runValidated(
     return 2
   }
 
-  const cwd = process.cwd()
   const ig = loadIgnore(cwd, flags.ignorePath)
   const files = await discoverFiles(positionals, cwd, ig)
 
-  const cacheLocation = flags.cache === true
+  const cacheLocation = flags.cache
     ? resolve(cwd, flags.cacheLocation ?? DEFAULT_CACHE_LOCATION)
     : undefined
   const cache = cacheLocation ? loadCache(cacheLocation) : undefined
   const optionsHash = cache ? hashOptions(opts) : ""
-  const version = cache ? await readPackageVersion() : ""
 
   let anyChanged = false
   for (const path of files) {
     const type = inferFileType(path, flags.type)
     const original = await readFile(path, "utf8")
-    const originalHash = cache ? hashString(original) : ""
-    if (cache && cacheHit(cache, path, originalHash, optionsHash, version)) continue
+    if (cache) {
+      const entry = cache.files[path]
+      if (entry?.contentHash === hashString(original)
+          && entry.optionsHash === optionsHash
+          && entry.version === version) continue
+    }
 
     const formatted = matchTrailingNewline(original, await transformContent(original, type, opts))
-    if (original === formatted) {
-      if (cache) cache.files[path] = { contentHash: originalHash, optionsHash, version }
-      continue
+    const unchanged = original === formatted
+    if (!unchanged) {
+      anyChanged = true
+      if (check) {
+        io.stderr.write(`Would reformat: ${path}\n`)
+      } else {
+        await writeFile(path, formatted)
+        io.stdout.write(`Reformatted: ${path}\n`)
+      }
     }
-    anyChanged = true
-    if (check) {
-      io.stderr.write(`Would reformat: ${path}\n`)
-    } else {
-      await writeFile(path, formatted)
-      io.stdout.write(`Reformatted: ${path}\n`)
-      if (cache) cache.files[path] = { contentHash: hashString(formatted), optionsHash, version }
+    if (cache && (unchanged || !check)) {
+      cache.files[path] = { contentHash: hashString(formatted), optionsHash, version }
     }
   }
 
-  if (cache && cacheLocation) saveCache(cacheLocation, cache)
+  if (cacheLocation && cache) saveCache(cacheLocation, cache)
   return check && anyChanged ? 1 : 0
 }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -6,9 +6,10 @@
  * @packageDocumentation
  */
 
-import { existsSync, readFileSync } from "node:fs"
+import { createHash } from "node:crypto"
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs"
 import { readFile, writeFile } from "node:fs/promises"
-import { extname, join, relative, resolve } from "node:path"
+import { dirname, extname, join, relative, resolve } from "node:path"
 import { fileURLToPath } from "node:url"
 
 import { Command, CommanderError, Option } from "commander"
@@ -49,6 +50,8 @@ const HTML_EXTENSIONS = new Set([".html", ".htm"])
  */
 interface ParsedFlags {
   check?: boolean
+  cache?: boolean
+  cacheLocation?: string
   config?: string | false  // string if --config <path>, false if --no-config
   ignorePath?: string
   stdinFilepath?: string
@@ -82,6 +85,8 @@ function buildProgram(version: string, io: CliIO): Command {
     .option("--config <path>", "path to a punctilio config file (otherwise auto-discovered)")
     .option("--no-config", "ignore any auto-discovered config file")
     .option("--ignore-path <path>", "path to an ignore file (otherwise .punctilioignore in cwd)")
+    .option("--cache", "skip files whose content and options hash matches the last run")
+    .option("--cache-location <path>", "cache file location (default node_modules/.cache/punctilio/cache.json)")
     .option("--stdin-filepath <path>", "treat stdin as if it were this filename (infers type from extension)")
     .addOption(new Option("--type <type>", "force file type (otherwise inferred from extension)").choices(FILE_TYPES))
     .addOption(new Option("--punctuation-style <style>", "quote and punctuation style").choices(PUNCTUATION_STYLES))
@@ -181,6 +186,58 @@ async function discoverFiles(
     if (rel.startsWith("..") || rel === "") return true
     return !ig.ignores(rel)
   })
+}
+
+interface CacheEntry {
+  contentHash: string
+  optionsHash: string
+  version: string
+}
+
+interface Cache {
+  files: Record<string, CacheEntry>
+}
+
+const DEFAULT_CACHE_LOCATION = join("node_modules", ".cache", "punctilio", "cache.json")
+
+function hashString(s: string): string {
+  return createHash("sha256").update(s).digest("hex").slice(0, 16)
+}
+
+function hashOptions(opts: CliOptions): string {
+  const stable = Object.entries(opts)
+    .filter(([, v]) => v !== undefined)
+    .sort(([a], [b]) => a.localeCompare(b))
+  return hashString(JSON.stringify(stable))
+}
+
+function loadCache(location: string): Cache {
+  if (!existsSync(location)) return { files: {} }
+  try {
+    const parsed = JSON.parse(readFileSync(location, "utf8")) as Cache
+    return parsed.files ? parsed : { files: {} }
+  } catch {
+    return { files: {} }
+  }
+}
+
+function saveCache(location: string, cache: Cache): void {
+  mkdirSync(dirname(location), { recursive: true })
+  writeFileSync(location, JSON.stringify(cache))
+}
+
+function cacheHit(
+  cache: Cache,
+  filepath: string,
+  contentHash: string,
+  optionsHash: string,
+  version: string,
+): boolean {
+  const entry = cache.files[filepath]
+  if (!entry) return false
+  return entry.contentHash === contentHash
+    && entry.optionsHash === optionsHash
+    && entry.version === version
 }
 
 function buildOptions(flags: ParsedFlags): CliOptions {
@@ -319,20 +376,36 @@ async function runValidated(
   const ig = loadIgnore(cwd, flags.ignorePath)
   const files = await discoverFiles(positionals, cwd, ig)
 
+  const cacheLocation = flags.cache === true
+    ? resolve(cwd, flags.cacheLocation ?? DEFAULT_CACHE_LOCATION)
+    : undefined
+  const cache = cacheLocation ? loadCache(cacheLocation) : undefined
+  const optionsHash = cache ? hashOptions(opts) : ""
+  const version = cache ? await readPackageVersion() : ""
+
   let anyChanged = false
   for (const path of files) {
     const type = inferFileType(path, flags.type)
     const original = await readFile(path, "utf8")
+    const originalHash = cache ? hashString(original) : ""
+    if (cache && cacheHit(cache, path, originalHash, optionsHash, version)) continue
+
     const formatted = matchTrailingNewline(original, await transformContent(original, type, opts))
-    if (original === formatted) continue
+    if (original === formatted) {
+      if (cache) cache.files[path] = { contentHash: originalHash, optionsHash, version }
+      continue
+    }
     anyChanged = true
     if (check) {
       io.stderr.write(`Would reformat: ${path}\n`)
     } else {
       await writeFile(path, formatted)
       io.stdout.write(`Reformatted: ${path}\n`)
+      if (cache) cache.files[path] = { contentHash: hashString(formatted), optionsHash, version }
     }
   }
+
+  if (cache && cacheLocation) saveCache(cacheLocation, cache)
   return check && anyChanged ? 1 : 0
 }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -11,6 +11,7 @@ import { extname } from "node:path"
 import { fileURLToPath } from "node:url"
 
 import { Command, CommanderError, Option } from "commander"
+import { cosmiconfig } from "cosmiconfig"
 
 import { transformMarkdown, type MarkdownOptions } from "./markdown.js"
 import { transformHtml, type HtmlOptions } from "./html.js"
@@ -45,6 +46,7 @@ const HTML_EXTENSIONS = new Set([".html", ".htm"])
  */
 interface ParsedFlags {
   check?: boolean
+  config?: string | false  // string if --config <path>, false if --no-config
   stdinFilepath?: string
   type?: FileType
   punctuationStyle?: PunctuationStyle
@@ -73,6 +75,8 @@ function buildProgram(version: string, io: CliIO): Command {
     .version(version, "-V, --version", "show version")
     .argument("[files...]", "files to format (pass '-' to read from stdin)")
     .option("--check", "exit 1 if any file would change; write nothing")
+    .option("--config <path>", "path to a punctilio config file (otherwise auto-discovered)")
+    .option("--no-config", "ignore any auto-discovered config file")
     .option("--stdin-filepath <path>", "treat stdin as if it were this filename (infers type from extension)")
     .addOption(new Option("--type <type>", "force file type (otherwise inferred from extension)").choices(FILE_TYPES))
     .addOption(new Option("--punctuation-style <style>", "quote and punctuation style").choices(PUNCTUATION_STYLES))
@@ -107,6 +111,31 @@ function inferFileType(path: string, override?: FileType): FileType {
   throw new UsageError(
     `Cannot infer file type from extension "${ext}" for ${path}. Pass --type md|html.`,
   )
+}
+
+/**
+ * Loads a punctilio config file via cosmiconfig.
+ *
+ * Search names tried (in order): `.punctiliorc`, `.punctiliorc.json`,
+ * `.punctiliorc.yaml`, `.punctiliorc.yml`, `.punctiliorc.js`,
+ * `.punctiliorc.cjs`, `punctilio.config.js`, `punctilio.config.cjs`,
+ * and a `"punctilio"` key in `package.json`.
+ *
+ * Returns `{}` when no config is found, the file is empty, or
+ * `--no-config` was passed. Keys in the loaded config must match the
+ * library's option names (`punctuationStyle`, `skipTags`, etc.), not
+ * the kebab-cased CLI flag names.
+ */
+async function loadConfig(
+  cwd: string,
+  configPath: string | undefined,
+  disabled: boolean,
+): Promise<CliOptions> {
+  if (disabled) return {}
+  const explorer = cosmiconfig("punctilio")
+  const result = configPath ? await explorer.load(configPath) : await explorer.search(cwd)
+  if (!result || result.isEmpty) return {}
+  return result.config as CliOptions
 }
 
 function buildOptions(flags: ParsedFlags): CliOptions {
@@ -211,7 +240,12 @@ async function runValidated(
   io: CliIO,
   program: Command,
 ): Promise<number> {
-  const opts = buildOptions(flags)
+  const config = await loadConfig(
+    process.cwd(),
+    typeof flags.config === "string" ? flags.config : undefined,
+    flags.config === false,
+  )
+  const opts: CliOptions = { ...config, ...buildOptions(flags) }
   const check = flags.check === true
 
   if (readsStdin(positionals, flags)) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -19,8 +19,8 @@ import { glob } from "tinyglobby"
 
 import { transformMarkdown, type MarkdownOptions } from "./markdown.js"
 import { transformHtml, type HtmlOptions } from "./html.js"
-import type { PunctuationStyle } from "./quotes.js"
-import type { DashStyle } from "./dashes.js"
+import { PUNCTUATION_STYLES, type PunctuationStyle } from "./quotes.js"
+import { DASH_STYLES, type DashStyle } from "./dashes.js"
 
 type CliOptions = MarkdownOptions & HtmlOptions
 type FileType = "md" | "html"
@@ -34,8 +34,6 @@ interface CliIO {
 class UsageError extends Error {}
 
 const FILE_TYPES = ["md", "html"] as const satisfies readonly FileType[]
-const PUNCTUATION_STYLES = ["american", "british", "german", "french", "none"] as const satisfies readonly PunctuationStyle[]
-const DASH_STYLES = ["american", "british", "none"] as const satisfies readonly DashStyle[]
 const EMPHASIS_MARKERS = ["*", "_"] as const
 const BULLET_MARKERS = ["-", "*", "+"] as const
 const RULE_MARKERS = ["-", "*", "_"] as const

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -6,12 +6,15 @@
  * @packageDocumentation
  */
 
+import { existsSync, readFileSync } from "node:fs"
 import { readFile, writeFile } from "node:fs/promises"
-import { extname } from "node:path"
+import { extname, join, relative, resolve } from "node:path"
 import { fileURLToPath } from "node:url"
 
 import { Command, CommanderError, Option } from "commander"
 import { cosmiconfig } from "cosmiconfig"
+import ignore, { type Ignore } from "ignore"
+import { glob } from "tinyglobby"
 
 import { transformMarkdown, type MarkdownOptions } from "./markdown.js"
 import { transformHtml, type HtmlOptions } from "./html.js"
@@ -47,6 +50,7 @@ const HTML_EXTENSIONS = new Set([".html", ".htm"])
 interface ParsedFlags {
   check?: boolean
   config?: string | false  // string if --config <path>, false if --no-config
+  ignorePath?: string
   stdinFilepath?: string
   type?: FileType
   punctuationStyle?: PunctuationStyle
@@ -77,6 +81,7 @@ function buildProgram(version: string, io: CliIO): Command {
     .option("--check", "exit 1 if any file would change; write nothing")
     .option("--config <path>", "path to a punctilio config file (otherwise auto-discovered)")
     .option("--no-config", "ignore any auto-discovered config file")
+    .option("--ignore-path <path>", "path to an ignore file (otherwise .punctilioignore in cwd)")
     .option("--stdin-filepath <path>", "treat stdin as if it were this filename (infers type from extension)")
     .addOption(new Option("--type <type>", "force file type (otherwise inferred from extension)").choices(FILE_TYPES))
     .addOption(new Option("--punctuation-style <style>", "quote and punctuation style").choices(PUNCTUATION_STYLES))
@@ -136,6 +141,46 @@ async function loadConfig(
   const result = configPath ? await explorer.load(configPath) : await explorer.search(cwd)
   if (!result || result.isEmpty) return {}
   return result.config as CliOptions
+}
+
+/**
+ * Loads a .punctilioignore-style file into an `ignore` matcher.
+ * Falls back to the empty matcher (matches nothing) when the file
+ * doesn't exist.
+ */
+function loadIgnore(cwd: string, ignorePath: string | undefined): Ignore {
+  const ig = ignore()
+  const effective = ignorePath ?? join(cwd, ".punctilioignore")
+  if (existsSync(effective)) ig.add(readFileSync(effective, "utf8"))
+  return ig
+}
+
+function isGlobPattern(pattern: string): boolean {
+  return /[*?[\]{}]/.test(pattern)
+}
+
+/**
+ * Expands glob patterns and applies ignore rules. Non-glob positionals
+ * are passed through as literal file paths so they error loudly if
+ * missing (preserving the prior behavior of `punctilio file.md`); only
+ * literal paths matching an ignore rule are dropped silently.
+ */
+async function discoverFiles(
+  patterns: string[],
+  cwd: string,
+  ig: Ignore,
+): Promise<string[]> {
+  const literals = patterns.filter((p) => !isGlobPattern(p))
+  const globs = patterns.filter(isGlobPattern)
+  const expanded = globs.length > 0
+    ? await glob(globs, { cwd, absolute: true, onlyFiles: true })
+    : []
+  const all = [...literals.map((p) => resolve(cwd, p)), ...expanded]
+  return all.filter((file) => {
+    const rel = relative(cwd, file)
+    if (rel.startsWith("..") || rel === "") return true
+    return !ig.ignores(rel)
+  })
 }
 
 function buildOptions(flags: ParsedFlags): CliOptions {
@@ -270,8 +315,12 @@ async function runValidated(
     return 2
   }
 
+  const cwd = process.cwd()
+  const ig = loadIgnore(cwd, flags.ignorePath)
+  const files = await discoverFiles(positionals, cwd, ig)
+
   let anyChanged = false
-  for (const path of positionals) {
+  for (const path of files) {
     const type = inferFileType(path, flags.type)
     const original = await readFile(path, "utf8")
     const formatted = matchTrailingNewline(original, await transformContent(original, type, opts))

--- a/src/dashes.ts
+++ b/src/dashes.ts
@@ -4,7 +4,8 @@
 
 import { UNICODE_SYMBOLS, DEFAULT_SEPARATOR, LATIN_LETTERS, wordBoundaryStart, wordBoundaryEnd, getEscapedSeparator, cachedRegExp } from "./constants.js"
 
-export type DashStyle = "american" | "british" | "none"
+export const DASH_STYLES = ["american", "british", "none"] as const
+export type DashStyle = (typeof DASH_STYLES)[number]
 
 export interface DashOptions {
   /** Boundary marker for HTML element boundaries. Default: "\uE000\uE001" */

--- a/src/quotes.ts
+++ b/src/quotes.ts
@@ -25,7 +25,8 @@ const TERMINAL_PUNCTUATION_CLASS = TERMINAL_PUNCTUATION.join("")
  */
 const MAX_NESTED_QUOTES = 4
 
-export type PunctuationStyle = "american" | "british" | "german" | "french" | "none"
+export const PUNCTUATION_STYLES = ["american", "british", "german", "french", "none"] as const
+export type PunctuationStyle = (typeof PUNCTUATION_STYLES)[number]
 
 export interface QuoteOptions {
   /** Boundary marker for HTML element boundaries. Default: "\uE000\uE001" */

--- a/src/tests/cli.test.ts
+++ b/src/tests/cli.test.ts
@@ -414,6 +414,50 @@ describe("runCli", () => {
     expect(cap.stdout()).toContain(`${LDQ}Hello.${RDQ}`)
   })
 
+  it("expands glob patterns and respects .punctilioignore", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "punctilio-glob-"))
+    createdDirs.push(dir)
+    writeFileSync(join(dir, "a.md"), '"a"\n')
+    writeFileSync(join(dir, "b.md"), '"b"\n')
+    writeFileSync(join(dir, ".punctilioignore"), "b.md\n")
+
+    const originalCwd = process.cwd()
+    process.chdir(dir)
+    try {
+      const cap = captureIO()
+      const code = await runCli(["*.md", "--no-nbsp"], cap.io)
+      expect(code).toBe(0)
+      expect(readFileSync(join(dir, "a.md"), "utf8")).toContain(`${LDQ}a${RDQ}`)
+      expect(readFileSync(join(dir, "b.md"), "utf8")).toBe('"b"\n')
+    } finally {
+      process.chdir(originalCwd)
+    }
+  })
+
+  it("--ignore-path overrides the default .punctilioignore lookup", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "punctilio-ignore-"))
+    createdDirs.push(dir)
+    writeFileSync(join(dir, "a.md"), '"a"\n')
+    writeFileSync(join(dir, "b.md"), '"b"\n')
+    const customIgnore = join(dir, "custom.ignore")
+    writeFileSync(customIgnore, "a.md\n")
+
+    const originalCwd = process.cwd()
+    process.chdir(dir)
+    try {
+      const cap = captureIO()
+      const code = await runCli(
+        ["*.md", "--ignore-path", customIgnore, "--no-nbsp"],
+        cap.io,
+      )
+      expect(code).toBe(0)
+      expect(readFileSync(join(dir, "a.md"), "utf8")).toBe('"a"\n')
+      expect(readFileSync(join(dir, "b.md"), "utf8")).toContain(`${LDQ}b${RDQ}`)
+    } finally {
+      process.chdir(originalCwd)
+    }
+  })
+
   it("--no-config skips config-file loading", async () => {
     const configPath = tmpFile(
       JSON.stringify({ punctuationStyle: "british", nbsp: false }),

--- a/src/tests/cli.test.ts
+++ b/src/tests/cli.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, writeFileSync, readFileSync, rmSync } from "node:fs"
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { Readable, Writable } from "node:stream"
@@ -380,6 +380,163 @@ describe("runCli", () => {
     const code = await runCli(["--bogus"], cap.io)
     expect(code).toBe(2)
     expect(cap.stderr()).toMatch(/unknown option/i)
+  })
+
+  it("--cache writes a cache file and skips unchanged files on the second run", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "punctilio-cache-"))
+    createdDirs.push(dir)
+    const filePath = join(dir, "doc.md")
+    writeFileSync(filePath, '"Hello."\n')
+    const cacheLocation = join(dir, "cache.json")
+
+    const originalCwd = process.cwd()
+    process.chdir(dir)
+    try {
+      const first = captureIO()
+      const firstCode = await runCli(
+        ["doc.md", "--cache", "--cache-location", cacheLocation, "--no-nbsp"],
+        first.io,
+      )
+      expect(firstCode).toBe(0)
+      expect(first.stdout()).toContain("Reformatted")
+      expect(existsSync(cacheLocation)).toBe(true)
+
+      // Second run on the now-formatted file: cache should make it a no-op
+      const second = captureIO()
+      const secondCode = await runCli(
+        ["doc.md", "--cache", "--cache-location", cacheLocation, "--no-nbsp"],
+        second.io,
+      )
+      expect(secondCode).toBe(0)
+      expect(second.stdout()).not.toContain("Reformatted")
+    } finally {
+      process.chdir(originalCwd)
+    }
+  })
+
+  it("--cache without --cache-location uses the default location under cwd", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "punctilio-cache-default-"))
+    createdDirs.push(dir)
+    writeFileSync(join(dir, "doc.md"), '"Hello."\n')
+
+    const originalCwd = process.cwd()
+    process.chdir(dir)
+    try {
+      const cap = captureIO()
+      const code = await runCli(["doc.md", "--cache", "--no-nbsp"], cap.io)
+      expect(code).toBe(0)
+      expect(existsSync(join(dir, "node_modules", ".cache", "punctilio", "cache.json"))).toBe(true)
+    } finally {
+      process.chdir(originalCwd)
+    }
+  })
+
+  it("--cache invalidates when options change", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "punctilio-cache-opts-"))
+    createdDirs.push(dir)
+    const filePath = join(dir, "doc.md")
+    writeFileSync(filePath, `${LDQ}Hello.${RDQ}\n`)
+    const cacheLocation = join(dir, "cache.json")
+
+    const originalCwd = process.cwd()
+    process.chdir(dir)
+    try {
+      // Prime the cache with american style (file is already in american form)
+      const first = captureIO()
+      await runCli(
+        ["doc.md", "--cache", "--cache-location", cacheLocation, "--no-nbsp"],
+        first.io,
+      )
+
+      // Switch to british: cache hash mismatches, file gets reformatted
+      const second = captureIO()
+      const code = await runCli(
+        [
+          "doc.md", "--cache", "--cache-location", cacheLocation,
+          "--punctuation-style", "british", "--no-nbsp",
+        ],
+        second.io,
+      )
+      expect(code).toBe(0)
+      expect(second.stdout()).toContain("Reformatted")
+    } finally {
+      process.chdir(originalCwd)
+    }
+  })
+
+  it("--cache recovers gracefully from a corrupt cache file", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "punctilio-cache-corrupt-"))
+    createdDirs.push(dir)
+    const filePath = join(dir, "doc.md")
+    writeFileSync(filePath, '"Hello."\n')
+    const cacheLocation = join(dir, "cache.json")
+    writeFileSync(cacheLocation, "{not valid json")
+
+    const originalCwd = process.cwd()
+    process.chdir(dir)
+    try {
+      const cap = captureIO()
+      const code = await runCli(
+        ["doc.md", "--cache", "--cache-location", cacheLocation, "--no-nbsp"],
+        cap.io,
+      )
+      expect(code).toBe(0)
+      expect(cap.stdout()).toContain("Reformatted")
+    } finally {
+      process.chdir(originalCwd)
+    }
+  })
+
+  it("--cache ignores a JSON cache file missing the `files` key", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "punctilio-cache-shape-"))
+    createdDirs.push(dir)
+    const filePath = join(dir, "doc.md")
+    writeFileSync(filePath, '"Hello."\n')
+    const cacheLocation = join(dir, "cache.json")
+    writeFileSync(cacheLocation, "{}")
+
+    const originalCwd = process.cwd()
+    process.chdir(dir)
+    try {
+      const cap = captureIO()
+      const code = await runCli(
+        ["doc.md", "--cache", "--cache-location", cacheLocation, "--no-nbsp"],
+        cap.io,
+      )
+      expect(code).toBe(0)
+      expect(cap.stdout()).toContain("Reformatted")
+    } finally {
+      process.chdir(originalCwd)
+    }
+  })
+
+  it("--cache caches no-op (idempotent) files too, then skips them next run", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "punctilio-cache-noop-"))
+    createdDirs.push(dir)
+    const filePath = join(dir, "doc.md")
+    writeFileSync(filePath, `${LDQ}Hello.${RDQ}\n`)
+    const cacheLocation = join(dir, "cache.json")
+
+    const originalCwd = process.cwd()
+    process.chdir(dir)
+    try {
+      // First run: nothing to do, but cache should still record the clean state
+      const first = captureIO()
+      await runCli(
+        ["doc.md", "--cache", "--cache-location", cacheLocation, "--no-nbsp"],
+        first.io,
+      )
+      // Second run: cache hit, no transform attempted
+      const second = captureIO()
+      const code = await runCli(
+        ["doc.md", "--cache", "--cache-location", cacheLocation, "--no-nbsp"],
+        second.io,
+      )
+      expect(code).toBe(0)
+      expect(second.stdout()).not.toContain("Reformatted")
+    } finally {
+      process.chdir(originalCwd)
+    }
   })
 
   it("propagates unexpected errors instead of swallowing them", async () => {

--- a/src/tests/cli.test.ts
+++ b/src/tests/cli.test.ts
@@ -388,4 +388,43 @@ describe("runCli", () => {
       runCli(["/does/not/exist.md", "--no-nbsp"], cap.io),
     ).rejects.toThrow(/ENOENT/)
   })
+
+  it("loads transform options from --config <path>", async () => {
+    const configPath = tmpFile(
+      JSON.stringify({ punctuationStyle: "british", nbsp: false }),
+      ".punctiliorc.json",
+    )
+    const cap = captureIO('"Hello."')
+    const code = await runCli(["-", "--type", "md", "--config", configPath], cap.io)
+    expect(code).toBe(0)
+    expect(cap.stdout()).toContain(`${LDQ}Hello${RDQ}.`)
+  })
+
+  it("CLI flags override config-file values", async () => {
+    const configPath = tmpFile(
+      JSON.stringify({ punctuationStyle: "british", nbsp: false }),
+      ".punctiliorc.json",
+    )
+    const cap = captureIO('"Hello."')
+    const code = await runCli(
+      ["-", "--type", "md", "--config", configPath, "--punctuation-style", "american"],
+      cap.io,
+    )
+    expect(code).toBe(0)
+    expect(cap.stdout()).toContain(`${LDQ}Hello.${RDQ}`)
+  })
+
+  it("--no-config skips config-file loading", async () => {
+    const configPath = tmpFile(
+      JSON.stringify({ punctuationStyle: "british", nbsp: false }),
+      ".punctiliorc.json",
+    )
+    const cap = captureIO('"Hello."')
+    const code = await runCli(
+      ["-", "--type", "md", "--config", configPath, "--no-config", "--no-nbsp"],
+      cap.io,
+    )
+    expect(code).toBe(0)
+    expect(cap.stdout()).toContain(`${LDQ}Hello.${RDQ}`)
+  })
 })

--- a/src/tests/cli.test.ts
+++ b/src/tests/cli.test.ts
@@ -55,6 +55,18 @@ afterAll(() => {
   for (const dir of createdDirs) rmSync(dir, { recursive: true, force: true })
 })
 
+async function withTempCwd<T>(prefix: string, fn: (dir: string) => Promise<T>): Promise<T> {
+  const dir = mkdtempSync(join(tmpdir(), prefix))
+  createdDirs.push(dir)
+  const originalCwd = process.cwd()
+  process.chdir(dir)
+  try {
+    return await fn(dir)
+  } finally {
+    process.chdir(originalCwd)
+  }
+}
+
 describe("runCli", () => {
   it("formats a markdown file in place", async () => {
     const path = tmpFile('"Hello" -- world.\n', "doc.md")
@@ -383,160 +395,73 @@ describe("runCli", () => {
   })
 
   it("--cache writes a cache file and skips unchanged files on the second run", async () => {
-    const dir = mkdtempSync(join(tmpdir(), "punctilio-cache-"))
-    createdDirs.push(dir)
-    const filePath = join(dir, "doc.md")
-    writeFileSync(filePath, '"Hello."\n')
-    const cacheLocation = join(dir, "cache.json")
+    await withTempCwd("punctilio-cache-", async (dir) => {
+      writeFileSync(join(dir, "doc.md"), '"Hello."\n')
+      const cacheLocation = join(dir, "cache.json")
+      const args = ["doc.md", "--cache", "--cache-location", cacheLocation, "--no-nbsp"]
 
-    const originalCwd = process.cwd()
-    process.chdir(dir)
-    try {
       const first = captureIO()
-      const firstCode = await runCli(
-        ["doc.md", "--cache", "--cache-location", cacheLocation, "--no-nbsp"],
-        first.io,
-      )
-      expect(firstCode).toBe(0)
+      expect(await runCli(args, first.io)).toBe(0)
       expect(first.stdout()).toContain("Reformatted")
       expect(existsSync(cacheLocation)).toBe(true)
 
-      // Second run on the now-formatted file: cache should make it a no-op
       const second = captureIO()
-      const secondCode = await runCli(
-        ["doc.md", "--cache", "--cache-location", cacheLocation, "--no-nbsp"],
-        second.io,
-      )
-      expect(secondCode).toBe(0)
+      expect(await runCli(args, second.io)).toBe(0)
       expect(second.stdout()).not.toContain("Reformatted")
-    } finally {
-      process.chdir(originalCwd)
-    }
+    })
   })
 
   it("--cache without --cache-location uses the default location under cwd", async () => {
-    const dir = mkdtempSync(join(tmpdir(), "punctilio-cache-default-"))
-    createdDirs.push(dir)
-    writeFileSync(join(dir, "doc.md"), '"Hello."\n')
-
-    const originalCwd = process.cwd()
-    process.chdir(dir)
-    try {
+    await withTempCwd("punctilio-cache-default-", async (dir) => {
+      writeFileSync(join(dir, "doc.md"), '"Hello."\n')
       const cap = captureIO()
-      const code = await runCli(["doc.md", "--cache", "--no-nbsp"], cap.io)
-      expect(code).toBe(0)
+      expect(await runCli(["doc.md", "--cache", "--no-nbsp"], cap.io)).toBe(0)
       expect(existsSync(join(dir, "node_modules", ".cache", "punctilio", "cache.json"))).toBe(true)
-    } finally {
-      process.chdir(originalCwd)
-    }
+    })
   })
 
   it("--cache invalidates when options change", async () => {
-    const dir = mkdtempSync(join(tmpdir(), "punctilio-cache-opts-"))
-    createdDirs.push(dir)
-    const filePath = join(dir, "doc.md")
-    writeFileSync(filePath, `${LDQ}Hello.${RDQ}\n`)
-    const cacheLocation = join(dir, "cache.json")
+    await withTempCwd("punctilio-cache-opts-", async (dir) => {
+      writeFileSync(join(dir, "doc.md"), `${LDQ}Hello.${RDQ}\n`)
+      const cacheLocation = join(dir, "cache.json")
+      const baseArgs = ["doc.md", "--cache", "--cache-location", cacheLocation, "--no-nbsp"]
 
-    const originalCwd = process.cwd()
-    process.chdir(dir)
-    try {
-      // Prime the cache with american style (file is already in american form)
       const first = captureIO()
-      await runCli(
-        ["doc.md", "--cache", "--cache-location", cacheLocation, "--no-nbsp"],
-        first.io,
-      )
+      await runCli(baseArgs, first.io)
 
-      // Switch to british: cache hash mismatches, file gets reformatted
       const second = captureIO()
-      const code = await runCli(
-        [
-          "doc.md", "--cache", "--cache-location", cacheLocation,
-          "--punctuation-style", "british", "--no-nbsp",
-        ],
-        second.io,
-      )
-      expect(code).toBe(0)
+      expect(await runCli([...baseArgs, "--punctuation-style", "british"], second.io)).toBe(0)
       expect(second.stdout()).toContain("Reformatted")
-    } finally {
-      process.chdir(originalCwd)
-    }
+    })
   })
 
-  it("--cache recovers gracefully from a corrupt cache file", async () => {
-    const dir = mkdtempSync(join(tmpdir(), "punctilio-cache-corrupt-"))
-    createdDirs.push(dir)
-    const filePath = join(dir, "doc.md")
-    writeFileSync(filePath, '"Hello."\n')
-    const cacheLocation = join(dir, "cache.json")
-    writeFileSync(cacheLocation, "{not valid json")
+  it.each([
+    ["recovers gracefully from a corrupt cache file", "{not valid json"],
+    ["ignores a JSON cache file missing the `files` key", "{}"],
+  ])("--cache %s", async (_label, seedContent) => {
+    await withTempCwd("punctilio-cache-bad-", async (dir) => {
+      writeFileSync(join(dir, "doc.md"), '"Hello."\n')
+      const cacheLocation = join(dir, "cache.json")
+      writeFileSync(cacheLocation, seedContent)
 
-    const originalCwd = process.cwd()
-    process.chdir(dir)
-    try {
       const cap = captureIO()
-      const code = await runCli(
-        ["doc.md", "--cache", "--cache-location", cacheLocation, "--no-nbsp"],
-        cap.io,
-      )
-      expect(code).toBe(0)
+      expect(await runCli(["doc.md", "--cache", "--cache-location", cacheLocation, "--no-nbsp"], cap.io)).toBe(0)
       expect(cap.stdout()).toContain("Reformatted")
-    } finally {
-      process.chdir(originalCwd)
-    }
-  })
-
-  it("--cache ignores a JSON cache file missing the `files` key", async () => {
-    const dir = mkdtempSync(join(tmpdir(), "punctilio-cache-shape-"))
-    createdDirs.push(dir)
-    const filePath = join(dir, "doc.md")
-    writeFileSync(filePath, '"Hello."\n')
-    const cacheLocation = join(dir, "cache.json")
-    writeFileSync(cacheLocation, "{}")
-
-    const originalCwd = process.cwd()
-    process.chdir(dir)
-    try {
-      const cap = captureIO()
-      const code = await runCli(
-        ["doc.md", "--cache", "--cache-location", cacheLocation, "--no-nbsp"],
-        cap.io,
-      )
-      expect(code).toBe(0)
-      expect(cap.stdout()).toContain("Reformatted")
-    } finally {
-      process.chdir(originalCwd)
-    }
+    })
   })
 
   it("--cache caches no-op (idempotent) files too, then skips them next run", async () => {
-    const dir = mkdtempSync(join(tmpdir(), "punctilio-cache-noop-"))
-    createdDirs.push(dir)
-    const filePath = join(dir, "doc.md")
-    writeFileSync(filePath, `${LDQ}Hello.${RDQ}\n`)
-    const cacheLocation = join(dir, "cache.json")
+    await withTempCwd("punctilio-cache-noop-", async (dir) => {
+      writeFileSync(join(dir, "doc.md"), `${LDQ}Hello.${RDQ}\n`)
+      const cacheLocation = join(dir, "cache.json")
+      const args = ["doc.md", "--cache", "--cache-location", cacheLocation, "--no-nbsp"]
 
-    const originalCwd = process.cwd()
-    process.chdir(dir)
-    try {
-      // First run: nothing to do, but cache should still record the clean state
       const first = captureIO()
-      await runCli(
-        ["doc.md", "--cache", "--cache-location", cacheLocation, "--no-nbsp"],
-        first.io,
-      )
-      // Second run: cache hit, no transform attempted
+      await runCli(args, first.io)
       const second = captureIO()
-      const code = await runCli(
-        ["doc.md", "--cache", "--cache-location", cacheLocation, "--no-nbsp"],
-        second.io,
-      )
-      expect(code).toBe(0)
+      expect(await runCli(args, second.io)).toBe(0)
       expect(second.stdout()).not.toContain("Reformatted")
-    } finally {
-      process.chdir(originalCwd)
-    }
+    })
   })
 
   it("propagates unexpected errors instead of swallowing them", async () => {
@@ -572,47 +497,30 @@ describe("runCli", () => {
   })
 
   it("expands glob patterns and respects .punctilioignore", async () => {
-    const dir = mkdtempSync(join(tmpdir(), "punctilio-glob-"))
-    createdDirs.push(dir)
-    writeFileSync(join(dir, "a.md"), '"a"\n')
-    writeFileSync(join(dir, "b.md"), '"b"\n')
-    writeFileSync(join(dir, ".punctilioignore"), "b.md\n")
+    await withTempCwd("punctilio-glob-", async (dir) => {
+      writeFileSync(join(dir, "a.md"), '"a"\n')
+      writeFileSync(join(dir, "b.md"), '"b"\n')
+      writeFileSync(join(dir, ".punctilioignore"), "b.md\n")
 
-    const originalCwd = process.cwd()
-    process.chdir(dir)
-    try {
       const cap = captureIO()
-      const code = await runCli(["*.md", "--no-nbsp"], cap.io)
-      expect(code).toBe(0)
+      expect(await runCli(["*.md", "--no-nbsp"], cap.io)).toBe(0)
       expect(readFileSync(join(dir, "a.md"), "utf8")).toContain(`${LDQ}a${RDQ}`)
       expect(readFileSync(join(dir, "b.md"), "utf8")).toBe('"b"\n')
-    } finally {
-      process.chdir(originalCwd)
-    }
+    })
   })
 
   it("--ignore-path overrides the default .punctilioignore lookup", async () => {
-    const dir = mkdtempSync(join(tmpdir(), "punctilio-ignore-"))
-    createdDirs.push(dir)
-    writeFileSync(join(dir, "a.md"), '"a"\n')
-    writeFileSync(join(dir, "b.md"), '"b"\n')
-    const customIgnore = join(dir, "custom.ignore")
-    writeFileSync(customIgnore, "a.md\n")
+    await withTempCwd("punctilio-ignore-", async (dir) => {
+      writeFileSync(join(dir, "a.md"), '"a"\n')
+      writeFileSync(join(dir, "b.md"), '"b"\n')
+      const customIgnore = join(dir, "custom.ignore")
+      writeFileSync(customIgnore, "a.md\n")
 
-    const originalCwd = process.cwd()
-    process.chdir(dir)
-    try {
       const cap = captureIO()
-      const code = await runCli(
-        ["*.md", "--ignore-path", customIgnore, "--no-nbsp"],
-        cap.io,
-      )
-      expect(code).toBe(0)
+      expect(await runCli(["*.md", "--ignore-path", customIgnore, "--no-nbsp"], cap.io)).toBe(0)
       expect(readFileSync(join(dir, "a.md"), "utf8")).toBe('"a"\n')
       expect(readFileSync(join(dir, "b.md"), "utf8")).toContain(`${LDQ}b${RDQ}`)
-    } finally {
-      process.chdir(originalCwd)
-    }
+    })
   })
 
   it("--no-config skips config-file loading", async () => {


### PR DESCRIPTION
## Summary

Adds four formatter-ergonomics features that the JS-formatter ecosystem (prettier, biome, dprint) treats as table stakes:

1. **Config file via [`cosmiconfig`](https://github.com/cosmiconfig/cosmiconfig).** `.punctiliorc[.json|.yaml|.yml|.js|.cjs]`, `punctilio.config.js`, or a `"punctilio"` key in `package.json`. `--config <path>` to specify, `--no-config` to skip discovery. Config keys use library option names (`punctuationStyle`, `skipTags`, …); CLI flags override.
2. **Glob expansion via [`tinyglobby`](https://github.com/superchupu/tinyglobby).** Positional patterns containing `*?[]{}` are expanded internally; literal paths pass through unchanged so `punctilio missing.md` still errors loudly. Cross-platform-correct globbing without depending on the shell.
3. **`.punctilioignore` via the [`ignore`](https://github.com/kaelzhang/node-ignore) package.** Gitignore syntax. Defaults to `.punctilioignore` in cwd, overridable with `--ignore-path <path>`. Applies to both glob-expanded results and literal positional paths.
4. **Incremental `--cache`** (opt-in). Mirrors prettier's `--cache`: skips files whose `(content-hash, options-hash, version)` tuple was seen successfully on the previous run. Default location `node_modules/.cache/punctilio/cache.json`; `--cache-location <path>` to override. Corrupt or stale cache files are ignored — they never block formatting.

## New flags

```
--config <path>          # specify config file
--no-config              # skip config auto-discovery
--ignore-path <path>     # specify ignore file
--cache                  # enable incremental cache
--cache-location <path>  # override default cache file path
```

## New dependencies (pinned exact)

```
cosmiconfig@9.0.1
ignore@7.0.5
tinyglobby@0.2.16
```

## Test plan

- [x] `pnpm test` — 1779 passing (added 9 new tests), 100% coverage
- [x] `pnpm lint`, `pnpm exec tsc --noEmit` — clean
- [x] Round-trip cache test: format → cache; second run on same content is a no-op
- [x] Cache invalidation on options change verified
- [x] `--ignore-path` and `.punctilioignore` filter glob results
- [x] Smoke-tested `punctilio --cache 'docs/**/*.md'` end-to-end on the built CLI

Stacks on top of #189 (which already merged into the formatter base branch).

---
_Generated by [Claude Code](https://claude.ai/code/session_01629Ysss8k29mY7PqFfmMYa)_