### PR TITLE
Prevent cascade binding in nbspAfterShortWords

### DIFF
--- a/src/nbsp.ts
+++ b/src/nbsp.ts
@@ -115,6 +115,11 @@ const COPYRIGHT_SYMBOLS = `[${COPYRIGHT}${REGISTERED}${TRADEMARK}]`
  * Adds non-breaking space after short words (1-2 letters) to prevent them from
  * being left alone at the end of a line.
  *
+ * Skips when the short word is already preceded by an NBSP from an earlier
+ * transform, or when this match immediately follows the previous one
+ * (back-to-back short words in the same pass). Either case would bind three
+ * or more words into a single line-break atom — defeating widow protection.
+ *
  * @example "a cat" → "a\u00A0cat", "I am" → "I\u00A0am"
  */
 export function nbspAfterShortWords(text: string, options: NbspOptions = {}): string {
@@ -123,7 +128,13 @@ export function nbspAfterShortWords(text: string, options: NbspOptions = {}): st
     `(?<=^|${SPACE}|${PUNCTUATION_OR_QUOTE}|>)(?<shortWord>[${LATIN_LETTERS}]{1,2})(?<marker>${sep}?)${SPACE}`,
     "gmu"
   )
-  return text.replace(pattern, `$<shortWord>$<marker>${NBSP}`)
+  let previousMatchEnd = -1
+  return text.replace(pattern, (match, shortWord: string, marker: string, offset: number) => {
+    if (offset === previousMatchEnd) return match
+    if (offset > 0 && NBSP_CHARS.includes(text[offset - 1])) return match
+    previousMatchEnd = offset + match.length
+    return `${shortWord}${marker}${NBSP}`
+  })
 }
 
 /**

--- a/src/tests/nbsp.test.ts
+++ b/src/tests/nbsp.test.ts
@@ -40,8 +40,15 @@ describe("nbspAfterShortWords", () => {
     ["or if", `or${NBSP}if`],
     ["I think", `I${NBSP}think`],
     ['"a cat"', `"a${NBSP}cat"`],
-    ["the cat sat on a mat", `the cat sat on${NBSP}a${NBSP}mat`],
-    ["Go to the store", `Go${NBSP}to${NBSP}the store`],
+    // Cascade prevention: only the first short word in a run gets glued, so
+    // the result never binds three or more words into a non-breaking atom.
+    ["the cat sat on a mat", `the cat sat on${NBSP}a mat`],
+    ["Go to the store", `Go${NBSP}to the store`],
+    ["is a Monte Carlo", `is${NBSP}a Monte Carlo`],
+    ["I am here", `I${NBSP}am here`],
+    // Pre-existing NBSP from an earlier transform: don't extend the chain.
+    [`Dr.${NBSP}is here`, `Dr.${NBSP}is here`],
+    [`5${NBSP}kg of items`, `5${NBSP}kg of${NBSP}items`],
     ["the cat", "the cat"],
     // Accented Latin short words
     ["à chat", `à${NBSP}chat`],

--- a/src/tests/rehype.test.ts
+++ b/src/tests/rehype.test.ts
@@ -623,12 +623,12 @@ describe("rehypePunctilio", () => {
 
     it("inserts nbsp when option enabled", async () => {
       const result = await processHtml('<p>Dr. Smith has 5 kg of items.</p>', { nbsp: true })
-      expect(result).toBe(`<p>Dr.${NBSP}Smith has 5${NBSP}kg${NBSP}of${NBSP}items.</p>`)
+      expect(result).toBe(`<p>Dr.${NBSP}Smith has 5${NBSP}kg of${NBSP}items.</p>`)
     })
 
     it("inserts nbsp by default", async () => {
       const result = await processHtml('<p>Dr. Smith has 5 kg of items.</p>')
-      expect(result).toBe(`<p>Dr.${NBSP}Smith has 5${NBSP}kg${NBSP}of${NBSP}items.</p>`)
+      expect(result).toBe(`<p>Dr.${NBSP}Smith has 5${NBSP}kg of${NBSP}items.</p>`)
     })
 
     it("does not insert nbsp when option disabled", async () => {

--- a/src/tests/remark.test.ts
+++ b/src/tests/remark.test.ts
@@ -48,7 +48,7 @@ describe("remarkPunctilio", () => {
   describe("basic transformations (nbsp enabled)", () => {
     it.each([
       ["quotes", '"Hello," she said.', `${LDQ}Hello,${RDQ} she${NBSP}said.`],
-      ["apostrophes", "It's a test.", `It${RSQ}s${NBSP}a${NBSP}test.`],
+      ["apostrophes", "It's a test.", `It${RSQ}s${NBSP}a test.`],
       ["em dashes", "Wait -- here it comes.", `Wait${EM_DASH}here it${NBSP}comes.`],
       ["en dashes (number range)", "Pages 1-5", `Pages${NBSP}1${EN_DASH}5`],
       ["ellipses", "Wait...", `Wait${ELLIPSIS}`],


### PR DESCRIPTION
Fixes widow protection logic in `nbspAfterShortWords` to prevent binding three or more consecutive words into a single non-breaking atom, which defeats the purpose of the transform.

## Changes

- Modified `nbspAfterShortWords` to skip applying NBSP when:
  - The short word immediately follows a previous match (back-to-back short words in the same pass)
  - The short word is already preceded by an NBSP from an earlier transform
- Updated test expectations to reflect the corrected behavior, where only the first short word in a run receives the NBSP treatment
- Updated integration tests in rehype and remark suites to match the new expected output

## Implementation Details

The fix uses a callback-based `String.replace()` instead of a simple replacement string, tracking `previousMatchEnd` to detect consecutive matches. This prevents patterns like "Go to the store" from becoming `Go\u00A0to\u00A0the store` (binding three words), instead producing `Go\u00A0to the store` (protecting only the first short word).

The check for pre-existing NBSP characters ensures that earlier transforms (like abbreviation handling) don't get extended into unintended cascades.

https://claude.ai/code/session_01McLeUvMxJrd8N6NiFbn3kJ