### PR TITLE
fix: close remaining idempotency gaps (ellipsis, fractions, ranges, German quotes)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,7 +52,10 @@
 
 ### Fixed
 - Idempotency for ranges preceded by a symbol-pass operator: `transform("5x10-20")` and `transform("+/-1-5")` no longer throw. The symbol pass rewrites the range-blocking `x` to `×` and `+/-` to `±`, which are now also excluded from number-range detection.
-- Idempotency for orphan German quotes: `transform('word"', { punctuationStyle: "german" })` no longer throws. A lone German closing quote (U+201C/U+2018, which double as American openers) is no longer re-read as an opener on re-processing.
+- Idempotency for ranges followed by a symbol-pass operator: `transform("1-55x5")` and `transform("5--1st", { superscript: true })` no longer throw. The multiplication (`x` → `×`) and superscript (`st`/`nd`/`rd`/`th` → superscripts) passes turn a range-blocking trailing word character into a non-word one; the range detector now rejects those trailing forms too.
+- Idempotency for ellipses before number ranges: `transform("wait...1-5 minutes")` no longer throws. Ellipses are now folded before range detection, so the post-ellipsis space is present on the first pass.
+- Idempotency for fractions before legal symbols: `transform("1/2(tm)", { fractions: true })` no longer throws. Fractions run before `legalSymbols`, so the converted `½` no longer leaves a `/` that the path-context heuristic mistook for a URL.
+- Idempotency for orphan German quotes: `transform('word"', { punctuationStyle: "german" })` no longer throws. German normalization now collapses every German/curly quote to a straight quote and lets the pipeline re-classify by position, which also fixes lone closers adjacent to other quotes.
 
 ## [3.13.0] - 2026-06-06
 

--- a/src/dashes.ts
+++ b/src/dashes.ts
@@ -11,7 +11,14 @@ export interface DashOptions {
   dashStyle?: DashStyle
 }
 
-const { EN_DASH, EM_DASH, MINUS, MULTIPLICATION, PLUS_MINUS, LEFT_DOUBLE_QUOTE, RIGHT_DOUBLE_QUOTE, LEFT_SINGLE_QUOTE, RIGHT_SINGLE_QUOTE } = UNICODE_SYMBOLS
+const { EN_DASH, EM_DASH, MINUS, MULTIPLICATION, PLUS_MINUS, SUPERSCRIPT_ST, SUPERSCRIPT_ND, SUPERSCRIPT_RD, SUPERSCRIPT_TH, LEFT_DOUBLE_QUOTE, RIGHT_DOUBLE_QUOTE, LEFT_SINGLE_QUOTE, RIGHT_SINGLE_QUOTE } = UNICODE_SYMBOLS
+
+// Characters a later pass produces from a trailing *word* character: the symbol
+// pass turns "x" into "×", and the superscript pass turns the ordinal letters
+// "st"/"nd"/"rd"/"th" into superscripts. Before conversion those word chars block
+// a range via the trailing word boundary ("1-55x5", "5--1st"); rejecting their
+// non-word replacements keeps a second pass from en-dashing the same range.
+const SYMBOL_PASS_TRAILING = `${MULTIPLICATION}${SUPERSCRIPT_ST}${SUPERSCRIPT_ND}${SUPERSCRIPT_RD}${SUPERSCRIPT_TH}`
 
 // Prevents false-positive ranges in model names like "Llama-2-7B".
 export const numberRangeDisallowedPrefixes = ["-", EN_DASH, EM_DASH, MINUS] as const
@@ -70,6 +77,14 @@ export function enDashNumberRange(text: string, options: DashOptions = {}): stri
         suffix?: string
       }>(args)
       if (groups.following) return args[0] as string
+      // A range whose end abuts a symbol-pass replacement (× or a superscript
+      // ordinal) is an operand, not a range (e.g. "1-55×5", "5--1ˢᵗ"). This
+      // mirrors `notAfterDash` on the trailing side; done in the callback rather
+      // than as a regex lookahead to keep the composed pattern ReDoS-safe.
+      const matchEnd = (args.at(-3) as number) + (args[0] as string).length
+      if (cachedRegExp(`^${chr}?[${SYMBOL_PASS_TRAILING}]`, "").test((args.at(-2) as string).slice(matchEnd))) {
+        return args[0] as string
+      }
       const startNum = groups.start.replace(cachedRegExp(chr, "g"), "")
       const endNum = groups.end.replace(cachedRegExp(chr, "g"), "")
       if (/^(?:19|20)\d{2}$/.test(startNum) && /^(?:0[1-9]|1[0-2])$/.test(endNum)) return args[0] as string

--- a/src/index.ts
+++ b/src/index.ts
@@ -151,7 +151,7 @@ export interface TransformOptions {
 
 import { niceQuotes } from "./quotes.js"
 import { hyphenReplace } from "./dashes.js"
-import { collapseSpaces as collapseSpacesTransform, degrees as degreesTransform, fractions as fractionsTransform, punctuationLigatures as ligaturesTransform, primeMarks, superscriptOrdinal as superscriptTransform, symbolTransform } from "./symbols.js"
+import { collapseSpaces as collapseSpacesTransform, degrees as degreesTransform, ellipsis as ellipsisTransform, fractions as fractionsTransform, punctuationLigatures as ligaturesTransform, primeMarks, superscriptOrdinal as superscriptTransform, symbolTransform } from "./symbols.js"
 import { nbspTransform as nbspTransformFn } from "./nbsp.js"
 import { assertKnownOptionKeys, assertSeparatorCountPreserved, filterUndefined, formatErrorString } from "./utils.js"
 import { DEFAULT_SEPARATOR, ISSUES_URL, UNICODE_SYMBOLS } from "./constants.js"
@@ -242,18 +242,31 @@ export function transform(text: string, options: TransformOptions = {}): string 
     text = collapseSpacesTransform(text)
   }
 
+  // Fold ellipses before range detection so that "...1-5" gains its post-ellipsis
+  // space ("… 1-5") before enDashNumberRange runs. Otherwise the first pass sees a
+  // range blocked by the leading dot and the second pass sees it preceded by a
+  // space and en-dashes it, breaking idempotency. ellipsis is idempotent, so the
+  // later symbolTransform call repeats it harmlessly.
+  if (symbols) {
+    text = ellipsisTransform(text, pipelineOpts)
+  }
+
   text = hyphenReplace(text, pipelineOpts)
   if (pipelineOpts.punctuationStyle !== "none") {
     text = primeMarks(text, pipelineOpts)
   }
   text = niceQuotes(text, pipelineOpts)
 
-  if (symbols) {
-    text = symbolTransform(text, pipelineOpts)
-  }
-
+  // Fractions run before symbolTransform so that "1/2(tm)" → "½(tm)" before
+  // legalSymbols inspects it. Otherwise the unconverted "/" looks like a path
+  // segment and suppresses the (tm) → ™ conversion on the first pass, while the
+  // second pass (no "/") converts it, breaking idempotency.
   if (fractions) {
     text = fractionsTransform(text, pipelineOpts)
+  }
+
+  if (symbols) {
+    text = symbolTransform(text, pipelineOpts)
   }
 
   if (degrees) {

--- a/src/quotes.ts
+++ b/src/quotes.ts
@@ -311,59 +311,18 @@ function applyPunctuationStyle(text: string, sep: string, style: PunctuationStyl
   return text
 }
 
-// Normalize German quotes back to American for idempotent re-processing.
-// Tracks „..." and ‚...' pairs so ambiguous closers map correctly.
+// Collapse every German/curly quote to its straight equivalent so the main
+// pipeline re-classifies them by position exactly as it would for fresh straight
+// input. German output uses „…" (U+201E…U+201C) and ‚…' (U+201A…U+2018) with
+// apostrophes as U+2019; U+201C/U+2018 each double as American openers, so any
+// depth-based scheme misclassifies orphans or quotes adjacent to other quotes.
+// Position-based re-classification sidesteps that ambiguity and keeps
+// re-processing German output idempotent.
 function normalizeGermanQuotes(text: string): string {
-  const DLQ = UNICODE_SYMBOLS.DOUBLE_LOW_9_QUOTE
-  const SLQ = UNICODE_SYMBOLS.SINGLE_LOW_9_QUOTE
-
-  const chars: string[] = []
-  let doubleDepth = 0
-  let singleDepth = 0
-
-  for (const ch of text) {
-    if (ch === DLQ) {
-      chars.push(LEFT_DOUBLE_QUOTE)
-      doubleDepth++
-    } else if (ch === LEFT_DOUBLE_QUOTE) {
-      // U+201C is both the American opening double quote and the German closing
-      // double quote. A balanced closer (depth > 0) maps to RDQ; an orphan
-      // (depth 0) maps to a straight quote so convertDoubleQuotes re-derives it
-      // by position. Without the orphan branch, re-processing German output like
-      // "word“" turns the lone closer back into an opener („) and breaks
-      // idempotency.
-      if (doubleDepth > 0) {
-        chars.push(RIGHT_DOUBLE_QUOTE)
-        doubleDepth--
-      } else {
-        chars.push('"')
-      }
-    } else if (ch === SLQ) {
-      chars.push(LEFT_SINGLE_QUOTE)
-      singleDepth++
-    } else if (ch === LEFT_SINGLE_QUOTE) {
-      // Mirror of the U+201C case: U+2018 is both the American opening single
-      // quote and the German closing single quote.
-      if (singleDepth > 0) {
-        chars.push(RIGHT_SINGLE_QUOTE)
-        singleDepth--
-      } else {
-        chars.push("'")
-      }
-    } else if (ch === RIGHT_DOUBLE_QUOTE) {
-      // RDQ is not used in German typography — normalize to straight quote
-      // so the pipeline can re-classify it (e.g., from a previous American pass)
-      chars.push('"')
-    } else if (ch === RIGHT_SINGLE_QUOTE) {
-      // RSQ is not used in German typography — normalize to straight quote
-      // so the pipeline can re-classify apostrophes vs closing quotes
-      chars.push("'")
-    } else {
-      chars.push(ch)
-    }
-  }
-
-  return chars.join("")
+  const { DOUBLE_LOW_9_QUOTE, SINGLE_LOW_9_QUOTE } = UNICODE_SYMBOLS
+  return text
+    .replace(cachedRegExp(`[${DOUBLE_LOW_9_QUOTE}${LEFT_DOUBLE_QUOTE}${RIGHT_DOUBLE_QUOTE}]`, "g"), '"')
+    .replace(cachedRegExp(`[${SINGLE_LOW_9_QUOTE}${LEFT_SINGLE_QUOTE}${RIGHT_SINGLE_QUOTE}]`, "g"), "'")
 }
 
 function applyGermanQuotes(text: string): string {

--- a/src/tests/dashes.test.ts
+++ b/src/tests/dashes.test.ts
@@ -358,6 +358,7 @@ describe("enDashNumberRange preserves", () => {
     "2024-01-15", "2024-01", "1999-12", // ISO dates
     "192-168-1-1", "12-34-5678", // IPs
     `5${UNICODE_SYMBOLS.MULTIPLICATION}10-20`, `2${UNICODE_SYMBOLS.MULTIPLICATION}5-10`, // × (from "x") before a range start: a multiplication operand, not a range
+    `1-55${UNICODE_SYMBOLS.MULTIPLICATION}5`, `10-20${UNICODE_SYMBOLS.MULTIPLICATION}3`, // × after a range end: the trailing side
     `${UNICODE_SYMBOLS.PLUS_MINUS}1-5`, // ± (from "+/-") before a range start: not a range
   ])('"%s"', (input) => {
     expect(enDashNumberRange(input)).toBe(input)

--- a/src/tests/index.test.ts
+++ b/src/tests/index.test.ts
@@ -473,6 +473,10 @@ describe("transform", () => {
       "word \t- word",
       "word \t-- word",
       "a \t- b \t- c",
+      "1-55x5",
+      "wait...1-5 minutes",
+      // fractions strip the "/" that legalSymbols' path heuristic keys on
+      "1/2(tm) and 3/4(r)",
     ])('is idempotent: "%s"', (input) => {
       const first = transform(input, { fractions: true, degrees: true, superscript: true, ligatures: true })
       const second = transform(first, { fractions: true, degrees: true, superscript: true, ligatures: true })
@@ -484,6 +488,16 @@ describe("transform", () => {
       // the same result a fully space-padded dash would already produce.
       expect(transform("word \t- word")).toBe(`word${EM_DASH}word`)
       expect(transform("word \t- word", { dashStyle: "british" })).toBe(`word ${EN_DASH} word`)
+    })
+
+    // The superscript pass turns trailing ordinal letters (st/nd/rd/th) into
+    // non-word superscripts, which can flip a range's trailing word boundary.
+    it.each([
+      "5--1st",
+      "items 1-52nd",
+    ])('range abutting a superscript ordinal is idempotent: "%s"', (input) => {
+      const first = transform(input, { superscript: true })
+      expect(transform(first, { superscript: true })).toBe(first)
     })
 
     it.each([


### PR DESCRIPTION
## Summary

Follow-up to #212. I fuzzed the idempotency invariant (`transform(transform(x)) === transform(x)`, which **throws by default**) across every style and option combination and fixed the remaining classes where realistic input crashed. After this PR, ASCII/straight input is idempotent across ~2,000,000 fuzzed cases (all styles × all option combos).

## Root causes fixed

Each is a case where a *later* pipeline stage changes a character an *earlier* stage keyed on, so the second (verification) pass diverges from the first.

| # | Input (threw before) | Mechanism | Fix |
|---|---|---|---|
| 1 | `wait...1-5 minutes` | `ellipsis` inserts a space after `…`, turning a dot-blocked range into a space-preceded one next pass | fold ellipses **before** range detection (ellipsis is idempotent, so `symbolTransform`'s later call is a no-op) |
| 2 | `1/2(tm)` (`fractions:true`) | the unconverted `/` makes `legalSymbols`' path heuristic skip `(tm)`→™; the next pass (no `/`) converts it | run `fractions` **before** `symbolTransform` |
| 3 | `1-55x5`, `5--1st` (`superscript:true`) | multiplication (`x`→`×`) and superscript (`st/nd/rd/th`→superscripts) turn a trailing word char into a non-word one, flipping the range's trailing word boundary | reject ranges whose end abuts a symbol-pass replacement, in the range callback (kept out of the regex to stay ReDoS-safe) |
| 4 | `word"` and quote-adjacent combos (`german`) | U+201C/U+2018 double as American openers *and* German closers, so depth-tracking misclassified orphans/adjacent quotes | collapse every German/curly quote to straight and let the pipeline re-classify by position (also shrinks the function ~55→7 lines) |

## Testing
- Full suite green: **1855 tests**, **100% coverage**, ESLint + `recheck` ReDoS analysis clean.
- New regression cases for each class (range±superscript/× preserved as operands; `wait...1-5 minutes`, `1/2(tm) and 3/4(r)`, orphan German quotes all idempotent end-to-end).
- A 2M-case ASCII-input idempotency fuzz across all styles/options now reports a single residual degenerate case (below).
- A self-critique pass verified the `args.at(-3)`/`at(-2)` callback indices, that no *legitimate* range is rejected, and that the German rewrite produces identical output to fresh straight input on the degenerate `word„hi"` shape.

## Remaining residue (deliberately not chased here)
A long tail of non-idempotency remains **only when feeding raw curly quotes / prime marks in positions punctilio itself never emits** (e.g. `1234”<-` under German: a closing curly quote glued to a digit, which `primeMarks` — running before quote normalization — then primes on the second pass). These are transform-of-malformed-input, not violations of the stability of punctilio's own output, but `checkIdempotency` still throws on them.

Closing that tail cleanly would mean either reordering `primeMarks` after quote normalization (risky — primes and quotes are deeply intertwined) or, more generally, **bounded fixed-point iteration**: re-run the pipeline until it stabilizes (guaranteeing idempotency for every convergent input, with the throw reserved for genuine oscillation). That's an architectural change to the single-pass + throw-tripwire design, so I've left it out pending a maintainer call. Happy to implement it in a follow-up if you'd like.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ct8kzZNpY4fSYKfWMiMwkf)_