### PR TITLE
Reduce Dependabot churn by capping open PRs to 0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,19 +1,15 @@
 version: 2
 updates:
+  # Disable version-update churn by capping open PRs at 0.
+  # Security updates ignore this limit and are still raised.
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 10
-    groups:
-      dev-dependencies:
-        dependency-type: "development"
-        update-types:
-          - "minor"
-          - "patch"
+    open-pull-requests-limit: 0
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 0


### PR DESCRIPTION
Simplifies Dependabot configuration to reduce version-update churn by setting `open-pull-requests-limit` to 0 for both npm and github-actions ecosystems.

**Changes:**
- Set npm `open-pull-requests-limit` from 10 to 0
- Set github-actions `open-pull-requests-limit` from 5 to 0
- Removed npm dependency grouping configuration (dev-dependencies group)
- Added clarifying comments explaining that security updates bypass this limit

**Rationale:**
This prevents accumulation of multiple version-update PRs while still allowing security updates to be raised immediately. The previous grouping of dev-dependencies is no longer needed with the stricter limit.

https://claude.ai/code/session_014ty5WHaFCbP44RvjSFz77S