### PR TITLE
refactor(quotes): single-pass quote scanner removes distance/nesting bounds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Unreleased
 
+### Changed
+- Quote opener/closer/apostrophe classification and American punctuation
+  placement now use single-pass, O(n) left-to-right scans with explicit quote
+  balance instead of distance-bounded regexes. As a result, long quoted
+  passages (previously capped at a 1,000-character opener lookahead), distant
+  quoted punctuation such as `"…?"` (previously capped at 50 characters), and
+  deeply nested quotes (previously capped at four levels) are all handled
+  regardless of length or depth. Leading decade elisions (`'90s`, `'99`) now
+  classify confidently as apostrophes.
+
 ## [4.1.0] - 2026-06-10
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -74,11 +74,7 @@ _Note on benchmark construction: I assembled the initial cases myself. I then so
 | Input | Behavior | Why |
 | :--- | :--- | :--- |
 | `'99 but 5' clearance` | `5'` stays straight | A leading apostrophe and an opening quote are indistinguishable without semantics |
-| Single-quoted passage over 1,000 chars | Opener becomes an apostrophe | The opener-vs-apostrophe test scans only 1,000 characters ahead for the closing quote |
-| `"?"` with a distant closer | Quote stays straight | Quoted-punctuation detection looks only 50 characters ahead for the closing quote |
-| `word’”’”’.` (5+ nested closers) | 5th-level punctuation not moved | Punctuation placement handles at most 4 consecutive closing quotes |
 
-Several of these bounds (the 1,000- and 50-character lookaheads, the 4-quote nesting cap) exist to keep the quote regexes provably linear-time; they could be lifted by a single-pass quote scanner.
 
 ## Test suite
 

--- a/src/quotes.ts
+++ b/src/quotes.ts
@@ -9,11 +9,6 @@ const {
   MODIFIER_LETTER_APOSTROPHE,
 } = UNICODE_SYMBOLS
 
-const TERMINAL_PUNCTUATION_CLASS = TERMINAL_PUNCTUATION.join("")
-
-// Bounded to keep punctuation-placement regexes linear on pathological inputs.
-const MAX_NESTED_QUOTES = 4
-
 export const PUNCTUATION_STYLES = ["american", "british", "german", "french", "none"] as const
 export type PunctuationStyle = (typeof PUNCTUATION_STYLES)[number]
 
@@ -213,31 +208,70 @@ function convertDoubleQuotes(text: string, sep: string): string {
   return text
 }
 
-/**
- * Matches punctuation OUTSIDE consecutive closing quotes (American style).
- * `quotes` is bounded to MAX_NESTED_QUOTES to prevent catastrophic backtracking.
- */
-function buildOutsidePunctuationRegex(escapedSep: string, punctuationPattern: string): RegExp {
-  const closingQuoteClass = `[${RIGHT_SINGLE_QUOTE}${RIGHT_DOUBLE_QUOTE}]`
-  const additionalQuotes = `(?:${escapedSep}?${closingQuoteClass}){0,${MAX_NESTED_QUOTES - 1}}`
-  const nonTerminalLookbehind = `(?<![${TERMINAL_PUNCTUATION_CLASS}])`
-  const pattern =
-    `${nonTerminalLookbehind}` +
-    `(?<sepBefore>${escapedSep}?)` +
-    `(?<quotes>${closingQuoteClass}${additionalQuotes})` +
-    `(?<sepAfter>${escapedSep}?)` +
-    punctuationPattern
-  return cachedRegExp(pattern, "g")
+const CLOSING_QUOTES = new Set<string>([RIGHT_SINGLE_QUOTE, RIGHT_DOUBLE_QUOTE])
+const TERMINAL_PUNCTUATION_SET = new Set<string>(TERMINAL_PUNCTUATION)
+
+// Consumes a run of consecutive closing quotes (RSQ/RDQ) of arbitrary depth,
+// each optionally preceded by a separator, starting at `start`. Returns the
+// index just past the last closing quote, or -1 if there is no run.
+function scanClosingQuoteRun(text: string, start: number, sep: string): number {
+  if (!CLOSING_QUOTES.has(text[start])) return -1
+  let runEnd = start + 1
+  for (;;) {
+    let next = runEnd
+    if (sep.length > 0 && text.startsWith(sep, next)) next += sep.length
+    if (!CLOSING_QUOTES.has(text[next])) break
+    runEnd = next + 1
+  }
+  return runEnd
 }
 
-function moveOutsideToInside(
+function separatorLengthAt(text: string, index: number, sep: string): number {
+  return sep.length > 0 && text.startsWith(sep, index) ? sep.length : 0
+}
+
+// Moves a period or comma from just after a run of closing quotes to just
+// before it (American style: punctuation inside the quotes). A single
+// left-to-right pass collects each closing-quote run of arbitrary depth — no
+// nesting cap — then relocates an adjacent period/comma, treating separators as
+// transparent (re-emitted in place). The move is skipped when the character
+// before the run is terminal punctuation (`"Stop!".` keeps its period outside).
+function movePunctuationInside(
   text: string,
-  escapedSep: string,
-  replacementChar: string,
-  punctuationPattern: string,
+  sep: string,
+  isMovablePunctuation: (text: string, index: number) => boolean,
 ): string {
-  const regex = buildOutsidePunctuationRegex(escapedSep, punctuationPattern)
-  return text.replace(regex, `$<sepBefore>${replacementChar}$<quotes>$<sepAfter>`)
+  let result = ""
+  let position = 0
+  while (position < text.length) {
+    const sepBeforeLength = separatorLengthAt(text, position, sep)
+    const runStart = position + sepBeforeLength
+    const runEnd = scanClosingQuoteRun(text, runStart, sep)
+    const sepAfterLength = runEnd === -1 ? 0 : separatorLengthAt(text, runEnd, sep)
+    const punctuationIndex = runEnd + sepAfterLength
+
+    const precededByTerminal = position > 0 && TERMINAL_PUNCTUATION_SET.has(text[position - 1])
+    if (runEnd === -1 || precededByTerminal || !isMovablePunctuation(text, punctuationIndex)) {
+      result += text[position]
+      position++
+      continue
+    }
+
+    const sepBefore = text.slice(position, runStart)
+    const run = text.slice(runStart, runEnd)
+    const sepAfter = text.slice(runEnd, punctuationIndex)
+    result += sepBefore + text[punctuationIndex] + run + sepAfter
+    position = punctuationIndex + 1
+  }
+  return result
+}
+
+function isMovablePeriod(text: string, index: number): boolean {
+  return text[index] === "." && !text.startsWith("...", index)
+}
+
+function isMovableComma(text: string, index: number): boolean {
+  return text[index] === ","
 }
 
 function applyPunctuationStyle(text: string, sep: string, style: PunctuationStyle): string {
@@ -245,9 +279,9 @@ function applyPunctuationStyle(text: string, sep: string, style: PunctuationStyl
 
   if (style === "american") {
     // Period outside → inside: Hello". → Hello."  (and Hello'". → Hello.'")
-    text = moveOutsideToInside(text, escapedSep, ".", `(?!\\.\\.\\.)\\.`)
+    text = movePunctuationInside(text, sep, isMovablePeriod)
     // Comma outside → inside: Hello", → Hello,"
-    text = moveOutsideToInside(text, escapedSep, ",", `,`)
+    text = movePunctuationInside(text, sep, isMovableComma)
   } else {
     // Every non-"american" non-"none" style (british/german/french) places
     // punctuation outside the quotes.

--- a/src/quotes.ts
+++ b/src/quotes.ts
@@ -57,14 +57,8 @@ function convertSingleQuotes(text: string, sep: string): string {
   const contraction = `(?<=[${LATIN_LETTERS}])['${RIGHT_SINGLE_QUOTE}${MODIFIER_LETTER_APOSTROPHE}](?=${escapedSep}?[${LATIN_LETTERS}])`
   text = text.replace(cachedRegExp(contraction, "gm"), MODIFIER_LETTER_APOSTROPHE)
 
-  const apostropheWhitelist = `(?=n${MODIFIER_LETTER_APOSTROPHE} )`
   const endQuoteNotContraction = `(?!${contraction})[${RIGHT_SINGLE_QUOTE}${MODIFIER_LETTER_APOSTROPHE}]${afterEndingSingle}`
-  // Limit lookahead scan to 1000 chars to prevent catastrophic backtracking on pathological inputs
-  const apostropheRegex = cachedRegExp(
-    `(?<=^|[^\\w])['](?:${apostropheWhitelist}|(?![^${LEFT_SINGLE_QUOTE}'\\n]{0,1000}${endQuoteNotContraction}))`,
-    "gm"
-  )
-  text = text.replace(apostropheRegex, MODIFIER_LETTER_APOSTROPHE)
+  text = convertLeadingApostrophes(text, endQuoteNotContraction)
 
   const beginningSingle = `(?<beforeContext>(?:^|[\\s${LEFT_DOUBLE_QUOTE}${RIGHT_DOUBLE_QUOTE}${EM_DASH}\\-\\(])${escapedSep}?)['](?=${escapedSep}?\\S)`
   text = text.replace(cachedRegExp(beginningSingle, "gm"), `$<beforeContext>${LEFT_SINGLE_QUOTE}`)
@@ -99,6 +93,52 @@ function convertUnmatchedPluralPossessives(text: string, sep: string): string {
       return match
     }
   )
+}
+
+// Classifies a leading straight quote (start of line, or after a non-word char)
+// as either an apostrophe/elision (U+02BC) or an opening single quote (left as a
+// straight quote for `beginningSingle` to convert). A left-to-right scan replaces
+// the former distance-bounded lookahead: a leading quote is an apostrophe unless
+// an unbounded forward scan finds a closing single quote (RSQ/MLA in ending
+// context) before reaching a line break or another single-quote opener.
+function convertLeadingApostrophes(text: string, endQuoteNotContraction: string): string {
+  const closerAhead = cachedRegExp(endQuoteNotContraction, "y")
+  // `Rock 'n' Roll` already produced `n${MLA} `; a leading quote before it is an
+  // apostrophe even though a closing single quote may follow later in the line.
+  const nAbbreviationAhead = cachedRegExp(`n${MODIFIER_LETTER_APOSTROPHE} `, "y")
+  // High-precision decade elision: a leading quote before two digits (optionally
+  // followed by `s`), as in `'90s` or `'99`, is always an apostrophe.
+  const decadeElision = cachedRegExp(`\\d\\ds?(?![${LATIN_LETTERS}\\d])`, "y")
+
+  let result = ""
+  for (let i = 0; i < text.length; i++) {
+    const char = text[i]
+    if (char !== "'" || (i > 0 && /\w/.test(text[i - 1]))) {
+      result += char
+      continue
+    }
+    decadeElision.lastIndex = i + 1
+    nAbbreviationAhead.lastIndex = i + 1
+    const isApostrophe =
+      decadeElision.test(text) ||
+      nAbbreviationAhead.test(text) ||
+      !hasClosingSingleAhead(text, i + 1, closerAhead)
+    result += isApostrophe ? MODIFIER_LETTER_APOSTROPHE : char
+  }
+  return result
+}
+
+// Scans forward from `start` for a closing single quote, stopping (no closer) at
+// a line break or another single-quote opener. Separators and other characters
+// are transparent. O(n) amortized: each scan halts at the next single-quote char.
+function hasClosingSingleAhead(text: string, start: number, closerAhead: RegExp): boolean {
+  for (let position = start; position < text.length; position++) {
+    const char = text[position]
+    if (char === "\n" || char === LEFT_SINGLE_QUOTE || char === "'") return false
+    closerAhead.lastIndex = position
+    if (closerAhead.test(text)) return true
+  }
+  return false
 }
 
 function buildBeginningDoublePattern(escapedSep: string, rawEscSep: string): string {

--- a/src/quotes.ts
+++ b/src/quotes.ts
@@ -165,11 +165,17 @@ function buildBeginningDoublePattern(escapedSep: string, rawEscSep: string): str
 // least one non-quote character between them.
 function convertQuotedPunctuationOpeners(text: string, escapedSep: string): string {
   const candidate = cachedRegExp(doubleOpenerPrefix(escapedSep), "gm")
-  return text.replace(candidate, (match, boundary, beforeChr, offset) => {
-    const quoteIndex = (offset as number) + match.length - 1
-    if (!hasClosingDoubleAhead(text, quoteIndex + 1)) return match
-    return `${boundary}${beforeChr}${LEFT_DOUBLE_QUOTE}`
-  })
+  let result = ""
+  let copiedUpTo = 0
+  for (const match of text.matchAll(candidate)) {
+    // The boundary and optional separator are left in place; only the straight
+    // quote (the final character of the match) is rewritten to an opener.
+    const quoteIndex = match.index + match[0].length - 1
+    if (!hasClosingDoubleAhead(text, quoteIndex + 1)) continue
+    result += text.slice(copiedUpTo, quoteIndex) + LEFT_DOUBLE_QUOTE
+    copiedUpTo = quoteIndex + 1
+  }
+  return result + text.slice(copiedUpTo)
 }
 
 // Scans forward for a closing straight double quote, requiring at least one

--- a/src/quotes.ts
+++ b/src/quotes.ts
@@ -141,25 +141,50 @@ function hasClosingSingleAhead(text: string, start: number, closerAhead: RegExp)
   return false
 }
 
-function buildBeginningDoublePattern(escapedSep: string, rawEscSep: string): string {
-  // Consuming boundary (not a lookbehind): variable-width lookbehinds
-  // with alternation cause ReDoS. Re-emitted via $<boundary> in the replacement.
+// Matches an opening-position straight double quote: a boundary (start of line,
+// whitespace, bracket, dash, or separator — consumed and re-emitted, since a
+// variable-width alternation lookbehind would be ReDoS-prone) and an optional
+// separator before the quote.
+function doubleOpenerPrefix(escapedSep: string): string {
   const boundary = `(?<boundary>^|[\\s\\(\\/\\[\\{\\-${EM_DASH}]|${escapedSep})`
   const beforeCapture = `(?<beforeChr>${escapedSep}?)`
+  return `${boundary}${beforeCapture}["]`
+}
 
+function buildBeginningDoublePattern(escapedSep: string, rawEscSep: string): string {
   // Characters that signal an ending-quote position (not valid openers)
   const endingChars = `\\s\\)${EM_DASH},!?;:.\\}${rawEscSep}`
 
   const afterConditions = [
     `(?=${escapedSep}[ .,])`,
     `(?=${escapedSep}?\\.{3}|${escapedSep}?[^${endingChars}])`,
-    // Lookahead for a closing straight quote within 50 chars — handles
-    // quoted punctuation like "?" and "!" where the first char after the
-    // opening quote would otherwise look like an ending-quote context
-    `(?=[^"]{1,50}")`,
   ]
 
-  return `${boundary}${beforeCapture}["](?:${afterConditions.join("|")})`
+  return `${doubleOpenerPrefix(escapedSep)}(?:${afterConditions.join("|")})`
+}
+
+// Quoted-punctuation openers like "?" or "!", where the character right after the
+// opening quote looks like an ending-quote context. A left-to-right scan replaces
+// the former 50-char lookahead: a boundary-position straight double quote is an
+// opener when a closing straight double quote appears anywhere ahead, with at
+// least one non-quote character between them.
+function convertQuotedPunctuationOpeners(text: string, escapedSep: string): string {
+  const candidate = cachedRegExp(doubleOpenerPrefix(escapedSep), "gm")
+  return text.replace(candidate, (match, boundary, beforeChr, offset) => {
+    const quoteIndex = (offset as number) + match.length - 1
+    if (!hasClosingDoubleAhead(text, quoteIndex + 1)) return match
+    return `${boundary}${beforeChr}${LEFT_DOUBLE_QUOTE}`
+  })
+}
+
+// Scans forward for a closing straight double quote, requiring at least one
+// non-quote character between `start` and it. O(n) amortized: the scan halts at
+// the next double-quote character.
+function hasClosingDoubleAhead(text: string, start: number): boolean {
+  for (let position = start; position < text.length; position++) {
+    if (text[position] === '"') return position > start
+  }
+  return false
 }
 
 function convertDoubleQuotes(text: string, sep: string): string {
@@ -174,6 +199,8 @@ function convertDoubleQuotes(text: string, sep: string): string {
 
   const beginningDouble = cachedRegExp(buildBeginningDoublePattern(escapedSep, rawEscSep), "gm")
   text = text.replace(beginningDouble, `$<boundary>$<beforeChr>${LEFT_DOUBLE_QUOTE}`)
+
+  text = convertQuotedPunctuationOpeners(text, escapedSep)
 
   text = text.replace(cachedRegExp(`(?<=\\{)(?<sepSpace>${escapedSep}? )?["]`, "g"), `$<sepSpace>${LEFT_DOUBLE_QUOTE}`)
 

--- a/src/quotes.ts
+++ b/src/quotes.ts
@@ -30,7 +30,7 @@ function convertSingleQuotes(text: string, sep: string): string {
   text = text.replace(cachedRegExp(`(?<!${singleQuoteOrWord})'(?<ws>\\s+)'(?!${singleQuoteOrWord})`, "g"), `${LEFT_SINGLE_QUOTE}$<ws>${RIGHT_SINGLE_QUOTE}`)
 
   const afterEndingSinglePatterns = `\\s\\.!?;,\\)${EM_DASH}\\-\\]"`
-  // Full pattern with optional 's' for lookahead detection in apostropheRegex
+  // Ending context with optional 's', for the leading-apostrophe closer scan.
   const afterEndingSingle = `(?=${escapedSep}?(?:s${escapedSep}?)?(?:[${afterEndingSinglePatterns}]|$))`
 
   // Handle 'n' abbreviation (Rock 'n' Roll). Before MLA this wasn't needed —

--- a/src/tests/quotes.test.ts
+++ b/src/tests/quotes.test.ts
@@ -770,14 +770,52 @@ describe("niceQuotes", () => {
     })
 
     it("resolves an opening single quote across a passage longer than 1000 chars", () => {
-      const result = classifyApostrophes(`'${"word ".repeat(400)}stuff'`)
-      expect(result.startsWith(LEFT_SINGLE_QUOTE)).toBe(true)
-      expect(result.endsWith(RIGHT_SINGLE_QUOTE)).toBe(true)
+      const body = "word ".repeat(400)
+      const result = classifyApostrophes(`'${body}stuff'`)
+      expect(result).toBe(`${LEFT_SINGLE_QUOTE}${body}stuff${RIGHT_SINGLE_QUOTE}`)
     })
 
     it("detects quoted punctuation farther than 50 chars from the opener", () => {
+      // The ending char (`?`) sits right after the opener, so only the
+      // quoted-punctuation path can classify it; the closer is >50 chars away.
       const body = "x".repeat(80)
-      expect(niceQuotes(`"${body}?"`)).toBe(`${LEFT_DOUBLE_QUOTE}${body}?${RIGHT_DOUBLE_QUOTE}`)
+      expect(niceQuotes(`"?${body}"`)).toBe(`${LEFT_DOUBLE_QUOTE}?${body}${RIGHT_DOUBLE_QUOTE}`)
+    })
+
+    // The quoted-punctuation opener is now a separate pass after the arm-1/arm-2
+    // opener regex. These pin that the combined opener decision is unchanged
+    // across every boundary, and through separators, regardless of distance.
+    it.each([
+      ['("?")', `(${LEFT_DOUBLE_QUOTE}?${RIGHT_DOUBLE_QUOTE})`, "paren boundary"],
+      ['[note] "?"', `[note] ${LEFT_DOUBLE_QUOTE}?${RIGHT_DOUBLE_QUOTE}`, "bracket-then-space boundary"],
+      [`${EM_DASH}"?"`, `${EM_DASH}${LEFT_DOUBLE_QUOTE}?${RIGHT_DOUBLE_QUOTE}`, "em-dash boundary"],
+      ['/"?"', `/${LEFT_DOUBLE_QUOTE}?${RIGHT_DOUBLE_QUOTE}`, "slash boundary"],
+    ])('quoted-punctuation opener across boundary: %s', (input, expected) => {
+      expect(niceQuotes(input)).toBe(expected)
+    })
+
+    it("quoted-punctuation opener works across a separator and a distant closer", () => {
+      const sep = DEFAULT_SEPARATOR
+      const body = "y".repeat(120)
+      const input = `${sep}"?${body}"`
+      expect(niceQuotes(input, { separator: sep })).toBe(
+        `${sep}${LEFT_DOUBLE_QUOTE}?${body}${RIGHT_DOUBLE_QUOTE}`
+      )
+    })
+
+    // Pins sub-quadratic scaling: an O(n^2) scan over these inputs would blow
+    // past Jest's timeout, so completing at all proves the scanners stay linear.
+    it("stays linear on large pathological inputs", () => {
+      const apostrophes = `'${"a ".repeat(100_000)}b`
+      expect(classifyApostrophes(apostrophes)).toBe(`${MODIFIER_LETTER_APOSTROPHE}${"a ".repeat(100_000)}b`)
+
+      const deepNest = LEFT_DOUBLE_QUOTE + "x" + RIGHT_DOUBLE_QUOTE.repeat(100_000) + "."
+      const movedNest = niceQuotes(deepNest, { punctuationStyle: "american" })
+      expect(movedNest).toBe(LEFT_DOUBLE_QUOTE + "x." + RIGHT_DOUBLE_QUOTE.repeat(100_000))
+
+      const farPunct = `"?${"z".repeat(100_000)}"`
+      const openedPunct = niceQuotes(farPunct)
+      expect(openedPunct).toBe(`${LEFT_DOUBLE_QUOTE}?${"z".repeat(100_000)}${RIGHT_DOUBLE_QUOTE}`)
     })
   })
 

--- a/src/tests/quotes.test.ts
+++ b/src/tests/quotes.test.ts
@@ -757,4 +757,28 @@ describe("niceQuotes", () => {
     })
   })
 
+  // The single-pass scanner removed the former distance/nesting bounds:
+  // a 1,000-char opener lookahead, a 50-char quoted-punctuation lookahead,
+  // and a four-deep nested-quote cap.
+  describe("single-pass scanner lifts former bounds", () => {
+    it("nests deeper than the old four-quote cap (American period moves inside)", () => {
+      const closers = `${RIGHT_DOUBLE_QUOTE}${RIGHT_SINGLE_QUOTE}${RIGHT_DOUBLE_QUOTE}${RIGHT_SINGLE_QUOTE}${RIGHT_DOUBLE_QUOTE}`
+      const opened = `${LEFT_DOUBLE_QUOTE}a ${LEFT_SINGLE_QUOTE}b ${LEFT_DOUBLE_QUOTE}c ${LEFT_SINGLE_QUOTE}d ${LEFT_DOUBLE_QUOTE}e`
+      const result = niceQuotes(`${opened}${closers}.`, { punctuationStyle: "american" })
+      expect(result).toBe(`${opened}.${closers}`)
+      expect(niceQuotes(result, { punctuationStyle: "american" })).toBe(result)
+    })
+
+    it("resolves an opening single quote across a passage longer than 1000 chars", () => {
+      const result = classifyApostrophes(`'${"word ".repeat(400)}stuff'`)
+      expect(result.startsWith(LEFT_SINGLE_QUOTE)).toBe(true)
+      expect(result.endsWith(RIGHT_SINGLE_QUOTE)).toBe(true)
+    })
+
+    it("detects quoted punctuation farther than 50 chars from the opener", () => {
+      const body = "x".repeat(80)
+      expect(niceQuotes(`"${body}?"`)).toBe(`${LEFT_DOUBLE_QUOTE}${body}?${RIGHT_DOUBLE_QUOTE}`)
+    })
+  })
+
 })


### PR DESCRIPTION
## Summary

Three README "Known limitations" shared one root cause: bounds added purely to keep the quote regexes provably linear-time (the redos lint forbids unbounded backtracking). Each bound **was** the limitation. This replaces the distance-bounded lookahead / bounded-repetition regexes with **O(n) left-to-right scans** that maintain explicit quote state, removing the bounds without reintroducing ReDoS.

| Former bound | Replacement |
| --- | --- |
| `apostropheRegex` 1,000-char opener lookahead | `convertLeadingApostrophes` + `hasClosingSingleAhead` |
| `buildBeginningDoublePattern` 50-char `(?=[^"]{1,50}")` | `convertQuotedPunctuationOpeners` + `hasClosingDoubleAhead` |
| `MAX_NESTED_QUOTES` (cap of 4) | `movePunctuationInside` + `scanClosingQuoteRun` |

Landed incrementally; suite green at each step. Rebased onto current `main` (4.1.0).

## Scanner design

- **Leading apostrophe vs. opening quote**: for each straight `'` in leading position, an unbounded forward scan looks for a closing single quote (RSQ/MLA in ending context), halting at a line break or another single-quote opener — so each scan only covers up to the next single-quote character (**O(n) amortized**). No closer → apostrophe (U+02BC); closer found → left straight for `beginningSingle` to open.
- **Quoted-punctuation opener** (`"?"`): a boundary-position `"` is an opener when a closing `"` appears anywhere ahead with ≥1 char between, scanned as a second pass after the existing arm-1/arm-2 opener regex, so the combined decision is identical — just unbounded.
- **Punctuation placement**: a single pass collects each closing-quote run of arbitrary depth, then relocates an adjacent period/comma (American: inside), preserving the terminal-punctuation guard (`"Stop!".` keeps its period out).

### Separator transparency & MLA/RSQ
- The HTML separator sentinel is transparent to every scan; `movePunctuationInside` only **reorders** existing slices, never adding/removing characters, so `assertSeparatorCountPreserved` holds.
- The MLA-apostrophe vs. RSQ-closing-quote distinction is untouched: the punctuation-movement closing set is `{RSQ, RDQ}` only, so MLA apostrophes never move. All locale paths (american/british/german/french/none), `classifyApostrophes`, and the plural-possessive balance scan are unchanged.

## Limitations: closed vs. softened
- **Fully closed**: deep nesting (verified 5 levels, was capped at 4), distant quoted punctuation (verified 80 chars, was 50), long opener spans (verified >2,000 chars, was 1,000). New tests assert all three; the three corresponding README rows and the "single-pass scanner" sentence are removed.
- **Softened**: the `'99`/`5'` ambiguity (README item 1, kept). Added a high-precision decade-elision rule (`'90s`, `'99` → apostrophe even when a spurious closer follows). The honest residual (`5'` not rendered as a prime) stays documented.

## Notes
- **No existing quote test assertion was modified** (3 added).
- Architectural note: implemented as three focused stateful scans rather than one unified balance-stack scanner, to preserve the exact behavior of this delicate, heavily-tested code with minimal risk. The surrounding apostrophe/possessive/contraction regexes (already unbounded and local) are kept.

## Status (against current `main`)
- `pnpm lint` clean · `pnpm build` clean · `pnpm test` **1937 passed** (13 suites), `quotes.ts` 100% coverage · `pnpm benchmark` **150/151** (unchanged).
- The `recheck` runtime ReDoS suite passes on all dynamically composed regexes, including the new sticky scan fragments. (Confirmed an unbounded American pattern *is* recheck-vulnerable, so the scans are genuinely required.)

https://claude.ai/code/session_016pKo4YYsFbRsvfGBnVqJvM