### PR TITLE
feat(view): add ProseView boundary-aware edit layer and legacy pass adapter

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -27,6 +27,14 @@ export {
   REFERENCE_ABBREVIATIONS,
   UNITS,
 } from "./nbsp.js"
+export {
+  buildProseView,
+  type ProseNode,
+  type ProseView,
+  replaceAllInView,
+  type ReplaceAllOptions,
+  runLegacyPass,
+} from "./prose-view.js"
 export { classifyApostrophes, niceQuotes, PUNCTUATION_STYLES, type PunctuationStyle, type QuoteOptions } from "./quotes.js"
 
 export interface TransformOptions {

--- a/src/prose-view.ts
+++ b/src/prose-view.ts
@@ -1,0 +1,281 @@
+import { DEFAULT_SEPARATOR } from "./constants.js"
+import { transformTextNodes } from "./utils.js"
+
+export interface ProseNode {
+  value: string
+}
+
+export interface ProseView {
+  /** Concatenation of the nodes' values. No markers, ever. */
+  readonly text: string
+  /** Offsets in `text` where one source node ends and the next begins (interior boundaries only; length = nodes.length - 1; may contain duplicates when nodes are empty). */
+  readonly boundaries: readonly number[]
+  /** True iff a node edge falls at exactly this offset. O(log n) binary search. */
+  hasBoundary(offset: number): boolean
+  /** Queue an edit replacing [start, end) with `text`. Edits must not overlap; enforced at commit. */
+  replace(start: number, end: number, text: string, opts?: { bind?: "left" | "right" }): void
+  /** Apply queued edits back onto the source nodes (mutating their `value`s), then recompute `text`/`boundaries`. The view supports arbitrarily many queue/commit cycles. */
+  commit(): void
+}
+
+interface QueuedEdit {
+  start: number
+  end: number
+  text: string
+  bind: "left" | "right"
+}
+
+/** True iff the offset falls between a high surrogate and its low surrogate. */
+function splitsSurrogatePair(text: string, offset: number): boolean {
+  if (offset <= 0 || offset >= text.length) return false
+  const high = text.charCodeAt(offset - 1)
+  const low = text.charCodeAt(offset)
+  return high >= 0xd800 && high <= 0xdbff && low >= 0xdc00 && low <= 0xdfff
+}
+
+class ProseViewImpl implements ProseView {
+  private readonly nodes: ProseNode[]
+  private cachedText: string
+  private cachedBoundaries: number[]
+  private edits: QueuedEdit[] = []
+
+  constructor(nodes: ProseNode[]) {
+    this.nodes = nodes
+    this.cachedText = ""
+    this.cachedBoundaries = []
+    this.refresh()
+  }
+
+  get text(): string {
+    return this.cachedText
+  }
+
+  get boundaries(): readonly number[] {
+    return this.cachedBoundaries
+  }
+
+  /** Recompute `text` and `boundaries` from the current node values. @internal */
+  refresh(): void {
+    let text = ""
+    const boundaries: number[] = []
+    this.nodes.forEach((node, index) => {
+      text += node.value
+      if (index < this.nodes.length - 1) {
+        boundaries.push(text.length)
+      }
+    })
+    this.cachedText = text
+    this.cachedBoundaries = boundaries
+  }
+
+  /** @internal */
+  hasQueuedEdits(): boolean {
+    return this.edits.length > 0
+  }
+
+  /** @internal */
+  getNodes(): ProseNode[] {
+    return this.nodes
+  }
+
+  hasBoundary(offset: number): boolean {
+    const boundaries = this.cachedBoundaries
+    let low = 0
+    let high = boundaries.length - 1
+    while (low <= high) {
+      const mid = (low + high) >>> 1
+      const value = boundaries[mid]
+      if (value === offset) return true
+      if (value < offset) {
+        low = mid + 1
+      } else {
+        high = mid - 1
+      }
+    }
+    return false
+  }
+
+  replace(start: number, end: number, text: string, opts?: { bind?: "left" | "right" }): void {
+    if (!Number.isInteger(start) || !Number.isInteger(end)) {
+      throw new Error(`replace() offsets must be integers, got start=${start}, end=${end}.`)
+    }
+    if (start < 0 || start > end || end > this.cachedText.length) {
+      throw new Error(
+        `replace() requires 0 <= start <= end <= text.length (${this.cachedText.length}), ` +
+        `got start=${start}, end=${end}.`
+      )
+    }
+    if (splitsSurrogatePair(this.cachedText, start)) {
+      throw new Error(`replace() start=${start} splits a UTF-16 surrogate pair.`)
+    }
+    if (splitsSurrogatePair(this.cachedText, end)) {
+      throw new Error(`replace() end=${end} splits a UTF-16 surrogate pair.`)
+    }
+    this.edits.push({ start, end, text, bind: opts?.bind ?? "left" })
+  }
+
+  /**
+   * Apply queued edits to the source nodes. Edits are ordered by start offset,
+   * tie-breaking shorter spans first so a zero-length edit sorts before a
+   * spanning edit at the same start. A pure insertion may therefore coexist
+   * with a replacement starting at the same offset: the insertion's text lands
+   * before the replaced span's text. Overlapping spans (and two pure
+   * insertions at the same offset) are rejected.
+   */
+  commit(): void {
+    if (this.edits.length === 0) {
+      return
+    }
+
+    const sorted = [...this.edits].sort(
+      (a, b) => a.start - b.start || (a.end - a.start) - (b.end - b.start)
+    )
+    for (let i = 1; i < sorted.length; i++) {
+      const prev = sorted[i - 1]
+      const curr = sorted[i]
+      if (prev.end > curr.start) {
+        throw new Error(
+          `Overlapping edits: [${prev.start}, ${prev.end}) and [${curr.start}, ${curr.end}).`
+        )
+      }
+      if (prev.end === curr.start && prev.start === prev.end && curr.start === curr.end) {
+        throw new Error(
+          `Two pure insertions at the same offset ${curr.start} are ambiguous; combine them.`
+        )
+      }
+    }
+
+    // Node spans in `text` via cumulative lengths.
+    const starts: number[] = []
+    const ends: number[] = []
+    let cursor = 0
+    for (const node of this.nodes) {
+      starts.push(cursor)
+      cursor += node.value.length
+      ends.push(cursor)
+    }
+
+    // Apply right-to-left so earlier offsets stay valid as we mutate.
+    for (let i = sorted.length - 1; i >= 0; i--) {
+      this.applyEdit(sorted[i], starts, ends)
+    }
+
+    this.edits = []
+    this.refresh()
+  }
+
+  /** Index of the node whose span contains the character at `offset`. */
+  private nodeContainingChar(offset: number, starts: number[], ends: number[]): number {
+    for (let i = 0; i < this.nodes.length; i++) {
+      if (offset >= starts[i] && offset < ends[i]) return i
+    }
+    /* istanbul ignore next -- defensive: callers only pass offsets that fall within a node span */
+    return this.nodes.length - 1
+  }
+
+  private targetNodeForInsertion(edit: QueuedEdit, starts: number[], ends: number[]): number {
+    if (edit.bind === "left") {
+      if (edit.start === 0) return 0
+      return this.nodeContainingChar(edit.start - 1, starts, ends)
+    }
+    if (edit.start === this.cachedText.length) return this.nodes.length - 1
+    return this.nodeContainingChar(edit.start, starts, ends)
+  }
+
+  private applyEdit(edit: QueuedEdit, starts: number[], ends: number[]): void {
+    const { start, end, text } = edit
+
+    // Decide where replacement/insertion text lands before mutating values.
+    const targetIndex = end > start
+      ? this.nodeContainingChar(start, starts, ends)
+      : this.targetNodeForInsertion(edit, starts, ends)
+    const insertOffsetInTarget = start - starts[targetIndex]
+
+    // Delete the intersection of [start, end) from every covered node.
+    for (let i = 0; i < this.nodes.length; i++) {
+      const delStart = Math.max(start, starts[i])
+      const delEnd = Math.min(end, ends[i])
+      if (delStart >= delEnd) continue
+      const node = this.nodes[i]
+      const localStart = delStart - starts[i]
+      const localEnd = delEnd - starts[i]
+      node.value = node.value.slice(0, localStart) + node.value.slice(localEnd)
+    }
+
+    // Insert replacement text into the target node. For replacements the
+    // deletion above removed [start, end) from the target, so `start` is the
+    // correct insertion point inside the (now shortened) target value.
+    if (text.length > 0) {
+      const target = this.nodes[targetIndex]
+      target.value = target.value.slice(0, insertOffsetInTarget) + text + target.value.slice(insertOffsetInTarget)
+    }
+  }
+}
+
+export function buildProseView(nodes: ProseNode[]): ProseView {
+  return new ProseViewImpl(nodes)
+}
+
+export interface ReplaceAllOptions {
+  /** Opt-in: allow a match that contains an interior node boundary. Default: such matches are skipped. */
+  allowBoundaries?: (match: RegExpExecArray, view: ProseView) => boolean
+  /** For pure-insertion edits produced by the replacer (rare), bind side. */
+  bind?: "left" | "right"
+}
+
+/** True iff some interior boundary falls strictly inside the match span. */
+function matchContainsBoundary(match: RegExpExecArray, view: ProseView): boolean {
+  const matchStart = match.index
+  const matchEnd = match.index + match[0].length
+  for (const boundary of view.boundaries) {
+    if (boundary > matchStart && boundary < matchEnd) return true
+  }
+  return false
+}
+
+export function replaceAllInView(
+  view: ProseView,
+  regex: RegExp,
+  replacer: (match: RegExpExecArray, view: ProseView) => string | null,
+  options?: ReplaceAllOptions,
+): void {
+  if (!regex.global) {
+    throw new Error("replaceAllInView() requires a regex with the global (g) flag.")
+  }
+
+  const allowBoundaries = options?.allowBoundaries
+  const bind = options?.bind
+  const text = view.text
+  regex.lastIndex = 0
+
+  let match: RegExpExecArray | null
+  while ((match = regex.exec(text)) !== null) {
+    if (match[0].length === 0) {
+      regex.lastIndex += 1
+    }
+
+    if (matchContainsBoundary(match, view) && !allowBoundaries?.(match, view)) {
+      continue
+    }
+
+    const replacement = replacer(match, view)
+    if (replacement === null) {
+      continue
+    }
+
+    view.replace(match.index, match.index + match[0].length, replacement, bind ? { bind } : undefined)
+  }
+}
+
+export function runLegacyPass(
+  view: ProseView,
+  passFn: (markedText: string) => string,
+  separator: string = DEFAULT_SEPARATOR,
+): void {
+  const impl = view as ProseViewImpl
+  if (impl.hasQueuedEdits()) {
+    throw new Error("runLegacyPass() cannot run while the view has uncommitted queued edits.")
+  }
+  transformTextNodes(impl.getNodes(), passFn, separator)
+  impl.refresh()
+}

--- a/src/rehype.ts
+++ b/src/rehype.ts
@@ -5,7 +5,8 @@ import { SKIP, visitParents } from "unist-util-visit-parents"
 
 import { transform, TRANSFORM_OPTION_KEYS, type TransformOptions } from "./index.js"
 import { DEFAULT_SEPARATOR, MAX_RECURSION_DEPTH } from "./constants.js"
-import { assertKnownOptionKeys, formatErrorString, transformTextNodes } from "./utils.js"
+import { assertKnownOptionKeys, formatErrorString } from "./utils.js"
+import { buildProseView, runLegacyPass } from "./prose-view.js"
 
 type ElementPredicate = (node: Element) => boolean
 
@@ -213,7 +214,8 @@ export function transformElement(
     ? textNodes.map((n) => n.value + separator).join("")
     : ""
 
-  transformTextNodes(textNodes, transformFn, separator)
+  const view = buildProseView(textNodes)
+  runLegacyPass(view, transformFn, separator)
 
   if (checkInvariance) {
     const transformedContent = textNodes.map((n) => n.value + separator).join("")

--- a/src/tests/prose-view.test.ts
+++ b/src/tests/prose-view.test.ts
@@ -1,0 +1,367 @@
+import {
+  buildProseView,
+  type ProseNode,
+  type ProseView,
+  replaceAllInView,
+  runLegacyPass,
+} from "../prose-view.js"
+import { DEFAULT_SEPARATOR } from "../constants.js"
+
+function nodes(...values: string[]): ProseNode[] {
+  return values.map((value) => ({ value }))
+}
+
+describe("buildProseView: text and boundaries", () => {
+  it.each([
+    ["multi-node", ["abc", "de", "f"], "abcdef", [3, 5]],
+    ["single node", ["hello"], "hello", []],
+    ["empty array", [], "", []],
+    ["empty middle node gives duplicate boundary", ["ab", "", "cd"], "abcd", [2, 2]],
+    ["leading empty node", ["", "xy"], "xy", [0]],
+    ["trailing empty node", ["xy", ""], "xy", [2]],
+  ])("%s", (_desc, values, text, boundaries) => {
+    const view = buildProseView(nodes(...values))
+    expect(view.text).toBe(text)
+    expect(view.boundaries).toEqual(boundaries)
+  })
+})
+
+describe("hasBoundary", () => {
+  const view = buildProseView(nodes("abc", "de", "f"))
+  it.each([
+    [0, false],
+    [3, true],
+    [5, true],
+    [4, false],
+    [6, false],
+  ])("offset %i -> %s", (offset, expected) => {
+    expect(view.hasBoundary(offset)).toBe(expected)
+  })
+
+  it("single-node view has no boundaries", () => {
+    const single = buildProseView(nodes("hello"))
+    expect(single.hasBoundary(0)).toBe(false)
+    expect(single.hasBoundary(5)).toBe(false)
+  })
+})
+
+/** Independently compute the expected text after applying non-overlapping edits. */
+function applyEdits(
+  text: string,
+  edits: { start: number; end: number; text: string }[],
+): string {
+  const sorted = [...edits].sort((a, b) => a.start - b.start)
+  let result = ""
+  let cursor = 0
+  for (const edit of sorted) {
+    result += text.slice(cursor, edit.start) + edit.text
+    cursor = edit.end
+  }
+  return result + text.slice(cursor)
+}
+
+describe("replace + commit", () => {
+  it("single-node edit", () => {
+    const ns = nodes("hello")
+    const view = buildProseView(ns)
+    view.replace(1, 4, "XYZ")
+    view.commit()
+    expect(ns.map((n) => n.value)).toEqual(["hXYZo"])
+    expect(view.text).toBe("hXYZo")
+  })
+
+  it("deletion spanning a boundary shrinks both covered nodes, count preserved", () => {
+    const ns = nodes("abc", "def")
+    const view = buildProseView(ns)
+    view.replace(2, 4, "")
+    view.commit()
+    expect(ns.map((n) => n.value)).toEqual(["ab", "ef"])
+    expect(ns.length).toBe(2)
+  })
+
+  it("replacement spanning boundary lands text in node containing start", () => {
+    const ns = nodes("abc", "def")
+    const view = buildProseView(ns)
+    view.replace(2, 4, "XY")
+    view.commit()
+    expect(ns.map((n) => n.value)).toEqual(["abXY", "ef"])
+    expect(view.text).toBe("abXYef")
+  })
+
+  it("deletion that fully empties a covered node keeps node count", () => {
+    const ns = nodes("ab", "cd", "ef")
+    const view = buildProseView(ns)
+    view.replace(1, 5, "")
+    view.commit()
+    expect(ns.map((n) => n.value)).toEqual(["a", "", "f"])
+    expect(ns.length).toBe(3)
+  })
+
+  it.each([
+    ["bind left (default)", undefined, ["abcZ", "def"]],
+    ["bind right", "right" as const, ["abc", "Zdef"]],
+  ])("pure insertion at boundary: %s", (_desc, bind, expected) => {
+    const ns = nodes("abc", "def")
+    const view = buildProseView(ns)
+    view.replace(3, 3, "Z", bind ? { bind } : undefined)
+    view.commit()
+    expect(ns.map((n) => n.value)).toEqual(expected)
+  })
+
+  it.each([
+    ["insertion at 0, bind left -> first node", 0, "left" as const, ["Zabc", "def"]],
+    ["insertion at 0, bind right -> first node", 0, "right" as const, ["Zabc", "def"]],
+    ["insertion at length, bind left -> last node", 6, "left" as const, ["abc", "defZ"]],
+    ["insertion at length, bind right -> last node", 6, "right" as const, ["abc", "defZ"]],
+  ])("%s", (_desc, offset, bind, expected) => {
+    const ns = nodes("abc", "def")
+    const view = buildProseView(ns)
+    view.replace(offset, offset, "Z", { bind })
+    view.commit()
+    expect(ns.map((n) => n.value)).toEqual(expected)
+  })
+
+  it("multiple non-adjacent edits in one commit, queue order != position order", () => {
+    const ns = nodes("abcdef", "ghijkl")
+    const view = buildProseView(ns)
+    // Queue out of position order.
+    view.replace(8, 10, "Y")
+    view.replace(1, 3, "X")
+    view.commit()
+    const expected = applyEdits("abcdefghijkl", [
+      { start: 8, end: 10, text: "Y" },
+      { start: 1, end: 3, text: "X" },
+    ])
+    expect(ns.map((n) => n.value).join("")).toBe(expected)
+  })
+
+  it("empty-string replacement is a pure deletion", () => {
+    const ns = nodes("hello")
+    const view = buildProseView(ns)
+    view.replace(0, 2, "")
+    view.commit()
+    expect(ns.map((n) => n.value)).toEqual(["llo"])
+  })
+
+  it("commit with no edits is a no-op", () => {
+    const ns = nodes("abc", "def")
+    const view = buildProseView(ns)
+    view.commit()
+    expect(ns.map((n) => n.value)).toEqual(["abc", "def"])
+    expect(view.text).toBe("abcdef")
+  })
+
+  it("repeated queue/commit cycles", () => {
+    const ns = nodes("abc", "def")
+    const view = buildProseView(ns)
+    view.replace(0, 1, "X")
+    view.commit()
+    expect(view.text).toBe("Xbcdef")
+    view.replace(view.text.length, view.text.length, "!")
+    view.commit()
+    expect(view.text).toBe("Xbcdef!")
+    expect(ns.map((n) => n.value)).toEqual(["Xbc", "def!"])
+  })
+
+  it("invariant: committed concatenation == old text with edits applied", () => {
+    const ns = nodes("The quick ", "brown fox ", "jumps")
+    const view = buildProseView(ns)
+    const oldText = view.text
+    const edits = [
+      { start: 0, end: 3, text: "A" },
+      { start: 16, end: 21, text: "" },
+      { start: 25, end: 25, text: "!" },
+    ]
+    for (const e of edits) view.replace(e.start, e.end, e.text)
+    view.commit()
+    expect(ns.map((n) => n.value).join("")).toBe(applyEdits(oldText, edits))
+  })
+})
+
+describe("replace assertions", () => {
+  let view: ProseView
+  beforeEach(() => {
+    view = buildProseView(nodes("abc", "def"))
+  })
+
+  it.each([
+    ["negative start", -1, 2],
+    ["start > end", 4, 2],
+    ["end > length", 0, 7],
+  ])("throws on out-of-range: %s", (_desc, start, end) => {
+    expect(() => view.replace(start, end, "x")).toThrow(/0 <= start <= end/)
+  })
+
+  it.each([
+    ["non-integer start", 1.5, 2],
+    ["non-integer end", 1, 2.5],
+  ])("throws on %s", (_desc, start, end) => {
+    expect(() => view.replace(start, end, "x")).toThrow(/must be integers/)
+  })
+
+  it.each([
+    ["start splits surrogate pair", 1, 3],
+    ["end splits surrogate pair", 0, 1],
+  ])("throws when %s", (_desc, start, end) => {
+    // "\u{1F600}" (emoji) occupies offsets 0-1 as a surrogate pair.
+    const emojiView = buildProseView(nodes("\u{1F600}xx"))
+    expect(() => emojiView.replace(start, end, "y")).toThrow(/surrogate pair/)
+  })
+
+  it("rejects overlapping edits at commit", () => {
+    view.replace(0, 3, "X")
+    view.replace(2, 4, "Y")
+    expect(() => view.commit()).toThrow(/Overlapping edits/)
+  })
+
+  it("rejects two pure insertions at the same offset", () => {
+    view.replace(2, 2, "X")
+    view.replace(2, 2, "Y")
+    expect(() => view.commit()).toThrow(/ambiguous/)
+  })
+
+  it("allows an insertion adjacent to a replacement end", () => {
+    const ns = nodes("abcdef")
+    const v = buildProseView(ns)
+    v.replace(0, 2, "X")
+    v.replace(2, 2, "Y")
+    v.commit()
+    expect(ns[0].value).toBe("XYcdef")
+  })
+
+  it.each([
+    ["insertion queued first", "insertion-first" as const],
+    ["replacement queued first", "replacement-first" as const],
+  ])(
+    "coexisting insertion and replacement at the same start: %s (order-independent, insertion before span)",
+    (_desc, order) => {
+      const ns = nodes("abcdef")
+      const v = buildProseView(ns)
+      if (order === "insertion-first") {
+        v.replace(2, 2, "I")
+        v.replace(2, 5, "R")
+      } else {
+        v.replace(2, 5, "R")
+        v.replace(2, 2, "I")
+      }
+      v.commit()
+      expect(ns[0].value).toBe("abIRf")
+    }
+  )
+})
+
+describe("replaceAllInView", () => {
+  it("throws when regex lacks global flag", () => {
+    const view = buildProseView(nodes("aaa"))
+    expect(() => replaceAllInView(view, /a/, () => "b")).toThrow(/global/)
+  })
+
+  it("replaces all matches and commits via caller", () => {
+    const ns = nodes("a-a-a")
+    const view = buildProseView(ns)
+    replaceAllInView(view, /a/g, () => "X")
+    view.commit()
+    expect(view.text).toBe("X-X-X")
+  })
+
+  it("does not commit on its own", () => {
+    const ns = nodes("aaa")
+    const view = buildProseView(ns)
+    replaceAllInView(view, /a/g, () => "X")
+    // Edits queued but not applied.
+    expect(view.text).toBe("aaa")
+    expect(ns[0].value).toBe("aaa")
+  })
+
+  it("skips matches containing an interior boundary by default", () => {
+    const ns = nodes("foo", "bar")
+    const view = buildProseView(ns)
+    replaceAllInView(view, /oob/g, () => "ZZZ")
+    view.commit()
+    expect(view.text).toBe("foobar")
+  })
+
+  it("allowBoundaries opt-in lets a boundary-spanning match through and receives it", () => {
+    const ns = nodes("foo", "bar")
+    const view = buildProseView(ns)
+    const seen: string[] = []
+    replaceAllInView(
+      view,
+      /oob/g,
+      (m) => {
+        seen.push(m[0])
+        return "ZZZ"
+      },
+      { allowBoundaries: () => true },
+    )
+    view.commit()
+    expect(seen).toEqual(["oob"])
+    expect(view.text).toBe("fZZZar")
+  })
+
+  it("replacer returning null leaves the match untouched", () => {
+    const ns = nodes("a1b2")
+    const view = buildProseView(ns)
+    replaceAllInView(view, /\d/g, (m) => (m[0] === "1" ? null : "X"))
+    view.commit()
+    expect(view.text).toBe("a1bX")
+  })
+
+  it("terminates on zero-length matches", () => {
+    const ns = nodes("abc")
+    const view = buildProseView(ns)
+    const positions: number[] = []
+    replaceAllInView(view, /(?=[\s\S])/g, (m) => {
+      positions.push(m.index)
+      return null
+    })
+    // One zero-length lookahead match before each character; terminates.
+    expect(positions).toEqual([0, 1, 2])
+  })
+
+  it("passes bind option through for pure-insertion edits", () => {
+    const ns = nodes("ab", "cd")
+    const view = buildProseView(ns)
+    // Match the empty string right at the boundary only.
+    replaceAllInView(view, /(?<=b)(?=c)/g, () => "Z", { bind: "right" })
+    view.commit()
+    expect(ns.map((n) => n.value)).toEqual(["ab", "Zcd"])
+  })
+})
+
+describe("runLegacyPass", () => {
+  it("round-trips a marked transform across nodes", () => {
+    const ns = nodes("hello ", "world")
+    const view = buildProseView(ns)
+    runLegacyPass(view, (marked) => marked.toUpperCase())
+    expect(ns.map((n) => n.value)).toEqual(["HELLO ", "WORLD"])
+    expect(view.text).toBe("HELLO WORLD")
+  })
+
+  it("uses a custom separator", () => {
+    const ns = nodes("a", "b")
+    const view = buildProseView(ns)
+    runLegacyPass(view, (marked) => marked.replace(/a/, "X"), "|")
+    expect(ns.map((n) => n.value)).toEqual(["X", "b"])
+  })
+
+  it("throws when the separator is present in input", () => {
+    const ns = nodes(`has${DEFAULT_SEPARATOR}sep`)
+    const view = buildProseView(ns)
+    expect(() => runLegacyPass(view, (m) => m)).toThrow(/separator sequence/)
+  })
+
+  it("throws when the pass changes the fragment count", () => {
+    const ns = nodes("a", "b")
+    const view = buildProseView(ns)
+    expect(() =>
+      runLegacyPass(view, (marked) => marked.replaceAll(DEFAULT_SEPARATOR, "")),
+    ).toThrow(/altered the number of text nodes/)
+  })
+
+  it("throws when the view has uncommitted queued edits", () => {
+    const view = buildProseView(nodes("a", "b"))
+    view.replace(0, 1, "X")
+    expect(() => runLegacyPass(view, (m) => m)).toThrow(/uncommitted/)
+  })
+})


### PR DESCRIPTION
Stage 2 of the v5 architecture rollout (tracking PR: #219), stacked on #220. Introduces the structural replacement for the U+E000 U+E001 sentinel system: element boundaries become metadata on a text view instead of in-band characters.

## Contents
- `src/prose-view.ts` — `buildProseView(nodes)`: a view over HAST-like text nodes exposing their concatenated `text` plus interior `boundaries`, with an offset-based edit queue (`replace`/`commit`) that writes back onto the source nodes. Node count is always preserved (nodes can become empty), making the v4 "transformation altered the number of text nodes" failure mode unrepresentable. Deterministic edit ordering: equal-start ties sort pure insertions before spanning edits, so acceptance never depends on queue order. Surrogate-pair splits rejected at `replace()` time.
- `replaceAllInView(view, regex, replacer, opts)` — regex passes over clean text; matches containing an interior boundary are skipped unless the pass opts in via `allowBoundaries` (boundary tolerance becomes a per-position decision instead of ~70 hand-woven `escapedSep?` pattern sites).
- `runLegacyPass(view, passFn, separator)` — adapter that renders the view to a sentinel-marked string, runs a v4 pass, and splits the result back. The sentinel becomes an internal encoding detail of the adapter rather than API. Deleted once the last pass migrates off it.
- `transformElement` in `src/rehype.ts` rewired onto view + adapter; contract and behavior unchanged (golden corpus byte-identical).

## Reviewer note: where's the consumer?
By design, this stage is behavior-identical and the new edit API has no production consumer yet — the next PR in the stack (quote/prime role classifier) is the first consumer of `hasBoundary`/`replace`/`commit`, and the residual dash/nbsp/symbol passes follow via `replaceAllInView`. Landing the layer separately keeps each stage reviewable against an empty golden diff.

## Verification
Full Jest suite (15 suites, 2176 tests, 100% coverage), `pnpm lint`, `node benchmark.mjs --min-passes 150` all green.

https://claude.ai/code/session_01JurYodPWZhfCQ2FoJ2Ek22

---
_Generated by [Claude Code](https://claude.ai/code/session_01JurYodPWZhfCQ2FoJ2Ek22)_