### PR TITLE
fix: validate style options, deduplicate CLI files, stabilize cache keys

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -148,7 +148,7 @@ async function discoverFiles(
   const expanded = globs.length > 0
     ? await glob(globs, { cwd, absolute: true, onlyFiles: true })
     : []
-  const all = [...literals.map((p) => resolve(cwd, p)), ...expanded]
+  const all = [...new Set([...literals.map((p) => resolve(cwd, p)), ...expanded])]
   return all.filter((file) => {
     const rel = relative(cwd, file)
     return rel.startsWith("..") || !ig.ignores(rel)

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,8 @@
 export { DEFAULT_SEPARATOR, UNICODE_SYMBOLS } from "./constants.js"
-import type { PunctuationStyle } from "./quotes.js"
+import { DASH_STYLES, type DashStyle } from "./dashes.js"
+import { PUNCTUATION_STYLES, type PunctuationStyle } from "./quotes.js"
 export {
+  DASH_STYLES,
   type DashOptions,
   type DashStyle,
   enDashDateRange,
@@ -9,7 +11,6 @@ export {
   minusReplace,
   numberRangeDisallowedPrefixes,
 } from "./dashes.js"
-import type { DashStyle } from "./dashes.js"
 export {
   HONORIFICS,
   nbspAfterCopyrightSymbols,
@@ -25,7 +26,7 @@ export {
   REFERENCE_ABBREVIATIONS,
   UNITS,
 } from "./nbsp.js"
-export { classifyApostrophes, niceQuotes, type PunctuationStyle, type QuoteOptions } from "./quotes.js"
+export { classifyApostrophes, niceQuotes, PUNCTUATION_STYLES, type PunctuationStyle, type QuoteOptions } from "./quotes.js"
 
 export interface TransformOptions {
   /**
@@ -197,6 +198,22 @@ export function transform(text: string, options: TransformOptions = {}): string 
     throw new Error(
       `Invalid separator: must contain only BMP characters (no characters outside the Basic Multilingual Plane). ` +
       `Received "${separator}" which contains a non-BMP character.`
+    )
+  }
+
+  const punctuationStyle = options.punctuationStyle ?? "american"
+  if (!PUNCTUATION_STYLES.includes(punctuationStyle as typeof PUNCTUATION_STYLES[number])) {
+    throw new Error(
+      `Invalid punctuationStyle: "${punctuationStyle}". ` +
+      `Must be one of: ${PUNCTUATION_STYLES.join(", ")}.`
+    )
+  }
+
+  const dashStyle = options.dashStyle ?? "american"
+  if (!DASH_STYLES.includes(dashStyle as typeof DASH_STYLES[number])) {
+    throw new Error(
+      `Invalid dashStyle: "${dashStyle}". ` +
+      `Must be one of: ${DASH_STYLES.join(", ")}.`
     )
   }
 

--- a/src/tests/cli.test.ts
+++ b/src/tests/cli.test.ts
@@ -587,6 +587,17 @@ describe("runCli", () => {
     })
   })
 
+  it("deduplicates files when a literal path also matches a glob", async () => {
+    await withTempCwd("punctilio-dedup-", async (dir) => {
+      writeFileSync(join(dir, "a.md"), '"a"\n')
+      const cap = captureIO()
+      expect(await runCli(["a.md", "*.md", "--no-nbsp"], cap.io)).toBe(0)
+      const out = cap.stdout()
+      const reformatted = out.split("\n").filter((l) => l.includes("Reformatted"))
+      expect(reformatted).toHaveLength(1)
+    })
+  })
+
   it("--ignore-path overrides the default .punctilioignore lookup", async () => {
     await withTempCwd("punctilio-ignore-", async (dir) => {
       writeFileSync(join(dir, "a.md"), '"a"\n')

--- a/src/tests/index.test.ts
+++ b/src/tests/index.test.ts
@@ -1,4 +1,4 @@
-import { countSeparators, DEFAULT_SEPARATOR, transform } from "../index.js"
+import { countSeparators, DASH_STYLES, DEFAULT_SEPARATOR, PUNCTUATION_STYLES, transform } from "../index.js"
 import { ellipsis } from "../symbols.js"
 import { MAX_REGEX_CACHE_SIZE, REGEX_SPECIAL_CHARS, UNICODE_SYMBOLS } from "../constants.js"
 import { buildMixedContent } from "./test-helpers.js"
@@ -709,4 +709,82 @@ describe("transform", () => {
     })
 
   })
+
+  describe("option validation", () => {
+    it.each([
+      "American",
+      "AMERICAN",
+      "typo",
+      "",
+      "en-US",
+    ])("rejects invalid punctuationStyle: %s", (style) => {
+      expect(() => transform("hello", { punctuationStyle: style as never })).toThrow(
+        /Invalid punctuationStyle/
+      )
+    })
+
+    it("includes valid values in punctuationStyle error message", () => {
+      expect.assertions(PUNCTUATION_STYLES.length)
+      try {
+        transform("hello", { punctuationStyle: "bad" as never })
+      } catch (e) {
+        const msg = (e as Error).message
+        for (const style of PUNCTUATION_STYLES) {
+          expect(msg).toContain(style)
+        }
+      }
+    })
+
+    it.each([
+      "American",
+      "BRITISH",
+      "typo",
+      "",
+    ])("rejects invalid dashStyle: %s", (style) => {
+      expect(() => transform("hello", { dashStyle: style as never })).toThrow(
+        /Invalid dashStyle/
+      )
+    })
+
+    it("includes valid values in dashStyle error message", () => {
+      expect.assertions(DASH_STYLES.length)
+      try {
+        transform("hello", { dashStyle: "bad" as never })
+      } catch (e) {
+        const msg = (e as Error).message
+        for (const style of DASH_STYLES) {
+          expect(msg).toContain(style)
+        }
+      }
+    })
+
+    it.each([
+      "american",
+      "british",
+      "german",
+      "french",
+      "none",
+    ] as const)("accepts valid punctuationStyle: %s", (style) => {
+      expect(() => transform("hello", { punctuationStyle: style })).not.toThrow()
+    })
+
+    it.each([
+      "american",
+      "british",
+      "none",
+    ] as const)("accepts valid dashStyle: %s", (style) => {
+      expect(() => transform("hello", { dashStyle: style })).not.toThrow()
+    })
+  })
+
+  describe("style constant exports", () => {
+    it("exports PUNCTUATION_STYLES with all expected values", () => {
+      expect(PUNCTUATION_STYLES).toEqual(["american", "british", "german", "french", "none"])
+    })
+
+    it("exports DASH_STYLES with all expected values", () => {
+      expect(DASH_STYLES).toEqual(["american", "british", "none"])
+    })
+  })
+
 })

--- a/src/tests/utils.test.ts
+++ b/src/tests/utils.test.ts
@@ -1,5 +1,5 @@
 import { jest } from "@jest/globals"
-import { assertSeparatorAbsent, assertSeparatorCountPreserved, countSeparators, formatErrorString } from "../utils.js"
+import { assertSeparatorAbsent, assertSeparatorCountPreserved, countSeparators, formatErrorString, stableStringify } from "../utils.js"
 import { cachedRegExp, clearRegexCache, DEFAULT_SEPARATOR } from "../constants.js"
 
 describe("assertSeparatorAbsent", () => {
@@ -148,5 +148,25 @@ describe("formatErrorString", () => {
     const result = formatErrorString(exactText, "exact")
     expect(result).toBe(JSON.stringify(exactText))
     expect(stderrOutput).toHaveLength(0)
+  })
+})
+
+describe("stableStringify", () => {
+  it("sorts object keys alphabetically", () => {
+    expect(stableStringify({ b: 1, a: 2 })).toBe(stableStringify({ a: 2, b: 1 }))
+  })
+
+  it("filters out undefined values", () => {
+    expect(stableStringify({ a: 1, b: undefined })).toBe(stableStringify({ a: 1 }))
+  })
+
+  it("sorts array values for order-independent cache keys", () => {
+    expect(stableStringify({ tags: ["pre", "code"] })).toBe(stableStringify({ tags: ["code", "pre"] }))
+  })
+
+  it("does not mutate the original array", () => {
+    const opts = { tags: ["pre", "code", "a"] }
+    stableStringify(opts)
+    expect(opts.tags).toEqual(["pre", "code", "a"])
   })
 })

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -120,6 +120,7 @@ export function stableStringify(obj: object): string {
   const entries = Object.entries(obj)
     .filter(([, v]) => v !== undefined)
     .sort(([a], [b]) => a.localeCompare(b))
+    .map(([k, v]) => [k, Array.isArray(v) ? [...v].sort() : v])
   return JSON.stringify(entries)
 }
 


### PR DESCRIPTION
## Summary

- **Validate `punctuationStyle` and `dashStyle` at the library API level** — passing an invalid value like `"American"` or `"typo"` previously fell through silently to defaults; now throws with an actionable error listing all valid values.
- **Export `PUNCTUATION_STYLES` and `DASH_STYLES`** from the main module so consumers can programmatically enumerate valid values without importing from internal submodules.
- **Deduplicate files in CLI's `discoverFiles`** — overlapping literal paths and glob patterns (e.g. `punctilio README.md '*.md'`) no longer process the same file twice.
- **Sort array values in `stableStringify`** so processor cache keys are deterministic regardless of array element order (e.g. `skipTags: ["pre","code"]` and `["code","pre"]` now produce the same cache key).

## Changes

- `src/index.ts`: Add runtime validation for `punctuationStyle` and `dashStyle` with descriptive error messages; re-export `PUNCTUATION_STYLES` and `DASH_STYLES` arrays.
- `src/cli.ts`: Wrap file list in `new Set(...)` to deduplicate resolved paths from literals + glob expansion.
- `src/utils.ts`: Add `.map()` step to `stableStringify` that sorts array values before serialization (shallow-copies to avoid mutating the original).
- `src/tests/index.test.ts`: 20 new tests — parametrized rejection tests for invalid values, error message content verification with `expect.assertions`, positive tests for all valid values, and export value tests.
- `src/tests/utils.test.ts`: 4 new tests for `stableStringify` — key sorting, undefined filtering, array order independence, and non-mutation guarantee.
- `src/tests/cli.test.ts`: 1 new test verifying file deduplication when a literal path also matches a glob.

## Testing

- All 1824 tests pass (25 new), 100% branch/statement/function/line coverage maintained
- Build (`tsc`) and lint (`eslint`) clean
- ReDoS safety check (`recheck`) passes on all cached regexes

https://claude.ai/code/session_018arUxETauXVSqJYik9A871

---
_Generated by [Claude Code](https://claude.ai/code/session_018arUxETauXVSqJYik9A871)_