### PR TITLE
fix: restore idempotency for symbol-adjacent ranges and German orphan quotes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 ### Fixed
-- Idempotency for ranges adjacent to a multiplication sign: `transform("5x10-20")` no longer throws. `multiplication` rewrites the range-blocking `x` to `×`, which is now also excluded from number-range detection.
+- Idempotency for ranges preceded by a symbol-pass operator: `transform("5x10-20")` and `transform("+/-1-5")` no longer throw. The symbol pass rewrites the range-blocking `x` to `×` and `+/-` to `±`, which are now also excluded from number-range detection.
 - Idempotency for orphan German quotes: `transform('word"', { punctuationStyle: "german" })` no longer throws. A lone German closing quote (U+201C/U+2018, which double as American openers) is no longer re-read as an opener on re-processing.
 
 ## [3.13.0] - 2026-06-06

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+- Idempotency for ranges adjacent to a multiplication sign: `transform("5x10-20")` no longer throws. `multiplication` rewrites the range-blocking `x` to `×`, which is now also excluded from number-range detection.
+- Idempotency for orphan German quotes: `transform('word"', { punctuationStyle: "german" })` no longer throws. A lone German closing quote (U+201C/U+2018, which double as American openers) is no longer re-read as an opener on re-processing.
+
 ## [3.13.0] - 2026-06-06
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ My [`benchmark.mjs`](https://github.com/alexander-turner/punctilio/blob/main/ben
 |         Superscripts |     <span class="no-formatting">2nd → 2ⁿᵈ</span>      |      ✓      |       ✗       |      ✗      |       ✗       |     ✗      |
 | English localization | <span class="no-formatting">American / British</span> |      ✓      |       ✗       |      ✗      |       ✗       |     ✗      |
 |            Ligatures |       <span class="no-formatting">?? → ⁇</span>       |      ✓      |       ✗       |      ✓      |       ✗       |     ✗      |
-|   Non-English quotes |      <span class=”no-formatting”>„Hallo”</span>       |      ✓      |       ✗       |      ✓      |       ✗       |     ◐      |
+|   Non-English quotes |      <span class="no-formatting">„Hallo“</span>       |      ✓      |       ✗       |      ✓      |       ✗       |     ◐      |
 |  Non-breaking spaces |     <span class="no-formatting">Chapter 1</span>      |      ✓      |       ✗       |      ✗      |       ✗       |     ✓      |
 
 ### Known limitations of `punctilio`
@@ -223,7 +223,7 @@ repos:
 - The `british` style follows [Oxford style](https://www.ox.ac.uk/sites/files/oxford/Style%20Guide%20quick%20reference%20A-Z.pdf):
   - Periods and commas go outside quotation marks (“Hello”, she said.)
   - Spaced en-dashes between words (word – word)
-- The `german` style uses low-9 quotes: „double” (U+201E/U+201C) and ‚single' (U+201A/U+2018).
+- The `german` style uses low-9 quotes: „double“ (U+201E/U+201C) and ‚single‘ (U+201A/U+2018).
   - Punctuation outside quotes
 - The `french` style uses guillemets padded with a narrow no-break space (U+202F), per Unicode CLDR's `fr` locale and the Imprimerie nationale's *Lexique des règles typographiques*: « Bonjour ».
   - Single quotes remain as curly quotes

--- a/src/dashes.ts
+++ b/src/dashes.ts
@@ -11,7 +11,7 @@ export interface DashOptions {
   dashStyle?: DashStyle
 }
 
-const { EN_DASH, EM_DASH, MINUS, LEFT_DOUBLE_QUOTE, RIGHT_DOUBLE_QUOTE, LEFT_SINGLE_QUOTE, RIGHT_SINGLE_QUOTE } = UNICODE_SYMBOLS
+const { EN_DASH, EM_DASH, MINUS, MULTIPLICATION, LEFT_DOUBLE_QUOTE, RIGHT_DOUBLE_QUOTE, LEFT_SINGLE_QUOTE, RIGHT_SINGLE_QUOTE } = UNICODE_SYMBOLS
 
 // Prevents false-positive ranges in model names like "Llama-2-7B".
 export const numberRangeDisallowedPrefixes = ["-", EN_DASH, EM_DASH, MINUS] as const
@@ -43,7 +43,11 @@ export function enDashNumberRange(text: string, options: DashOptions = {}): stri
   // Build positive range pattern from readable components
   const phoneAreaCode = `(?<precedingAreaCode>\\d{3}-|\\(\\d{3}\\) ?)?`  // 555- or (555)
   // Lookbehind prevents matching after dashes, so Llama-2-7B and +44-20 don't en-dash.
-  const notAfterDash = `(?<![${DISALLOWED_PREFIX_CLASS_FRAGMENT}${LATIN_LETTERS}.+])`
+  // `${MULTIPLICATION}` keeps ranges stable across the multiplication pass, which runs
+  // after this one: a range start preceded by `x` (a Latin letter) is already rejected
+  // here, and `multiplication` later rewrites that `x` to `×`. Rejecting `×` too means a
+  // second pass over "5x10-20" → "5×10-20" doesn't suddenly en-dash the "10-20" tail.
+  const notAfterDash = `(?<![${DISALLOWED_PREFIX_CLASS_FRAGMENT}${LATIN_LETTERS}${MULTIPLICATION}.+])`
   const rangeStart = `(?<start>(?:p\\.?|[${currencies}])?\\d[\\d.,]*${chr}?)`  // p.10, $100, 1,000
   const rangeEnd = `(?<end>${chr}?[${currencies}]?\\d[\\d.,]*)`          // 20, $200, 2,000
   const moreSegments = `(?<following>(?:${chr}?[-${MINUS}]${chr}?\\d+)*)` // -4567 in phone numbers

--- a/src/dashes.ts
+++ b/src/dashes.ts
@@ -11,7 +11,7 @@ export interface DashOptions {
   dashStyle?: DashStyle
 }
 
-const { EN_DASH, EM_DASH, MINUS, MULTIPLICATION, LEFT_DOUBLE_QUOTE, RIGHT_DOUBLE_QUOTE, LEFT_SINGLE_QUOTE, RIGHT_SINGLE_QUOTE } = UNICODE_SYMBOLS
+const { EN_DASH, EM_DASH, MINUS, MULTIPLICATION, PLUS_MINUS, LEFT_DOUBLE_QUOTE, RIGHT_DOUBLE_QUOTE, LEFT_SINGLE_QUOTE, RIGHT_SINGLE_QUOTE } = UNICODE_SYMBOLS
 
 // Prevents false-positive ranges in model names like "Llama-2-7B".
 export const numberRangeDisallowedPrefixes = ["-", EN_DASH, EM_DASH, MINUS] as const
@@ -43,11 +43,12 @@ export function enDashNumberRange(text: string, options: DashOptions = {}): stri
   // Build positive range pattern from readable components
   const phoneAreaCode = `(?<precedingAreaCode>\\d{3}-|\\(\\d{3}\\) ?)?`  // 555- or (555)
   // Lookbehind prevents matching after dashes, so Llama-2-7B and +44-20 don't en-dash.
-  // `${MULTIPLICATION}` keeps ranges stable across the multiplication pass, which runs
-  // after this one: a range start preceded by `x` (a Latin letter) is already rejected
-  // here, and `multiplication` later rewrites that `x` to `×`. Rejecting `×` too means a
-  // second pass over "5x10-20" → "5×10-20" doesn't suddenly en-dash the "10-20" tail.
-  const notAfterDash = `(?<![${DISALLOWED_PREFIX_CLASS_FRAGMENT}${LATIN_LETTERS}${MULTIPLICATION}.+])`
+  // `${MULTIPLICATION}${PLUS_MINUS}` keep ranges stable across the symbol pass, which
+  // runs after this one: a range start preceded by `x` (a Latin letter) or `+`/`-` is
+  // already rejected here, and the symbol pass rewrites "5x10" → "5×10" and "+/-1" →
+  // "±1". Rejecting `×` and `±` too means a second pass over those outputs doesn't
+  // suddenly en-dash a tail the first pass left alone (e.g. "5x10-20" → "5×10-20").
+  const notAfterDash = `(?<![${DISALLOWED_PREFIX_CLASS_FRAGMENT}${LATIN_LETTERS}${MULTIPLICATION}${PLUS_MINUS}.+])`
   const rangeStart = `(?<start>(?:p\\.?|[${currencies}])?\\d[\\d.,]*${chr}?)`  // p.10, $100, 1,000
   const rangeEnd = `(?<end>${chr}?[${currencies}]?\\d[\\d.,]*)`          // 20, $200, 2,000
   const moreSegments = `(?<following>(?:${chr}?[-${MINUS}]${chr}?\\d+)*)` // -4567 in phone numbers

--- a/src/quotes.ts
+++ b/src/quotes.ts
@@ -218,15 +218,31 @@ function normalizeGermanQuotes(text: string): string {
     if (ch === DLQ) {
       chars.push(LEFT_DOUBLE_QUOTE)
       doubleDepth++
-    } else if (ch === LEFT_DOUBLE_QUOTE && doubleDepth > 0) {
-      chars.push(RIGHT_DOUBLE_QUOTE)
-      doubleDepth--
+    } else if (ch === LEFT_DOUBLE_QUOTE) {
+      // U+201C is both the American opening double quote and the German closing
+      // double quote. A balanced closer (depth > 0) maps to RDQ; an orphan
+      // (depth 0) maps to a straight quote so convertDoubleQuotes re-derives it
+      // by position. Without the orphan branch, re-processing German output like
+      // "word“" turns the lone closer back into an opener („) and breaks
+      // idempotency.
+      if (doubleDepth > 0) {
+        chars.push(RIGHT_DOUBLE_QUOTE)
+        doubleDepth--
+      } else {
+        chars.push('"')
+      }
     } else if (ch === SLQ) {
       chars.push(LEFT_SINGLE_QUOTE)
       singleDepth++
-    } else if (ch === LEFT_SINGLE_QUOTE && singleDepth > 0) {
-      chars.push(RIGHT_SINGLE_QUOTE)
-      singleDepth--
+    } else if (ch === LEFT_SINGLE_QUOTE) {
+      // Mirror of the U+201C case: U+2018 is both the American opening single
+      // quote and the German closing single quote.
+      if (singleDepth > 0) {
+        chars.push(RIGHT_SINGLE_QUOTE)
+        singleDepth--
+      } else {
+        chars.push("'")
+      }
     } else if (ch === RIGHT_DOUBLE_QUOTE) {
       // RDQ is not used in German typography — normalize to straight quote
       // so the pipeline can re-classify it (e.g., from a previous American pass)

--- a/src/tests/dashes.test.ts
+++ b/src/tests/dashes.test.ts
@@ -357,6 +357,7 @@ describe("enDashNumberRange preserves", () => {
     "978-3-16-148410-0", "0-13-468599-1", // ISBNs
     "2024-01-15", "2024-01", "1999-12", // ISO dates
     "192-168-1-1", "12-34-5678", // IPs
+    `5${UNICODE_SYMBOLS.MULTIPLICATION}10-20`, `2${UNICODE_SYMBOLS.MULTIPLICATION}5-10`, // after ×: a multiplication operand, not a range
   ])('"%s"', (input) => {
     expect(enDashNumberRange(input)).toBe(input)
   })

--- a/src/tests/dashes.test.ts
+++ b/src/tests/dashes.test.ts
@@ -357,7 +357,8 @@ describe("enDashNumberRange preserves", () => {
     "978-3-16-148410-0", "0-13-468599-1", // ISBNs
     "2024-01-15", "2024-01", "1999-12", // ISO dates
     "192-168-1-1", "12-34-5678", // IPs
-    `5${UNICODE_SYMBOLS.MULTIPLICATION}10-20`, `2${UNICODE_SYMBOLS.MULTIPLICATION}5-10`, // after ×: a multiplication operand, not a range
+    `5${UNICODE_SYMBOLS.MULTIPLICATION}10-20`, `2${UNICODE_SYMBOLS.MULTIPLICATION}5-10`, // × (from "x") before a range start: a multiplication operand, not a range
+    `${UNICODE_SYMBOLS.PLUS_MINUS}1-5`, // ± (from "+/-") before a range start: not a range
   ])('"%s"', (input) => {
     expect(enDashNumberRange(input)).toBe(input)
   })

--- a/src/tests/index.test.ts
+++ b/src/tests/index.test.ts
@@ -454,6 +454,10 @@ describe("transform", () => {
       'Product(tm) 5x5 at 72 F (c) 2024',
       "Add 1/2 cup - that's about 3/4 done",
       '1st place winner said "congrats!!"',
+      // multiplication rewrites x→×; the trailing range must not en-dash on a
+      // second pass (regression: this threw "Transform is not idempotent").
+      "the 5x10-20 pack",
+      "buy 3x5-10 cards",
     ])('is idempotent: "%s"', (input) => {
       const first = transform(input, { fractions: true, degrees: true, superscript: true, ligatures: true })
       const second = transform(first, { fractions: true, degrees: true, superscript: true, ligatures: true })

--- a/src/tests/index.test.ts
+++ b/src/tests/index.test.ts
@@ -454,10 +454,12 @@ describe("transform", () => {
       'Product(tm) 5x5 at 72 F (c) 2024',
       "Add 1/2 cup - that's about 3/4 done",
       '1st place winner said "congrats!!"',
-      // multiplication rewrites x→×; the trailing range must not en-dash on a
-      // second pass (regression: this threw "Transform is not idempotent").
+      // The symbol pass rewrites x→× and +/-→±; a range start preceded by the
+      // resulting symbol must not en-dash on a second pass (regression: these
+      // threw "Transform is not idempotent").
       "the 5x10-20 pack",
       "buy 3x5-10 cards",
+      "give or take +/-1-5 units",
     ])('is idempotent: "%s"', (input) => {
       const first = transform(input, { fractions: true, degrees: true, superscript: true, ligatures: true })
       const second = transform(first, { fractions: true, degrees: true, superscript: true, ligatures: true })

--- a/src/tests/quotes.test.ts
+++ b/src/tests/quotes.test.ts
@@ -675,6 +675,11 @@ describe("niceQuotes", () => {
       [`${LEFT_GUILLEMET}${NNBSP}Bonjour${NNBSP}${RIGHT_GUILLEMET}`, { punctuationStyle: "french" as const }],
       // German apostrophe idempotency — RSQ must not flip to LSQ on re-processing
       [`${RIGHT_SINGLE_QUOTE}Twas the night`, { punctuationStyle: "german" as const }],
+      // German orphan closers — U+201C and U+2018 double as American openers, so a
+      // lone German closing quote must not be re-read as an opener on the next pass.
+      [`word${LEFT_DOUBLE_QUOTE}`, { punctuationStyle: "german" as const }],
+      [`x${LEFT_SINGLE_QUOTE}`, { punctuationStyle: "german" as const }],
+      [LEFT_DOUBLE_QUOTE, { punctuationStyle: "german" as const }],
     ])("locale output is idempotent: %s", (input, options) => {
       expect(niceQuotes(input, options)).toBe(input)
     })


### PR DESCRIPTION
## Summary

`punctilio` advertises idempotency (`transform(transform(x)) === transform(x)`) and **throws by default** (`checkIdempotency: true`) when it's violated. Fuzzing that invariant surfaced two cases where realistic input crashes, plus some self-referential typography bugs in the README. This PR fixes the realistic crashes and the docs.

## Bugs fixed

### 1. Ranges next to a symbol-pass operator threw (default config)
`transform("the 5x10-20 pack")` and `transform("give or take +/-1-5 units")` threw `Transform is not idempotent`.

`enDashNumberRange` runs before the symbol pass and rejects a range start preceded by a Latin letter (`x`) or `+`/`-`. The symbol pass then rewrites `x`→`×` and `+/-`→`±` — characters the lookbehind *didn't* reject — so the verification pass en-dashed a tail the first pass had left alone (`5x10-20` → `5×10-20` → `5×10–20`).

Fix: add `×` (U+00D7) and `±` (U+00B1) to the range-start lookbehind. `LATIN_LETTERS` deliberately skips U+00D7 (the class is `…À-ÖØ-ö…`), so these were genuinely uncovered. `×`/`±` only ever sit before a range start as a multiplication/plus-minus operand, never a legitimate range, so no real ranges stop converting.

### 2. Orphan German quotes threw
`transform('word"', { punctuationStyle: "german" })` threw.

U+201C and U+2018 are *both* American opening quotes and German closing quotes. A lone German closer (e.g. when re-processing German output `word“`) was kept as-is by `normalizeGermanQuotes` and then flipped back into an opener (`„`) by `applyGermanQuotes`, breaking idempotency.

Fix: normalize a depth-0 (orphan) `“`/`‘` to a straight quote so the pipeline re-derives it by position. Balanced closers (depth > 0) are unchanged, and American-curly → German conversion (`“Hello”` → `„Hello“`, nested singles included) is unaffected.

### 3. README typography errors (ironic for a typography library)
- `<span class=”no-formatting”>` used curly quotes (U+201D) as the HTML attribute delimiter, breaking that cell.
- German examples showed `„Hallo”` / `‚single'` with the wrong closers, contradicting their own adjacent `U+201E/U+201C` and `U+201A/U+2018` annotations. punctilio actually emits `„Hallo“` / `‚single‘`.

## Testing
- Full suite green: **1848 tests**, **100% coverage** retained, ESLint + `recheck` ReDoS analysis clean.
- New regression cases: `5×10-20`/`2×5-10`/`±1-5` stay un-ranged (`enDashNumberRange`); `the 5x10-20 pack`, `buy 3x5-10 cards`, `give or take +/-1-5 units` are idempotent end-to-end; orphan German closers `word“`, `x‘`, bare `“` round-trip stably.
- A 400k-input idempotency fuzz confirms every realistic case is fixed.

## Deliberately scoped out (follow-up PR)
A few non-idempotency edge cases remain on adversarial, non-prose input and need broader (riskier) changes than this PR's contained fixes:
- **Trailing-side symbol guard** (`1-55x5` → `1-55×5` → `1–55×5`): the mirror of fix 1 on the range *end*. A trailing `(?!…×)` lookahead works but `recheck` flags it as ReDoS-prone, so it needs a different formulation.
- **Ellipsis inserts a legitimate space before a range** (`...1-5` → `… 1-5` → `… 1–5`): the space is a valid range prefix; this needs pipeline-ordering work, not a lookbehind tweak.
- **Apostrophe→comma placement** (`',` → `’,` → `,’`): an MLA apostrophe escapes the punctuation move on pass 1, then re-classifies as a closing quote on pass 2.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ct8kzZNpY4fSYKfWMiMwkf)_