### PR TITLE
Add summary jobs to enforce required status checks

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -27,3 +27,13 @@ jobs:
             echo "$UNPINNED"
             exit 1
           fi
+
+  all-checks-passed:
+    name: All checks passed
+    needs: [lint]
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
+      - name: Fail if lint did not succeed
+        if: needs.lint.result != 'success'
+        run: exit 1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,3 +41,13 @@ jobs:
 
       - name: Run benchmark
         run: pnpm build && node benchmark.mjs --min-passes 150
+
+  all-checks-passed:
+    name: All checks passed
+    needs: [test, benchmark]
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
+      - name: Fail if any job did not succeed
+        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+        run: exit 1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,6 +31,10 @@
 
 - Only include a "Lessons learned" section when the lessons generalize to other repositories using this template. Project-specific takeaways belong in commit messages or inline comments, not in the PR body.
 
+### GitHub Actions
+
+- Every workflow whose jobs you may want to mark as Required status checks must include an `if: always()` summary job that `needs:` all those jobs and exits non-zero on failure or cancellation. Without it, a skipped or cancelled job never reports a status and permanently blocks a protected branch.
+
 ### Testing
 
 - Parametrize tests for maximum compactness while achieving high coverage


### PR DESCRIPTION
GitHub Actions workflows can have jobs skipped or cancelled without reporting a status, which permanently blocks protected branches even when all intended checks pass. This PR adds an `all-checks-passed` summary job to both the lint and test workflows that explicitly fails if any required job doesn't succeed.

**Changes:**
- Added `all-checks-passed` job to `.github/workflows/lint.yml` that depends on the lint job and fails if it doesn't succeed
- Added `all-checks-passed` job to `.github/workflows/test.yml` that depends on test and benchmark jobs and fails if any are cancelled or failed
- Updated `CLAUDE.md` to document this pattern as a project convention

Both summary jobs use `if: always()` to run regardless of upstream job status, then explicitly check results and exit non-zero on failure or cancellation. This ensures the workflow always reports a definitive status that can be marked as a required check on protected branches.

https://claude.ai/code/session_014JYePFcVCBtERSyXNhQ6W2