### PR TITLE
refactor(dashes): run dash passes over ProseView instead of sentinel weaves

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -140,22 +140,12 @@ export const REGEX_SPECIAL_CHARS = [".", "*", "+", "?", "^", "$", "[", "]", "\\"
 const MAX_BOUNDARY_SEPARATORS = 3
 
 /**
- * Marker-aware word boundary pattern for the START of a match.
- *
- * Standard `\b` can create false boundaries when separator markers appear
- * between word characters (e.g., `x\uE000ReLU` has a false `\b` before `R`).
- * This pattern uses a negative lookbehind to reject matches preceded by a
- * word character followed by up to `MAX_BOUNDARY_SEPARATORS` markers.
- */
-export function wordBoundaryStart(escapedSeparator: string): string {
-  return `(?<!\\w${escapedSeparator}{0,${MAX_BOUNDARY_SEPARATORS}})\\b`
-}
-
-/**
  * Marker-aware word boundary pattern for the END of a match.
  *
- * Mirror of `wordBoundaryStart` \u2014 rejects matches followed by up to
- * `MAX_BOUNDARY_SEPARATORS` markers and then a word character.
+ * Standard `\b` can create false boundaries when separator markers appear
+ * between word characters (e.g., `ReLU\uE000x` has a false `\b` after `U`).
+ * This pattern rejects matches followed by up to `MAX_BOUNDARY_SEPARATORS`
+ * markers and then a word character.
  */
 export function wordBoundaryEnd(escapedSeparator: string): string {
   return `\\b(?!${escapedSeparator}{0,${MAX_BOUNDARY_SEPARATORS}}\\w)`

--- a/src/dashes.ts
+++ b/src/dashes.ts
@@ -14,13 +14,6 @@ export interface DashOptions {
 
 const { EN_DASH, EM_DASH, MINUS, MULTIPLICATION, PLUS_MINUS, SUPERSCRIPT_ST, SUPERSCRIPT_ND, SUPERSCRIPT_RD, SUPERSCRIPT_TH, LEFT_DOUBLE_QUOTE, RIGHT_DOUBLE_QUOTE, LEFT_SINGLE_QUOTE, RIGHT_SINGLE_QUOTE } = UNICODE_SYMBOLS
 
-// Characters a later pass produces from a trailing *word* character: the symbol
-// pass turns "x" into "×", and the superscript pass turns the ordinal letters
-// "st"/"nd"/"rd"/"th" into superscripts. Before conversion those word chars block
-// a range via the trailing word boundary ("1-55x5", "5--1st"); rejecting their
-// non-word replacements keeps a second pass from en-dashing the same range.
-const SYMBOL_PASS_TRAILING = `${MULTIPLICATION}${SUPERSCRIPT_ST}${SUPERSCRIPT_ND}${SUPERSCRIPT_RD}${SUPERSCRIPT_TH}`
-
 // Prevents false-positive ranges in model names like "Llama-2-7B".
 export const numberRangeDisallowedPrefixes = ["-", EN_DASH, EM_DASH, MINUS] as const
 

--- a/src/dashes.ts
+++ b/src/dashes.ts
@@ -1,11 +1,12 @@
-import { cachedRegExp, DEFAULT_SEPARATOR, getEscapedSeparator, LATIN_LETTERS, UNICODE_SYMBOLS, wordBoundaryEnd, wordBoundaryStart } from "./constants.js"
+import { cachedRegExp, DEFAULT_SEPARATOR, LATIN_LETTERS, UNICODE_SYMBOLS } from "./constants.js"
+import { boundaryCountAt, type ProseView, replaceAllInView, type ReplaceAllOptions, withProseView } from "./prose-view.js"
 import { namedGroups } from "./utils.js"
 
 export const DASH_STYLES = ["american", "british", "none"] as const
 export type DashStyle = (typeof DASH_STYLES)[number]
 
 export interface DashOptions {
-  /** Boundary marker for HTML element boundaries. Default: "\uE000\uE001" */
+  /** Boundary marker for HTML element boundaries. Default: "" */
   separator?: string
   /** "american" (unspaced em), "british" (spaced en), "none". Default: "american" */
   dashStyle?: DashStyle
@@ -31,232 +32,1053 @@ const months: readonly string[] = [
 
 const monthPattern = months.join("|")
 
+const WORD_CHAR_RE = /\w/
+const LATIN_LETTER_RE = new RegExp(`[${LATIN_LETTERS}]`)
+
+/**
+ * Runs one boundary-gated regex pass over the view and commits it immediately.
+ * v4 chained `text.replace` calls, each operating on the previous pass's full
+ * output; committing after every pass reproduces that sequencing so a later
+ * pass sees the earlier edits and never queues an overlapping edit.
+ */
+function pass(
+  view: ProseView,
+  regex: RegExp,
+  replacer: (match: RegExpExecArray, view: ProseView) => string | null,
+  options?: ReplaceAllOptions,
+): void {
+  replaceAllInView(view, regex, replacer, options)
+  view.commit()
+}
+
+// ---------------------------------------------------------------------------
+// Boundary-tolerance helpers over a ProseView
+//
+// v4 wove `${escapedSep}?` into patterns to tolerate the sentinel at specific
+// positions. Over a clean ProseView, `replaceAllInView` skips any match with an
+// interior boundary unless `allowBoundaries` opts in. Each pass below builds an
+// `allowBoundaries` callback that admits a match only when every interior
+// boundary sits at a position where the v4 pattern carried a separator weave.
+// ---------------------------------------------------------------------------
+
+/** Interior boundary offsets of a match, strictly inside (matchStart, matchEnd). */
+function interiorBoundaryOffsets(match: RegExpExecArray, view: ProseView): number[] {
+  const start = match.index
+  const end = match.index + match[0].length
+  const offsets: number[] = []
+  for (const boundary of view.boundaries) {
+    if (boundary > start && boundary < end) offsets.push(boundary)
+    else if (boundary >= end) break
+  }
+  return offsets
+}
+
+/**
+ * True iff every interior boundary of the match lands on a tolerated offset,
+ * with no offset carrying more boundaries than its budget. A v4 `${chr}?` slot
+ * tolerates exactly one boundary; two stacked boundaries (an empty fragment)
+ * exceed the single-separator budget and block the match, as in v4.
+ */
+function interiorBoundariesAllowed(
+  match: RegExpExecArray,
+  view: ProseView,
+  tolerated: Map<number, number>,
+): boolean {
+  const counts = new Map<number, number>()
+  for (const offset of interiorBoundaryOffsets(match, view)) {
+    counts.set(offset, (counts.get(offset) ?? 0) + 1)
+  }
+  for (const [offset, count] of counts) {
+    const budget = tolerated.get(offset)
+    if (budget === undefined || count > budget) return false
+  }
+  return true
+}
+
+/** Separators tolerated by the word-boundary helpers (mirrors constants.ts). */
+const MAX_BOUNDARY_SEPARATORS = 3
+
+/**
+ * Reproduces `wordBoundaryStart` = `(?<!\w${sep}{0,3})\b` at the marked position
+ * `matchStart` (the start char is a word char — a digit). The `\b` requires a
+ * non-word char to its left (a separator counts as non-word); the negative
+ * lookbehind additionally blocks when a word char sits within
+ * {@link MAX_BOUNDARY_SEPARATORS} stacked boundaries to the left.
+ */
+function wordBoundaryStartOk(view: ProseView, matchStart: number): boolean {
+  if (matchStart === 0) return true
+  const nb = boundaryCountAt(view, matchStart)
+  const prev = view.text[matchStart - 1]
+  const prevWord = prev !== undefined && WORD_CHAR_RE.test(prev)
+  if (nb === 0) return !prevWord // `\b` needs a non-word char immediately left
+  // A separator sits left (non-word) so `\b` holds; the lookbehind blocks only
+  // when a word char is within ≤MAX boundaries.
+  return !prevWord || nb > MAX_BOUNDARY_SEPARATORS
+}
+
+/**
+ * Reproduces `wordBoundaryEnd` = `\b(?!${sep}{0,3}\w)` at the marked position
+ * `pos`. The `\b` requires a word/non-word transition (a separator counts as
+ * non-word); the negative lookahead blocks when a word char sits within
+ * {@link MAX_BOUNDARY_SEPARATORS} stacked boundaries to the right.
+ */
+function wordBoundaryEndOk(view: ProseView, pos: number): boolean {
+  const text = view.text
+  // `wordBoundaryEndOk` is only ever called at the end of a digit run, so `pos`
+  // is always ≥ 1 and `text[pos - 1]` is a real char.
+  const prevChar = text[pos - 1] as string
+  const leftWord = WORD_CHAR_RE.test(prevChar)
+  const nb = boundaryCountAt(view, pos)
+  const nextClean = text[pos]
+  const nextCleanWord = nextClean !== undefined && WORD_CHAR_RE.test(nextClean)
+  // The marked char right after pos is a separator when nb > 0 (non-word).
+  const rightWord = nb > 0 ? false : nextCleanWord
+  if (leftWord === rightWord) return false // no `\b`
+  // `(?!${sep}{0,3}\w)`: a word char within ≤3 boundaries to the right blocks.
+  return !(nb <= MAX_BOUNDARY_SEPARATORS && nextCleanWord)
+}
+
+// ---------------------------------------------------------------------------
+// Number ranges
+// ---------------------------------------------------------------------------
+
+const CURRENCY_RE = /[$€£¥₹]/
+
 /** Convert number ranges to en-dash (e.g., "1-5" → "1–5"). */
 export function enDashNumberRange(text: string, options: DashOptions = {}): string {
-  const chr = getEscapedSeparator(options)
-  const wb = wordBoundaryStart(chr)
-  const wbe = wordBoundaryEnd(chr)
-
-  // Common currency symbols for price ranges
-  const currencies = "$€£¥₹"
-
-  // Build positive range pattern from readable components
-  const phoneAreaCode = `(?<precedingAreaCode>\\d{3}-|\\(\\d{3}\\) ?)?`  // 555- or (555)
-  // Lookbehind prevents matching after dashes, so Llama-2-7B and +44-20 don't en-dash.
-  // `${MULTIPLICATION}${PLUS_MINUS}` keep ranges stable across the symbol pass, which
-  // runs after this one: a range start preceded by `x` (a Latin letter) or `+`/`-` is
-  // already rejected here, and the symbol pass rewrites "5x10" → "5×10" and "+/-1" →
-  // "±1". Rejecting `×` and `±` too means a second pass over those outputs doesn't
-  // suddenly en-dash a tail the first pass left alone (e.g. "5x10-20" → "5×10-20").
-  const notAfterDash = `(?<![${DISALLOWED_PREFIX_CLASS_FRAGMENT}${LATIN_LETTERS}${MULTIPLICATION}${PLUS_MINUS}.+])`
-  const rangeStart = `(?<start>(?:p\\.?|[${currencies}])?\\d[\\d.,]*${chr}?)`  // p.10, $100, 1,000
-  const rangeEnd = `(?<end>${chr}?[${currencies}]?\\d[\\d.,]*)`          // 20, $200, 2,000
-  const moreSegments = `(?<following>(?:${chr}?[-${MINUS}]${chr}?\\d+)*)` // -4567 in phone numbers
-  const unitSuffix = `(?<suffix>${chr}?(?:[AaPp][Mm]|[xKBTM]))?`         // am/pm, K/M/B
-
-  // Positive ranges: 1-5, 5--10, $100-$200, €5-€10, p.10-15
-  const positiveRangePattern = [
-    phoneAreaCode, wb, notAfterDash, rangeStart, "-{1,3}", rangeEnd, moreSegments, unitSuffix, wbe
-  ].join("")
-
-  text = text.replace(
-    cachedRegExp(positiveRangePattern, "g"),
-    (...args) => {
-      const groups = namedGroups<{
-        precedingAreaCode?: string
-        start: string
-        end: string
-        following?: string
-        suffix?: string
-      }>(args)
-      if (groups.following) return args[0] as string
-      const startNum = groups.start.replace(cachedRegExp(chr, "g"), "")
-      const endNum = groups.end.replace(cachedRegExp(chr, "g"), "")
-      if (/^(?:19|20)\d{2}$/.test(startNum) && /^(?:0[1-9]|1[0-2])$/.test(endNum)) return args[0] as string
-      // Skip 3+4 digit phone-shaped patterns (555-1234, or the second half of
-      // 555-123-4567). Thousands-grouped endings (1,234 / 1.234) keep their
-      // internal separator and so fail /^\d{4}$/, falling through to convert
-      // as ranges. Space/NNBSP/thin-space grouping isn't captured by the outer
-      // range regex, so those variants currently aren't affected here.
-      if (/^\d{3}$/.test(startNum) && /^\d{4}$/.test(endNum)) return args[0] as string
-      // Skip US toll-free prefix pattern: 1-800, 1-888, 1-877, etc. Only the
-      // seven real toll-free codes (800, 888, 877, 866, 855, 844, 833) are
-      // blocked, so genuine ranges like 1-850 or 1-810 still en-dash.
-      if (/^1$/.test(startNum) && /^8(?:00|88|77|66|55|44|33)$/.test(endNum)) return args[0] as string
-      return `${groups.precedingAreaCode ?? ""}${groups.start}${EN_DASH}${groups.end}${groups.suffix ?? ""}`
-    }
-  )
-
-  // Negative ranges: −5-5 → −5–5, −5--2 → −5–−2
-  // Separate regex because MINUS isn't a word char, so \b in ${wb} would match after it
-  text = text.replace(
-    cachedRegExp(
-      `(?<![${LATIN_LETTERS}])(?<start>${MINUS}\\d[\\d.,]*${chr}?)-{1,3}?(?<neg>-)?(?<end>${chr}?\\d[\\d.,]*)(?<following>(?:${chr}?-${chr}?\\d+)*)(?<suffix>${chr}?[xKBTM])?${wbe}`,
-      "g"
-    ),
-    (...args) => {
-      const groups = namedGroups<{
-        start: string
-        neg?: string
-        end: string
-        following?: string
-        suffix?: string
-      }>(args)
-      if (groups.following) return args[0] as string
-      return `${groups.start}${EN_DASH}${groups.neg ? MINUS : ""}${groups.end}${groups.suffix ?? ""}`
-    }
-  )
-
-  return text
+  const separator = options.separator ?? DEFAULT_SEPARATOR
+  return withProseView(text, separator, (view) => {
+    convertPositiveRanges(view)
+    convertNegativeRanges(view)
+  })
 }
+
+/**
+ * v4's positive-range regex was `phoneAreaCode? \b (?:p\.?|[currency])?\d[\d.,]*
+ * -{1,3} [currency]?\d[\d.,]* (?:${chr}?[-−]${chr}?\d+)* (?:[AaPp][Mm]|[xKBTM])?
+ * \b`, scanned with the `g` flag. The lookbehinds (`notAfterDash`) and the
+ * separator weaves cannot survive over clean text, and — critically — the
+ * `g`-flag consume/advance behaviour determines which sub-ranges a later pass
+ * sees. The scan below reproduces it: at each offset it attempts the structural
+ * match (boundary-aware), consuming its span on success (whether or not the
+ * dash converts) and advancing one character otherwise. So a multi-segment
+ * number whose head fails to form a structural match (e.g. boundary-broken
+ * "2024-01-15") still exposes a later sub-range ("01-15"), while a structurally
+ * matching but non-converting number hides its inner dashes.
+ */
+function convertPositiveRanges(view: ProseView): void {
+  const text = view.text
+  let i = 0
+  while (i < text.length) {
+    const span = matchPositiveRangeAt(view, i)
+    i = span === null ? i + 1 : Math.max(span, i + 1)
+  }
+  view.commit()
+}
+
+/**
+ * Attempts v4's `phoneAreaCode? \b rangeStart -{1,3} rangeEnd following* suffix?
+ * \b` structural match beginning at clean offset `i`, converting the dash when
+ * v4's gates pass. Returns the consumed end offset on a structural match (so the
+ * scan skips it), or null when no structural match begins at `i`.
+ */
+function matchPositiveRangeAt(view: ProseView, i: number): number | null {
+  // Optional phoneAreaCode (`\d{3}-` or `(\d{3}) `); when it ends in a dash that
+  // dash can instead be the range dash, so both interpretations are tried. v4's
+  // `rangeStart` carries no leading separator slot, so a boundary right where it
+  // would begin (just past the area code) invalidates the area-code reading: v4
+  // falls back to treating the area-code digits as the range start.
+  const areaCode = readPhoneAreaCode(view, i)
+  const startStarts = areaCode === null || view.hasBoundary(i + areaCode) ? [i] : [i + areaCode, i]
+  for (const startStart of startStarts) {
+    const span = matchRangeBody(view, startStart)
+    if (span !== null) return span
+  }
+  return null
+}
+
+const THREE_DIGITS_RE = /^\d\d\d/
+const THREE_DIGITS_IN_PARENS_RE = /^\(\d\d\d\)/
+
+/** v4's `phoneAreaCode` = `\d{3}-|\(\d{3}\) ?` at `i`; returns its length or null. */
+function readPhoneAreaCode(view: ProseView, i: number): number | null {
+  const text = view.text
+  // `\d{3}-` with no separator woven into the digits or before the dash.
+  if (THREE_DIGITS_RE.test(text.slice(i, i + 3)) && text[i + 3] === "-"
+    && !view.hasBoundary(i + 1) && !view.hasBoundary(i + 2) && !view.hasBoundary(i + 3)) {
+    return 4
+  }
+  // `(\d{3})` with an optional trailing space.
+  if (THREE_DIGITS_IN_PARENS_RE.test(text.slice(i, i + 5))) {
+    return text[i + 5] === " " ? 6 : 5
+  }
+  return null
+}
+
+/**
+ * Matches `\b rangeStart -{1,3} rangeEnd following* suffix? \b` boundary-aware,
+ * beginning the start at `startStart`. Converts the dash on a v4-converting
+ * match. Returns the consumed end offset (structural span end) or null.
+ */
+function matchRangeBody(view: ProseView, startStart: number): number | null {
+  const text = view.text
+  // rangeStart = `(?:p\.?|[currency])?\d[\d.,]*`, anchored at a `\b`.
+  const start = readStartRun(view, startStart)
+  if (start === null) return null
+  const startSpanEnd = startStart + start.length
+  // One `${chr}?` between start and the dash tolerates a single boundary there.
+  if (boundaryCountAt(view, startSpanEnd) > 1) return null
+  // Dash run of 1..3 hyphens that never spans an interior boundary (a boundary
+  // between two hyphens truncates the run, as in v4's `-{1,3}`).
+  if (text[startSpanEnd] !== "-") return null
+  let dashEnd = startSpanEnd + 1
+  while (text[dashEnd] === "-" && dashEnd - startSpanEnd < 3 && !view.hasBoundary(dashEnd)) dashEnd++
+  if (boundaryCountAt(view, dashEnd) > 1) return null
+
+  // `readStartRun` already stops at the first interior boundary, so the start
+  // span is boundary-free and its clean digits are the whole run.
+  const startDigits = text.slice(startStart, startSpanEnd)
+  if (!wordBoundaryStartOk(view, startStart)) return null
+  if (!notAfterDashOk(view, startStart)) return null
+
+  const end = readEndRun(view, dashEnd)
+  if (end === null) return null
+  // v4's greedy end `[\d.,]*` and greedy `following*` backtrack together; the
+  // structural match commits at the longest end whose tail completes.
+  for (let len = end.length; len >= end.minLen; len--) {
+    const endPos = end.firstDigitStart + len
+    const tail = resolvePositiveTail(view, endPos)
+    if (tail === null) continue
+    const endStr = text.slice(dashEnd, endPos)
+    if (tail.followingEmpty && rangeNumbersConvert(startDigits, endStr)) {
+      view.replace(startSpanEnd, dashEnd, EN_DASH)
+    }
+    return tail.consumedEnd
+  }
+  return null
+}
+
+/**
+ * v4's `(?:p\.?|[currency])?\d[\d.,]*` start run, boundary-truncated. v4's `wb`
+ * (`(?<!\w${chr}{0,3})\b`) anchors the start at a word boundary, so the currency
+ * alternative is unreachable: a leading currency symbol is non-word, and the only
+ * `\b` sits after it, at the digit — so the currency is never part of `start`
+ * (e.g. "$100-2000" reads start "100", which the 3+4 phone gate then blocks). The
+ * `p`/`p.` prefix is a word char, so it can begin the run at a word boundary.
+ */
+function readStartRun(view: ProseView, pos: number): { length: number } | null {
+  const text = view.text
+  let i = pos
+  if (text[i] === "p") {
+    // v4's `p\.?\d` is contiguous (no separator slot), so a boundary between `p`,
+    // an optional `.`, and the first digit breaks the prefix.
+    if (view.hasBoundary(i + 1)) return null
+    i++
+    if (text[i] === ".") {
+      if (view.hasBoundary(i + 1)) return null
+      i++
+    }
+  }
+  // v4's `\d` is required after the optional `p\.?` prefix. The prefix chars are
+  // never digits, so a missing digit here means no start run begins.
+  if (!/\d/.test(text[i] ?? "")) return null
+  i++
+  while (/[\d.,]/.test(text[i] ?? "") && !view.hasBoundary(i)) i++
+  return { length: i - pos }
+}
+
+interface EndRun {
+  /** Clean offset of the first end digit (past an optional currency symbol). */
+  firstDigitStart: number
+  /** Length of the `[\d.,]` run from `firstDigitStart`, boundary-truncated. */
+  length: number
+  /** Minimum end length: 1 digit (`\d` is required). */
+  minLen: number
+}
+
+/** v4's `[currency]?\d[\d.,]*` end run starting at `pos`, boundary-truncated. */
+function readEndRun(view: ProseView, pos: number): EndRun | null {
+  const text = view.text
+  let i = pos
+  if (CURRENCY_RE.test(text[i] ?? "")) {
+    // v4 has no separator slot between the currency symbol and the digit.
+    if (view.hasBoundary(i + 1)) return null
+    i++
+  }
+  if (!/\d/.test(text[i] ?? "")) return null
+  const firstDigitStart = i
+  i++
+  while (/[\d.,]/.test(text[i] ?? "") && !view.hasBoundary(i)) i++
+  return { firstDigitStart, length: i - firstDigitStart, minLen: 1 }
+}
+
+interface ResolvedTail {
+  followingEmpty: boolean
+  /** End offset of the whole structural tail (following + optional suffix). */
+  consumedEnd: number
+}
+
+/**
+ * Resolves the tail at `endPos`: finds the longest `following` whose
+ * `suffix? wbe` completes (v4's greedy choice). `followingEmpty` reports whether
+ * that following is empty (the convert condition); `consumedEnd` is the tail's
+ * end including any suffix (for the scan's consume/advance). Returns null when
+ * no following completes.
+ */
+function resolvePositiveTail(view: ProseView, endPos: number): ResolvedTail | null {
+  const candidates = followingCandidates(view, endPos, true)
+  for (let i = candidates.length - 1; i >= 0; i--) {
+    const suffixEnd = suffixWbeEnd(view, candidates[i], true)
+    if (suffixEnd !== null) {
+      return { followingEmpty: i === 0, consumedEnd: suffixEnd }
+    }
+  }
+  return null
+}
+
+
+/**
+ * Negative ranges: −5-5 → −5–5, −5--2 → −5–−2. A separate hand scan (not a regex)
+ * because the end run, like v4's `(?<end>${chr}?\d[\d.,]*)`, must truncate at node
+ * boundaries before its tail is resolved: over clean text a regex would fuse
+ * separator-split digits into one run (e.g. "8{sep}{sep}{sep}{sep}{sep}0" reads as
+ * "80") and mis-place or miss the conversion. The scan mirrors `matchRangeBody`:
+ * at each MINUS-led start it resolves the longest end whose `following* suffix?
+ * wbe` tail completes, converting only when that tail leaves `following` empty.
+ */
+function convertNegativeRanges(view: ProseView): void {
+  const text = view.text
+  let i = 0
+  while (i < text.length) {
+    if (text[i] === MINUS) {
+      const span = matchNegativeRangeAt(view, i)
+      if (span !== null) {
+        i = Math.max(span, i + 1)
+        continue
+      }
+    }
+    i++
+  }
+  view.commit()
+}
+
+/**
+ * Attempts v4's `(?<![LAT]) ${MINUS}\d[\d.,]* -{1,3} -? end following* suffix? wbe`
+ * beginning the MINUS at clean offset `i`. Converts the dash run when v4's gates
+ * pass. Returns the consumed structural end offset, or null when no match begins.
+ */
+function matchNegativeRangeAt(view: ProseView, i: number): number | null {
+  const text = view.text
+  // v4's `(?<![LAT])`: a Latin letter directly before the MINUS (no intervening
+  // boundary, which would hide it) blocks the match.
+  if (boundaryCountAt(view, i) === 0) {
+    const before = text[i - 1]
+    if (before !== undefined && LATIN_LETTER_RE.test(before)) return null
+  }
+
+  // start = `${MINUS}\d[\d.,]*${chr}?`: the digits after MINUS must not cross a
+  // boundary (v4's `start` body has no separator slot before its trailing one).
+  if (!/\d/.test(text[i + 1] ?? "")) return null
+  let startEnd = i + 1
+  while (/[\d.,]/.test(text[startEnd] ?? "") && !view.hasBoundary(startEnd)) startEnd++
+  // One `${chr}?` between start and the dash tolerates a single boundary there.
+  if (boundaryCountAt(view, startEnd) > 1) return null
+  if (text[startEnd] !== "-") return null
+
+  // `-{1,3}?` then optional `(?<neg>-)`: a 1..3 hyphen run with no interior
+  // boundary, the last of which becomes `neg` when two or more hyphens are present.
+  let dashRunEnd = startEnd + 1
+  while (text[dashRunEnd] === "-" && dashRunEnd - startEnd < 3 && !view.hasBoundary(dashRunEnd)) dashRunEnd++
+  const dashRunLen = dashRunEnd - startEnd
+  const hasNeg = dashRunLen >= 2
+  const negEnd = dashRunEnd
+  // The `(?<end>${chr}?...)` head separator slot tolerates one boundary.
+  if (boundaryCountAt(view, negEnd) > 1) return null
+
+  const end = readNegEndRun(view, negEnd)
+  if (end === null) return null
+  // v4's greedy end and `following*` backtrack together; commit at the longest end
+  // whose tail completes, converting only when that tail's `following` is empty.
+  for (let len = end.length; len >= 1; len--) {
+    const endPos = end.firstDigitStart + len
+    const candidates = followingCandidates(view, endPos, false)
+    for (let c = candidates.length - 1; c >= 0; c--) {
+      const suffixEnd = suffixWbeEnd(view, candidates[c], false)
+      if (suffixEnd === null) continue
+      if (c === 0) {
+        view.replace(startEnd, negEnd, `${EN_DASH}${hasNeg ? MINUS : ""}`)
+      }
+      return suffixEnd
+    }
+  }
+  return null
+}
+
+interface NegEndRun {
+  firstDigitStart: number
+  length: number
+}
+
+/** v4's negative `end` body `\d[\d.,]*` starting at `pos`, boundary-truncated. */
+function readNegEndRun(view: ProseView, pos: number): NegEndRun | null {
+  const text = view.text
+  if (!/\d/.test(text[pos] ?? "")) return null
+  let i = pos + 1
+  while (/[\d.,]/.test(text[i] ?? "") && !view.hasBoundary(i)) i++
+  return { firstDigitStart: pos, length: i - pos }
+}
+
+/**
+ * Boundary-aware `following` end positions, shortest (empty) first, walking
+ * segments `${chr}?[-(−)]${chr}?\d+`. Separators are zero-width in clean text;
+ * each `${chr}?` tolerates one boundary, and each `\d+` stops at a boundary.
+ * `allowMinus` admits a MINUS as a segment's dash (positive ranges).
+ */
+function followingCandidates(view: ProseView, endSpanEnd: number, allowMinus: boolean): number[] {
+  const candidates = [endSpanEnd]
+  let pos = endSpanEnd
+  for (;;) {
+    if (boundaryCountAt(view, pos) > 1) break
+    const dashCh = view.text[pos]
+    if (dashCh !== "-" && !(allowMinus && dashCh === MINUS)) break
+    const digitStart = pos + 1
+    if (boundaryCountAt(view, digitStart) > 1) break
+    if (!/\d/.test(view.text[digitStart] ?? "")) break
+    let end = digitStart + 1
+    while (/\d/.test(view.text[end] ?? "") && !view.hasBoundary(end)) end++
+    pos = end
+    candidates.push(pos)
+  }
+  return candidates
+}
+
+/**
+ * v4's `(?<suffix>${chr}?(?:[AaPp][Mm]|[xKBTM]))?${wbe}` at `pos`. Returns the
+ * end offset after the optional suffix when the tail completes (wbe passes), or
+ * null when it does not.
+ */
+function suffixWbeEnd(view: ProseView, pos: number, allowAmPm: boolean): number | null {
+  if (wordBoundaryEndOk(view, pos)) return pos
+  // An optional suffix: one ${chr}? (zero-width, ≤1 boundary) then am/pm or one
+  // of x/K/B/T/M, followed by wbe. The suffix letters sit at the clean `pos`.
+  if (boundaryCountAt(view, pos) > 1) return null
+  const text = view.text
+  // `[AaPp][Mm]` is contiguous in v4 — a boundary between the two letters breaks
+  // the suffix.
+  if (allowAmPm && /[ap]/i.test(text[pos] ?? "") && /m/i.test(text[pos + 1] ?? "") && !view.hasBoundary(pos + 1)) {
+    return wordBoundaryEndOk(view, pos + 2) ? pos + 2 : null
+  }
+  if (/[xKBTM]/.test(text[pos] ?? "")) {
+    return wordBoundaryEndOk(view, pos + 1) ? pos + 1 : null
+  }
+  return null
+}
+
+const NOT_AFTER_DASH_RE = new RegExp(`[${DISALLOWED_PREFIX_CLASS_FRAGMENT}${LATIN_LETTERS}${MULTIPLICATION}${PLUS_MINUS}.+]`)
+
+/**
+ * v4's `notAfterDash` was a single-char negative lookbehind. A node boundary
+ * immediately before the start hides the clean char (v4 saw the separator, not
+ * the dash/letter), so the guard only fires when a disallowed clean char sits
+ * directly before the start with no intervening boundary.
+ */
+function notAfterDashOk(view: ProseView, startOffset: number): boolean {
+  if (startOffset === 0) return true
+  if (boundaryCountAt(view, startOffset) > 0) return true
+  const prev = view.text[startOffset - 1]
+  return prev === undefined || !NOT_AFTER_DASH_RE.test(prev)
+}
+
+/** v4 range-number gates: reject year-month, phone-shaped, and toll-free pairs. */
+function rangeNumbersConvert(startNum: string, endNum: string): boolean {
+  if (/^(?:19|20)\d{2}$/.test(startNum) && /^(?:0[1-9]|1[0-2])$/.test(endNum)) return false
+  // Skip 3+4 digit phone-shaped patterns (555-1234, or the second half of
+  // 555-123-4567). Thousands-grouped endings (1,234 / 1.234) keep their
+  // internal separator and so fail /^\d{4}$/, falling through to convert as
+  // ranges.
+  if (/^\d{3}$/.test(startNum) && /^\d{4}$/.test(endNum)) return false
+  // Skip US toll-free prefix pattern: 1-800, 1-888, 1-877, etc. Only the seven
+  // real toll-free codes (800, 888, 877, 866, 855, 844, 833) are blocked, so
+  // genuine ranges like 1-850 or 1-810 still en-dash.
+  if (/^1$/.test(startNum) && /^8(?:00|88|77|66|55|44|33)$/.test(endNum)) return false
+  return true
+}
+
+// ---------------------------------------------------------------------------
+// Date ranges
+// ---------------------------------------------------------------------------
 
 /** Convert month ranges to en-dash (e.g., "January-March" → "January–March"). */
 export function enDashDateRange(text: string, options: DashOptions = {}): string {
   const dashStyle = options.dashStyle ?? "american"
   if (dashStyle === "none") return text
-  const chr = getEscapedSeparator(options)
-  const wb = wordBoundaryStart(chr)
-  const wbe = wordBoundaryEnd(chr)
+  const separator = options.separator ?? DEFAULT_SEPARATOR
+  const [pre, post] = dashStyle === "british" ? [" ", " "] : ["", ""]
 
-  // Atomic-optional year groups (lookahead + backref). The capture inside
-  // the lookahead is locked in once matched, so the year group commits
-  // without backtracking.
-  const startYear = `(?=(?<startYear>${chr}? \\d{4})?)\\k<startYear>`
-  const endYear = `(?=(?<endYear> \\d{4})?)\\k<endYear>`
-  return text.replace(
-    cachedRegExp(`${wb}(?<startMonth>${monthPattern})${startYear}(?<preSep>${chr}?)(?<preSpace> ?)-(?<postSpace> ?)(?<postSep>${chr}?)(?<endMonth>${monthPattern})${endYear}${wbe}`, "g"),
-    (...args) => {
-      const groups = namedGroups<{
-        startMonth: string
-        startYear?: string
-        preSep: string
-        endMonth: string
-        endYear?: string
-        postSep: string
-      }>(args)
-      const [pre, post] = dashStyle === "british" ? [" ", " "] : ["", ""]
-      return `${groups.startMonth}${groups.startYear || ""}${groups.preSep}${pre}${EN_DASH}${post}${groups.postSep}${groups.endMonth}${groups.endYear || ""}`
-    }
-  )
+  return withProseView(text, separator, (view) => {
+    // Atomic-optional year groups (lookahead + backref). The capture inside the
+    // lookahead is locked in once matched, so the year group commits without
+    // backtracking.
+    const startYear = `(?=(?<startYear> \\d{4})?)\\k<startYear>`
+    const endYear = `(?=(?<endYear> \\d{4})?)\\k<endYear>`
+    const pattern = `\\b(?<startMonth>${monthPattern})${startYear}(?<preSpace> ?)-(?<postSpace> ?)(?<endMonth>${monthPattern})${endYear}\\b`
+    pass(
+      view,
+      cachedRegExp(pattern, "g"),
+      (match, v) => {
+        const groups = namedGroups<{
+          startMonth: string
+          startYear?: string
+          preSpace: string
+          postSpace: string
+          endMonth: string
+          endYear?: string
+        }>(matchArgs(match))
+        // Replace `[preSpace]-[postSpace]` (the dash and its spaces) with the
+        // styled en-dash, leaving the months and any boundaries around them.
+        const startLen = groups.startMonth.length + (groups.startYear?.length ?? 0)
+        const dashSpan = groups.preSpace.length + 1 + groups.postSpace.length
+        const dashStart = match.index + startLen
+        v.replace(dashStart, dashStart + dashSpan, `${pre}${EN_DASH}${post}`)
+        return null
+      },
+      {
+        allowBoundaries: (match, v) => {
+          const groups = namedGroups<{
+            startMonth: string
+            startYear?: string
+            preSpace: string
+            postSpace: string
+            endMonth: string
+            endYear?: string
+          }>(matchArgs(match))
+          const startLen = groups.startMonth.length + (groups.startYear?.length ?? 0)
+          // v4 tolerated one separator after the start year (`preSep`) and one
+          // before the end month (`postSep`), bracketing the dash and spaces.
+          const dashStart = match.index + startLen
+          const dashEnd = dashStart + groups.preSpace.length + 1 + groups.postSpace.length
+          const tolerated = new Map<number, number>()
+          tolerated.set(dashStart, 1)
+          tolerated.set(dashEnd, 1)
+          if (!interiorBoundariesAllowed(match, v, tolerated)) return false
+          return wordBoundaryStartOk(v, match.index) && wordBoundaryEndOk(v, match.index + match[0].length)
+        },
+      },
+    )
+  })
 }
+
+// ---------------------------------------------------------------------------
+// Minus signs
+// ---------------------------------------------------------------------------
 
 /** Convert hyphens to minus signs in numeric contexts (e.g., "-5" → "−5"). */
 export function minusReplace(text: string, options: DashOptions = {}): string {
-  const chr = getEscapedSeparator(options)
-
-  // Pattern 1a: Subtraction of negative number (e.g., "5 - -3" → "5 − −3")
-  // Must come before Pattern 1b so the negative hyphen is consumed first
-  text = text.replace(
-    cachedRegExp(`(?<=\\d${chr}?) - -(?<num>${chr}?\\d*\\.?\\d+)`, "g"),
-    ` ${MINUS} ${MINUS}$<num>`
-  )
-
-  // Pattern 1b: Spaced math subtraction (e.g., "5 - 3" → "5 − 3")
-  // Only when preceded by a digit - this distinguishes "5 - 3" from "Safari) - 9"
-  text = text.replace(
-    cachedRegExp(`(?<=\\d${chr}?) - (?<num>${chr}?\\d*\\.?\\d+)`, "g"),
-    ` ${MINUS} $<num>`
-  )
-
-  // Pattern 2: Direct negative numbers (e.g., "-5" → "−5", "(-3)" → "(−3)")
-  // Match after: start of line, whitespace, (, or quotes (straight or curly)
-  // No space allowed between hyphen and digit
-  text = text.replace(
-    cachedRegExp(`(?<before>^|[\\s\\("'${LEFT_DOUBLE_QUOTE}${RIGHT_DOUBLE_QUOTE}${LEFT_SINGLE_QUOTE}${RIGHT_SINGLE_QUOTE}])-(?<num>\\d*\\.?\\d+)`, "gm"),
-    `$<before>${MINUS}$<num>`
-  )
-
-  // Pattern 2b: Direct negative numbers after separator boundary (e.g., <em>-5</em>)
-  // Only when no word character precedes the separator — prevents both
-  // "2{SEP}-3" in "1-2-3" and "GPT{SEP}-3" from being misidentified as negative 3
-  text = text.replace(
-    cachedRegExp(`(?<![\\d.,${LATIN_LETTERS}])(?<before>${chr})-(?<num>\\d*\\.?\\d+)`, "gm"),
-    `$<before>${MINUS}$<num>`
-  )
-
-  return text
+  const separator = options.separator ?? DEFAULT_SEPARATOR
+  return withProseView(text, separator, (view) => {
+    minusSubtractionOfNegative(view)
+    minusSpacedSubtraction(view)
+    minusDirectNegative(view)
+  })
 }
 
-function convertParentheticalDashes(text: string, sep: string, style: DashStyle): string {
+/** Pattern 1a/1b: spaced math subtraction after a digit (`5 - 3`, `5 - -3`). */
+function minusSubtractionOfNegative(view: ProseView): void {
+  // "5 - -3" → "5 − −3"; the negative hyphen is consumed first. v4's `${chr}?`
+  // before `num` tolerates one boundary there (the `- -` prefix has 4 chars).
+  pass(
+    view,
+    cachedRegExp(`(?<=\\d) - -(?<num>\\d*\\.?\\d+)`, "g"),
+    (match, v) => {
+      // Replace only the ` - -` prefix; `num` (which may carry interior
+      // boundaries v4 truncated at) stays untouched.
+      if (!minusSubtractionPrefixOk(match, v, 4)) return null
+      v.replace(match.index, match.index + 4, ` ${MINUS} ${MINUS}`)
+      return null
+    },
+    { allowBoundaries: () => true },
+  )
+}
+
+function minusSpacedSubtraction(view: ProseView): void {
+  // "5 - 3" → "5 − 3"; only after a digit ("5 - 3" not "Safari) - 9").
+  pass(
+    view,
+    cachedRegExp(`(?<=\\d) - (?<num>\\d*\\.?\\d+)`, "g"),
+    (match, v) => {
+      if (!minusSubtractionPrefixOk(match, v, 3)) return null
+      v.replace(match.index, match.index + 3, ` ${MINUS} `)
+      return null
+    },
+    { allowBoundaries: () => true },
+  )
+}
+
+const NUM_BODY_RE = /^\d*\.?\d+/
+
+/**
+ * v4's subtraction patterns wove one `${chr}?` after the leading digit (in the
+ * lookbehind, at the match start) and one before `num` (`(?<num>${chr}?\d*\.?\d+)`).
+ * The `${chr}?-` prefix span ([match.index, match.index + prefixLen)) must stay
+ * separator-free; one boundary may sit at `num`'s head. v4's `num` body
+ * (`\d*\.?\d+`) carries no separator slot, so it stops at the first interior
+ * boundary: a boundary that truncates `num` to a still-valid number (e.g. "12"
+ * in "5 - 12{sep}5") leaves v4 matching, but one that strips the mandatory `\d+`
+ * (e.g. "." in "5 - .{sep}5") breaks v4's match. The targeted edit only rewrites
+ * the ` - ` prefix, so a converting match must keep v4's `num` satisfiable.
+ */
+function minusSubtractionPrefixOk(match: RegExpExecArray, view: ProseView, prefixLen: number): boolean {
+  // The `${chr}?` in v4's lookbehind (`(?<=\d${chr}?)`) sits at the match start
+  // between the leading digit and the space; it tolerates at most one boundary.
+  if (boundaryCountAt(view, match.index) > 1) return false
+  const numStart = match.index + prefixLen
+  for (const b of view.boundaries) {
+    if (b > match.index && b < numStart) return false
+  }
+  // The `${chr}?` before `num` tolerates at most one boundary at the num head.
+  if (boundaryCountAt(view, numStart) > 1) return false
+  // v4's `num` stops at the first interior boundary; the clean run up to it must
+  // still satisfy `\d*\.?\d+` (the mandatory trailing `\d+`).
+  const numEnd = match.index + match[0].length
+  let truncatedEnd = numEnd
+  for (const b of view.boundaries) {
+    if (b > numStart && b < numEnd) { truncatedEnd = b; break }
+    if (b >= numEnd) break
+  }
+  return NUM_BODY_RE.test(view.text.slice(numStart, truncatedEnd))
+}
+
+const MINUS_BEFORE_CLASS_RE = new RegExp(`[\\s("'${LEFT_DOUBLE_QUOTE}${RIGHT_DOUBLE_QUOTE}${LEFT_SINGLE_QUOTE}${RIGHT_SINGLE_QUOTE}]`)
+const NUM_BEFORE_2B_BLOCK_RE = new RegExp(`[\\d.,${LATIN_LETTERS}]`)
+
+/**
+ * Direct negative numbers. v4 ran two passes: Pattern 2 converts `-\d` after
+ * line start, whitespace, `(`, or a quote; Pattern 2b converts `${chr}-\d` (a
+ * separator-led hyphen) when no digit/`.`/`,`/Latin precedes the separator —
+ * which prevents `1${chr}-2` and `GPT${chr}-3` from reading as negatives. In
+ * the view, Pattern 2 fires when the clean char before the hyphen qualifies and
+ * no boundary intrudes; Pattern 2b fires when a boundary leads the hyphen.
+ */
+function minusDirectNegative(view: ProseView): void {
+  pass(
+    view,
+    cachedRegExp(`-(?<num>\\d*\\.?\\d+)`, "gm"),
+    (match, v) => {
+      const start = match.index
+      // v4's `num` (`\d*\.?\d+`) carries no separator slot, so it stops at the
+      // first interior boundary; the clean run up to it must still satisfy
+      // `\d*\.?\d+`. A boundary right after the hyphen (head) leaves no digits
+      // ("-{sep}5"), and one that strips the mandatory `\d+` ("-.{sep}1") breaks
+      // the match, but one past a valid number ("-5{sep}5") leaves it intact.
+      const numEnd = start + match[0].length
+      let numTruncEnd = numEnd
+      for (const b of v.boundaries) {
+        if (b > start && b < numEnd) { numTruncEnd = b; break }
+        if (b >= numEnd) break
+      }
+      if (!NUM_BODY_RE.test(v.text.slice(start + 1, numTruncEnd))) return null
+      // A boundary directly before the hyphen routes to Pattern 2b; otherwise
+      // Pattern 2 examines the clean preceding char. (The two never overlap: a
+      // hyphen has either a boundary or a clean char immediately before it.)
+      const nb = boundaryCountAt(v, start)
+      if (nb > 0) {
+        // Pattern 2b: the marked char before the separator run must not be a
+        // digit, `.`, `,`, or Latin letter. With ≥2 stacked separators that char
+        // is another separator (admitted); with one, it is the clean char left.
+        if (nb < 2) {
+          const before = v.text[start - 1]
+          if (before !== undefined && NUM_BEFORE_2B_BLOCK_RE.test(before)) return null
+        }
+      } else {
+        // Pattern 2: line start, whitespace, `(`, or a quote immediately left.
+        const before = v.text[start - 1]
+        const atLineStart = before === undefined || before === "\n"
+        if (!atLineStart && !MINUS_BEFORE_CLASS_RE.test(before)) return null
+      }
+      v.replace(start, start + 1, MINUS)
+      return null
+    },
+    { allowBoundaries: () => true },
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Parenthetical dashes
+// ---------------------------------------------------------------------------
+
+function convertParentheticalDashes(view: ProseView, style: DashStyle): void {
   const localizedDash = style === "british" ? EN_DASH : EM_DASH
   const maybeSpace = style === "british" ? " " : ""
-  const escapedSep = getEscapedSeparator({ separator: sep })
+  const rendered = `${maybeSpace}${localizedDash}${maybeSpace}`
 
-  // Convert spaced dashes: "word - word" or "word — word"
-  // When a separator follows the dash, preserve trailing spaces (they belong to the next text segment).
-  // A single plain hyphen directly before a word character (through optional separators) is a
-  // suspended/hanging hyphen ("Yes-men and -women"), not a parenthetical dash — skip it.
-  // Em/en dashes and multiple hyphens can have zero trailing spaces.
-  // `sepAfter` and `trailing` share one optional unit so a whitespace run
-  // can only be assigned to it as a whole, keeping the match unambiguous.
-  const spacedDashPattern = cachedRegExp(
-    `(?<=[^\\s]|^)(?<sepBefore>${escapedSep}?)[ ]+(?:[${EN_DASH}${EM_DASH}][-${EN_DASH}${EM_DASH}]*|-{2,}|-(?!${escapedSep}*[${LATIN_LETTERS}\\d]))(?!${escapedSep}?-*${escapedSep}?>)[ ]*(?:(?<sepAfter>${escapedSep})(?<trailing>[ ]*))?(?=\\S|$)`, "g"
-  )
-  text = text.replace(spacedDashPattern, (_match, sepBefore, sepAfter, trailing) => {
-    // sepAfter and trailing are undefined when the optional group didn't match.
-    sepAfter = sepAfter ?? ""
-    trailing = trailing ?? ""
-    // Trailing space after a separator belongs to the next text node — keep it
-    // regardless of style. Without a separator, the trailing space is part of
-    // the current node's whitespace around the dash and gets consumed.
-    const keepTrailing = sepAfter ? trailing : ""
-    return `${sepBefore}${maybeSpace}${localizedDash}${maybeSpace}${sepAfter}${keepTrailing}`
-  })
-  // Convert dashes at text node boundaries: separator alone precedes dash (e.g., "word{sep}– rest")
-  // Requires space after the dash to avoid matching number ranges like "1{sep}-{sep}5"
-  text = text.replace(
-    cachedRegExp(`(?<=[^\\s])(?<sepBefore>${escapedSep})[${EN_DASH}${EM_DASH}-]+[ ]+(?<sepAfter>${escapedSep}?)`, "g"),
-    `$<sepBefore>${maybeSpace}${localizedDash}${maybeSpace}$<sepAfter>`
-  )
-  // Convert multiple dashes: "word--word" or "word---word" or "quote"--"quote"
-  // Upper bound of 50 prevents ReDoS on pathological runs of dashes.
-  const quoteChars = `"'${LEFT_DOUBLE_QUOTE}${RIGHT_DOUBLE_QUOTE}${LEFT_SINGLE_QUOTE}${RIGHT_SINGLE_QUOTE}`
-  text = text.replace(
-    cachedRegExp(`(?<=[${LATIN_LETTERS}\\d${quoteChars}])(?<sepBefore>${escapedSep}?)[${EN_DASH}${EM_DASH}-]{2,50}(?<sepAfter>${escapedSep}?)(?=[${LATIN_LETTERS}${quoteChars} ])`, "g"),
-    `$<sepBefore>${maybeSpace}${localizedDash}${maybeSpace}$<sepAfter>`
-  )
-  // Convert dashes at start of line
-  text = text.replace(cachedRegExp(`^(?<leadingSep>${escapedSep})?[-]+ `, "gm"), `$<leadingSep>${localizedDash} `)
-  // British: convert unspaced em-dashes to spaced en-dashes (word—word → word – word)
-  if (style === "british") {
-    text = text.replace(
-      cachedRegExp(`(?<=[${LATIN_LETTERS}.!?'"])(?<sepBefore>${escapedSep}?)${EM_DASH}(?<sepAfter>${escapedSep}?)(?=[${LATIN_LETTERS}])`, "g"),
-      `$<sepBefore>${maybeSpace}${localizedDash}${maybeSpace}$<sepAfter>`
-    )
-  }
-  return text
+  convertSpacedDashes(view, rendered)
+  convertBoundaryLedDashes(view, rendered)
+  convertMultipleDashes(view, rendered)
+  convertLeadingLineDashes(view, localizedDash)
+  if (style === "british") convertUnspacedEmDashes(view, rendered)
 }
+
+const QUOTE_CHARS = `"'${LEFT_DOUBLE_QUOTE}${RIGHT_DOUBLE_QUOTE}${LEFT_SINGLE_QUOTE}${RIGHT_SINGLE_QUOTE}`
+
+const DASH_RUN_CHARS = new Set(["-", EN_DASH, EM_DASH])
+
+function isDashChar(ch: string | undefined): boolean {
+  return ch !== undefined && DASH_RUN_CHARS.has(ch)
+}
+
+/**
+ * Spaced dashes: "word - word" / "word — word". A single plain hyphen directly
+ * before a word char (the suspended/hanging hyphen, "Yes-men and -women") is
+ * skipped. The arrow guard rejects shapes like "- >" so `foo -> bar` stays.
+ *
+ * v4's dash core (`[${EN}${EM}][-${EN}${EM}]*|-{2,}|-(?!sep*[LAT\d])`) never
+ * spanned a separator, so a node boundary inside the dash run truncates the run
+ * — the boundary becomes the `sepAfter` slot and any dashes past it are left
+ * untouched. The replacer reproduces this by truncating the run at the first
+ * interior boundary and re-validating the dash core on the truncated form.
+ */
+function convertSpacedDashes(view: ProseView, rendered: string): void {
+  // v4's `(?<=[^\s]|^)` lookbehind is validated in the replacer instead, since a
+  // separator (non-space) also satisfies it, letting a match begin even when the
+  // clean char to the left is whitespace. The cheap `(?<![ ])` anchor keeps each
+  // `[ ]+` run starting at its leftmost space, avoiding quadratic backtracking.
+  const pattern = `(?<![ ])[ ]+(?<dashStart>[-${EN_DASH}${EM_DASH}])`
+  // v4's regex consumed the trailing `[ ]*` inside each match, advancing past it;
+  // this clean pattern does not, so a later match could begin inside a previous
+  // match's consumed trailing spaces. Track the last consumed offset and skip.
+  let consumedThrough = -1
+  pass(
+    view,
+    cachedRegExp(pattern, "g"),
+    (match, v) => {
+      const text = v.text
+      const groups = namedGroups<{ dashStart: string }>(matchArgs(match))
+      const firstDash = match.index + match[0].length - groups.dashStart.length
+      // v4's greedy `[ ]+` starts at the leftmost position whose `(?<=[^\s]|^)`
+      // holds: line/text start, a non-whitespace clean char, or a separator. A
+      // boundary inside the leading spaces restarts the match just after it (the
+      // spaces before it stay with the previous node). The previous match's
+      // consumed span is also a floor: leading spaces it already consumed are not
+      // re-used.
+      let matchStart = Math.max(match.index, consumedThrough)
+      for (const b of view.boundaries) {
+        if (b > matchStart && b <= firstDash - 1) matchStart = b
+        else if (b > firstDash) break
+      }
+      /* istanbul ignore if -- defensive: the previous match's trailing `(?=\S|$)`
+         stops at this dash, so `consumedThrough` never reaches past `firstDash`. */
+      if (matchStart >= firstDash + 1) return null
+      // Validate the lookbehind at matchStart: start of text/line, a boundary
+      // immediately left (separator), or a non-whitespace clean char.
+      const leftOk = matchStart === 0
+        || view.hasBoundary(matchStart)
+        || (text[matchStart - 1] !== undefined && !/\s/.test(text[matchStart - 1]))
+      if (!leftOk) return null
+      // The leading spaces between matchStart and the dash must be at least one
+      // (v4's `[ ]+` is one-or-more) — a boundary directly before the dash leaves
+      // none, which is the boundary-led pattern's job, not this one.
+      if (matchStart === firstDash) return null
+      // A separator between the leading spaces and the dash breaks v4's
+      // `[ ]+dashCore` (no separator slot there); neither spaced nor boundary-led
+      // matches, so skip.
+      if (view.hasBoundary(firstDash)) return null
+      // Maximal dash run from firstDash that does not cross a boundary (v4's core
+      // never spanned a separator).
+      let fullRunEnd = firstDash + 1
+      while (isDashChar(text[fullRunEnd]) && !v.hasBoundary(fullRunEnd)) fullRunEnd++
+      // v4's dashCore (`-{2,}` greedy, then single `-`) backtracks past the arrow
+      // guard AND the trailing `[ ]*(?=\S|$)`, so try run ends longest-first and
+      // take the first one whose whole tail validates.
+      const chosen = chooseSpacedDashRun(v, firstDash, fullRunEnd)
+      if (chosen === null) return null
+      consumedThrough = chosen.consumedEnd
+      v.replace(matchStart, chosen.editEnd, rendered)
+      return null
+    },
+    { allowBoundaries: () => true },
+  )
+}
+
+/**
+ * Picks v4's dashCore from the maximal dash run [firstDash, fullRunEnd). v4 tries
+ * `[EN EM][-EN EM]*`, then `-{2,}` (greedy), then a single `-`, backtracking past
+ * the arrow guard and the trailing `[ ]*(?=\S|$)`. Returns the chosen run end and
+ * the trailing-spaces end (`scan`) to replace, or null when no branch validates.
+ */
+function chooseSpacedDashRun(view: ProseView, firstDash: number, fullRunEnd: number): SpacedTrailing | null {
+  const text = view.text
+  const first = text[firstDash]
+  if (first === EN_DASH || first === EM_DASH) {
+    // `[EN EM][-EN EM]*`: the leading EN/EM is mandatory, the `[-EN EM]*` tail is
+    // greedy but backtracks past the arrow guard — e.g. "–-{sep}{sep}>" gives the
+    // `-` back so the run is just "–" (not an arrow) and converts.
+    for (let end = fullRunEnd; end > firstDash; end--) {
+      if (spacedArrowAhead(view, end)) continue
+      const trailing = spacedTrailingEnd(view, end)
+      if (trailing !== null) return trailing
+    }
+    return null
+  }
+  // v4's `-{2,}` and single-`-` branches match hyphens only, so a leading-hyphen
+  // run stops at the first EN/EM dash (e.g. "-–" is a single `-` core, not a
+  // two-dash run that would swallow the EN dash).
+  let hyphenRunEnd = firstDash
+  while (text[hyphenRunEnd] === "-" && hyphenRunEnd < fullRunEnd) hyphenRunEnd++
+  // All hyphens. Try `-{2,}` lengths longest-first, then a single `-`.
+  for (let end = hyphenRunEnd; end > firstDash; end--) {
+    if (end - firstDash === 1) {
+      // Single `-(?!${sep}*[LAT\d])`: the next clean char must not be a letter or
+      // digit (the suspended-hyphen guard).
+      const next = text[end]
+      if (next !== undefined && /[a-z\d]/i.test(next)) return null
+    }
+    if (spacedArrowAhead(view, end)) continue
+    const trailing = spacedTrailingEnd(view, end)
+    if (trailing !== null) return trailing
+  }
+  return null
+}
+
+interface SpacedTrailing {
+  /** Offset through which the edit deletes (kept post-boundary spaces excluded). */
+  editEnd: number
+  /** Offset past all consumed trailing chars (for overlap/`lastIndex` tracking). */
+  consumedEnd: number
+}
+
+/**
+ * v4's trailing `[ ]*(?:${chr} [ ]*)?(?=\S|$)`. The leading `[ ]*` (before any
+ * separator) is deleted; spaces after a separator are kept (they belong to the
+ * next node) but still consumed. The lookahead then requires a non-space char, a
+ * boundary, or end of text. Returns the edit/consumed offsets, or null on failure.
+ */
+function spacedTrailingEnd(view: ProseView, runEnd: number): SpacedTrailing | null {
+  const text = view.text
+  let editEnd = runEnd
+  while (text[editEnd] === " " && !view.hasBoundary(editEnd)) editEnd++
+  // v4's `(?:${chr} [ ]*)?(?=\S|$)` is a greedy optional group: try consuming a
+  // single sepAfter separator and its kept trailing spaces first, then fall back
+  // to no separator. `(?=\S|$)` is satisfied by a boundary (a non-space
+  // separator), a non-space clean char, or end of text.
+  if (boundaryCountAt(view, editEnd) === 1) {
+    let consumedEnd = editEnd
+    while (text[consumedEnd] === " " && (consumedEnd === editEnd || !view.hasBoundary(consumedEnd))) consumedEnd++
+    if (lookaheadNonSpace(view, consumedEnd)) return { editEnd, consumedEnd }
+  }
+  if (lookaheadNonSpace(view, editEnd)) return { editEnd, consumedEnd: editEnd }
+  return null
+}
+
+/** v4's `(?=\S|$)`: end of text, a node boundary, or a non-space clean char. */
+function lookaheadNonSpace(view: ProseView, pos: number): boolean {
+  return pos === view.text.length || view.hasBoundary(pos) || !/\s/.test(view.text[pos])
+}
+
+/**
+ * v4's `(?!${sep}?-*${sep}?>)` arrow guard, boundary-aware. The two `${sep}?`
+ * slots bracket the `-*` hyphen run: one boundary may sit before the run and one
+ * after. With no hyphens both slots collapse to the run-end offset (up to two
+ * boundaries there); a boundary inside the hyphen run, or more than the two
+ * slots allow, hides the `>` (so the dash is not an arrow and converts).
+ */
+function spacedArrowAhead(view: ProseView, runEnd: number): boolean {
+  const text = view.text
+  let h = runEnd
+  while (text[h] === "-") {
+    if (h > runEnd && view.hasBoundary(h)) return false // boundary inside -*
+    h++
+  }
+  if (h === runEnd) {
+    // No hyphens: both ${sep}? slots fall at this offset (≤2 boundaries total).
+    if (boundaryCountAt(view, runEnd) > 2) return false
+  } else {
+    if (boundaryCountAt(view, runEnd) > 1) return false // first ${sep}?
+    if (boundaryCountAt(view, h) > 1) return false // second ${sep}?
+  }
+  return text[h] === ">"
+}
+
+/**
+ * Dashes where a separator alone precedes the dash run: "word{sep}– rest". v4's
+ * pattern `(?<=[^\s])${sep}[dash]+[ ]+` required a separator immediately before
+ * the dash run, a non-space marked char before that separator, and at least one
+ * trailing space. Because the leading separator is required, this only fires
+ * where a node boundary opens a dash run, so the pass scans boundaries rather
+ * than the clean text. The "non-space before the separator" is satisfied by a
+ * real non-space clean char (single boundary) or by another stacked separator
+ * (two or more boundaries — a separator is itself non-space).
+ */
+function convertBoundaryLedDashes(view: ProseView, rendered: string): void {
+  const text = view.text
+  const edits: Array<[number, number]> = []
+  let lastProcessedEnd = -1
+  let prevOffset = -1
+  let stackedHere = 0
+  for (const b of view.boundaries) {
+    stackedHere = b === prevOffset ? stackedHere + 1 : 1
+    prevOffset = b
+    if (b < lastProcessedEnd) continue
+    if (!isDashChar(text[b])) continue
+    // Non-space before the separator: ≥2 stacked separators, or a non-space
+    // clean char immediately left.
+    if (stackedHere < 2) {
+      const before = text[b - 1]
+      if (before === undefined || /\s/.test(before)) continue
+    }
+    // Dash run from the boundary, not crossing a further boundary.
+    let runEnd = b + 1
+    while (isDashChar(text[runEnd]) && !view.hasBoundary(runEnd)) runEnd++
+    // Required trailing space run; stop at a boundary (sepAfter).
+    let spaceEnd = runEnd
+    while (text[spaceEnd] === " " && !view.hasBoundary(spaceEnd)) spaceEnd++
+    if (spaceEnd === runEnd) continue // no trailing space
+    edits.push([b, spaceEnd])
+    lastProcessedEnd = spaceEnd
+  }
+  for (const [from, to] of edits) view.replace(from, to, rendered)
+  view.commit()
+}
+
+/**
+ * Multiple dashes: "word--word", "word---word", `"quote"--"quote"`. v4's
+ * `(?<=[LAT\d quote])${sep}?[dash]{2,50}${sep}?(?=[LAT quote space])` tolerated
+ * one separator on each side of the run but its `[dash]{2,50}` never spanned a
+ * separator. A boundary inside the run truncates it (and the 2..50 count must
+ * still hold for the truncated run); two stacked boundaries on either edge
+ * exceed the single `${sep}?` slot and block the match.
+ */
+function convertMultipleDashes(view: ProseView, rendered: string): void {
+  const before = `[${LATIN_LETTERS}\\d${QUOTE_CHARS}]`
+  const after = `[${LATIN_LETTERS}${QUOTE_CHARS} ]`
+  // Upper bound of 50 prevents ReDoS on pathological runs of dashes.
+  const pattern = `(?<=${before})[${EN_DASH}${EM_DASH}-]{2,50}(?=${after})`
+  const afterRe = new RegExp(after)
+  pass(
+    view,
+    cachedRegExp(pattern, "g"),
+    (match, v) => {
+      const text = v.text
+      const start = match.index
+      // Two stacked boundaries before the run exceed sepBefore's one-sep budget.
+      if (boundaryCountAt(v, start) >= 2) return null
+      // Truncate the run at the first interior boundary (v4's class stops there).
+      let runEnd = start + 1
+      while (isDashChar(text[runEnd]) && !v.hasBoundary(runEnd)) runEnd++
+      if (runEnd - start < 2 || runEnd - start > 50) return null
+      // sepAfter tolerates one boundary; v4's trailing lookahead then checks the
+      // clean char after the run is [LAT quote space].
+      if (boundaryCountAt(v, runEnd) >= 2) return null
+      const next = text[runEnd]
+      if (next === undefined || !afterRe.test(next)) return null
+      v.replace(start, runEnd, rendered)
+      return null
+    },
+    { allowBoundaries: () => true },
+  )
+}
+
+/**
+ * Dashes at start of line: "^- " → styled dash. v4 wove one optional `${chr}?`
+ * at line start (before the dashes); it sits at the match start, never interior.
+ * The dash run has no interior separator slot, so a boundary inside the run
+ * blocks the match — the default interior-boundary rejection, which is what we
+ * want here.
+ */
+function convertLeadingLineDashes(view: ProseView, localizedDash: string): void {
+  pass(view, cachedRegExp(`^-+ `, "gm"), () => `${localizedDash} `)
+}
+
+/** British: unspaced em-dashes between letters become spaced en-dashes. */
+function convertUnspacedEmDashes(view: ProseView, rendered: string): void {
+  const pattern = `(?<=[${LATIN_LETTERS}.!?'"])${EM_DASH}(?=[${LATIN_LETTERS}])`
+  pass(
+    view,
+    cachedRegExp(pattern, "g"),
+    (match, v) => {
+      // v4's `(?<sepBefore>${chr}?)${EM_DASH}(?<sepAfter>${chr}?)` tolerated one
+      // boundary on each side; two or more exceed the slot and block the match.
+      if (boundaryCountAt(v, match.index) > 1) return null
+      if (boundaryCountAt(v, match.index + match[0].length) > 1) return null
+      v.replace(match.index, match.index + match[0].length, rendered)
+      return null
+    },
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Em-dash spacing normalization (american)
+// ---------------------------------------------------------------------------
 
 // TODO: Handle interrupted-then-resumed speech within quotes, where Chicago
 // allows a space after the dash: "Don't inter— Hey! Who threw that?"
-function normalizeEmDashSpacing(text: string, sep: string): string {
-  const escapedSep = getEscapedSeparator({ separator: sep })
-
-  // Remove all spaces around em-dashes. The `\S|^` / `\S|$` boundary
-  // anchors restrict the match to dashes adjacent to non-whitespace.
-  text = text.replace(
-    cachedRegExp(`(?<=\\S|^)(?<before>${escapedSep}?)[ ]*${EM_DASH}[ ]*(?<after>${escapedSep}?)(?=\\S|$)`, "g"),
-    `$<before>${EM_DASH}$<after>`
-  )
-
-  // Preserve space after em-dash at start of line (e.g., attribution)
-  text = text.replace(
-    cachedRegExp(`^(?<sep>${escapedSep}?)${EM_DASH}(?<after>[A-Z0-9])`, "gm"),
-    `$<sep>${EM_DASH} $<after>`
-  )
-
-  return text
+function normalizeEmDashSpacing(view: ProseView): void {
+  removeSpacesAroundEmDash(view)
+  preserveLineLeadingEmDashSpace(view)
 }
 
+/**
+ * Remove spaces directly around an em-dash that has non-whitespace on both
+ * sides. v4's `(?<=\S|^)${sep}?[ ]*${EM}[ ]*${sep}?(?=\S|$)` only consumed the
+ * spaces immediately adjacent to the dash; a separator between a space and the
+ * dash kept that space (the leading `[ ]*` could not reach across the marker).
+ * The walk therefore stops space consumption at node boundaries, and the
+ * `\S|^` / `\S|$` anchors treat a boundary (a non-space marker) as satisfying
+ * the anchor.
+ */
+function removeSpacesAroundEmDash(view: ProseView): void {
+  pass(
+    view,
+    cachedRegExp(EM_DASH, "g"),
+    (match, v) => {
+      const d = match.index
+      const text = v.text
+      // Leading spaces, stopping at a boundary or non-space.
+      let left = d
+      while (left > 0 && text[left - 1] === " " && !v.hasBoundary(left)) left--
+      // Trailing spaces, stopping at a boundary or non-space.
+      let right = d + 1
+      while (right < text.length && text[right] === " " && !v.hasBoundary(right)) right++
+      const leftAnchored = left === 0 || v.hasBoundary(left) || !/\s/.test(text[left - 1])
+      const rightAnchored = right === text.length || v.hasBoundary(right) || !/\s/.test(text[right])
+      if (!leftAnchored || !rightAnchored) return null
+      // Drop the adjacent space runs; the em-dash and any edge boundaries stay.
+      if (left < d) v.replace(left, d, "")
+      if (right > d + 1) v.replace(d + 1, right, "")
+      return null
+    },
+  )
+}
+
+/** Preserve a space after a line-leading em-dash before an uppercase/digit. */
+function preserveLineLeadingEmDashSpace(view: ProseView): void {
+  pass(
+    view,
+    cachedRegExp(`^${EM_DASH}(?<after>[A-Z0-9])`, "gm"),
+    (match, v) => {
+      // v4's `^${chr}?${EM_DASH}` tolerated one boundary between the line start
+      // and the em-dash; two or more exceed that slot and block the match.
+      if (boundaryCountAt(v, match.index) > 1) return null
+      const groups = namedGroups<{ after: string }>(matchArgs(match))
+      return `${EM_DASH} ${groups.after}`
+    },
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Public dash pipeline
+// ---------------------------------------------------------------------------
+
 export function hyphenReplace(text: string, options: DashOptions = {}): string {
-  const sep = options.separator ?? DEFAULT_SEPARATOR
+  const separator = options.separator ?? DEFAULT_SEPARATOR
   const style = options.dashStyle ?? "american"
   if (style === "none") return text
   text = minusReplace(text, options)
   text = enDashDateRange(text, options)
   text = enDashNumberRange(text, options)
-  text = convertParentheticalDashes(text, sep, style)
-  if (style === "american") text = normalizeEmDashSpacing(text, sep)
+  text = withProseView(text, separator, (view) => {
+    convertParentheticalDashes(view, style)
+    if (style === "american") normalizeEmDashSpacing(view)
+  })
   return text
 }
 
@@ -280,4 +1102,9 @@ const { WORD_JOINER } = UNICODE_SYMBOLS
 export function dashWordJoiner(text: string): string {
   const re = cachedRegExp(`(?<=[^\\s${WORD_JOINER}])[${EM_DASH}${EN_DASH}]`, "gu")
   return text.replace(re, `${WORD_JOINER}$&`)
+}
+
+/** Reconstructs `.replace()`-style callback args from a RegExpExecArray. */
+function matchArgs(match: RegExpExecArray): unknown[] {
+  return [...match, match.index, match.input, match.groups]
 }

--- a/src/dashes.ts
+++ b/src/dashes.ts
@@ -452,17 +452,33 @@ function followingCandidates(view: ProseView, endSpanEnd: number, allowMinus: bo
   return candidates
 }
 
+// First characters of the four superscript ordinal pairs. \w does not match these
+// Unicode chars, so wordBoundaryEndOk treats them as non-word — but they carry the
+// same blocking semantics as the plain letters they render (st/nd/rd/th).
+const SUPERSCRIPT_ORDINAL_FIRST_RE = new RegExp(
+  `[${SUPERSCRIPT_ST[0]}${SUPERSCRIPT_ND[0]}${SUPERSCRIPT_RD[0]}${SUPERSCRIPT_TH[0]}]`,
+)
+
 /**
  * v4's `(?<suffix>${chr}?(?:[AaPp][Mm]|[xKBTM]))?${wbe}` at `pos`. Returns the
  * end offset after the optional suffix when the tail completes (wbe passes), or
- * null when it does not.
+ * null when it does not. Two non-`\w` glyphs the v5 symbol passes emit
+ * (superscript ordinals, `×`) abut the digit run and must block conversion even
+ * though `wbe` would read them as a clean word boundary; both return null first.
  */
 function suffixWbeEnd(view: ProseView, pos: number, allowAmPm: boolean): number | null {
+  const text = view.text
+  // A superscript ordinal immediately following the digit run blocks conversion:
+  // `52ⁿᵈ` is an ordinal, not a range endpoint (same semantics as `52nd`).
+  if (SUPERSCRIPT_ORDINAL_FIRST_RE.test(text[pos] ?? "")) return null
+  // `×` (MULTIPLICATION) is the Unicode form of `x` produced by the symbols pass.
+  // It is non-\w so wordBoundaryEndOk would treat it as a clean boundary, but
+  // `55×5` is multiplication, not a range endpoint — block the same as `52nd`.
+  if (text[pos] === MULTIPLICATION) return null
   if (wordBoundaryEndOk(view, pos)) return pos
   // An optional suffix: one ${chr}? (zero-width, ≤1 boundary) then am/pm or one
   // of x/K/B/T/M, followed by wbe. The suffix letters sit at the clean `pos`.
   if (boundaryCountAt(view, pos) > 1) return null
-  const text = view.text
   // `[AaPp][Mm]` is contiguous in v4 — a boundary between the two letters breaks
   // the suffix.
   if (allowAmPm && /[ap]/i.test(text[pos] ?? "") && /m/i.test(text[pos + 1] ?? "") && !view.hasBoundary(pos + 1)) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,6 +34,7 @@ export {
   replaceAllInView,
   type ReplaceAllOptions,
   runLegacyPass,
+  withProseView,
 } from "./prose-view.js"
 export { classifyApostrophes, niceQuotes, PUNCTUATION_STYLES, type PunctuationStyle, type QuoteOptions } from "./quotes.js"
 

--- a/src/prose-view.ts
+++ b/src/prose-view.ts
@@ -247,6 +247,16 @@ function matchContainsBoundary(match: RegExpExecArray, view: ProseView): boolean
   return false
 }
 
+/** Count of node boundaries that fall at exactly `offset` (empty nodes stack). */
+export function boundaryCountAt(view: ProseView, offset: number): number {
+  let count = 0
+  for (const boundary of view.boundaries) {
+    if (boundary === offset) count++
+    else if (boundary > offset) break
+  }
+  return count
+}
+
 export function replaceAllInView(
   view: ProseView,
   regex: RegExp,
@@ -279,6 +289,26 @@ export function replaceAllInView(
 
     view.replace(match.index, match.index + match[0].length, replacement, bind ? { bind } : undefined)
   }
+}
+
+/**
+ * Splits sentinel-marked text on the separator, builds a ProseView over the
+ * fragments, runs `run` against the clean-text view, commits the queued edits,
+ * and rejoins the fragments with the separator. The separator count is
+ * preserved exactly: each fragment maps to one source node, and `commit()`
+ * never creates or destroys node boundaries.
+ */
+export function withProseView(
+  markedText: string,
+  separator: string,
+  run: (view: ProseView) => void,
+): string {
+  const fragments = separator.length > 0 ? markedText.split(separator) : [markedText]
+  const nodes: ProseNode[] = fragments.map((value) => ({ value }))
+  const view = buildProseView(nodes)
+  run(view)
+  view.commit()
+  return nodes.map((node) => node.value).join(separator)
 }
 
 export function runLegacyPass(

--- a/src/quote-classifier.ts
+++ b/src/quote-classifier.ts
@@ -1,5 +1,5 @@
 import { LATIN_LETTERS, TERMINAL_PUNCTUATION, UNICODE_SYMBOLS } from "./constants.js"
-import { buildProseView, type ProseNode, type ProseView } from "./prose-view.js"
+import { type ProseView, withProseView } from "./prose-view.js"
 
 const {
   EM_DASH,
@@ -859,15 +859,6 @@ function queueRenderEdits(view: ProseView, items: Item[], table: Record<QuoteRol
 // ---------------------------------------------------------------------------
 // Public engine entry points
 // ---------------------------------------------------------------------------
-
-function withProseView(markedText: string, separator: string, run: (view: ProseView) => void): string {
-  const fragments = separator.length > 0 ? markedText.split(separator) : [markedText]
-  const nodes: ProseNode[] = fragments.map((value) => ({ value }))
-  const view = buildProseView(nodes)
-  run(view)
-  view.commit()
-  return nodes.map((node) => node.value).join(separator)
-}
 
 /**
  * The quote/apostrophe role classifier: one boundary-aware scan over the

--- a/src/tests/dashes.test.ts
+++ b/src/tests/dashes.test.ts
@@ -694,6 +694,11 @@ describe("phone number preservation", () => {
     ["555-1234", "555-1234", "standalone 3+4 looks phone, preserve"],
     ["555-1,234", `555${EN_DASH}1,234`, "3+4 with thousands comma converts"],
     ["555-1.234", `555${EN_DASH}1.234`, "3+4 with thousands period converts"],
+    // A currency symbol is not part of the range start (v4's `\b` anchors the
+    // start at the digit), so "$100-2000" is the phone-shaped 3+4 and is kept.
+    ["$100-2000", "$100-2000", "currency 3+4 stays phone-shaped"],
+    ["$100--2000", "$100--2000", "currency 3+4 double dash stays"],
+    ["$100-200", `$100${EN_DASH}200`, "currency 3+3 converts"],
     ["1-5", `1${EN_DASH}5`, "simple range"],
     ["1-50", `1${EN_DASH}50`, "range to two digits"],
     ["1-99", `1${EN_DASH}99`, "range to 99"],
@@ -745,6 +750,482 @@ describe("hyphenReplace preserves multi-segment numbers across separators", () =
     ["model name across elements", `${sep}GPT${sep}-3`],
   ])("%s", (_desc, input) => {
     expect(hyphenReplace(input, { separator: sep })).toBe(input)
+  })
+})
+
+describe("ProseView boundary-tolerance edges", () => {
+  // Each v4 `${chr}?` slot tolerates exactly one boundary; two stacked
+  // boundaries (an empty fragment) or a boundary at a non-tolerated position
+  // blocks the match, matching the sentinel-weave behavior byte-for-byte.
+  describe("number range", () => {
+    it.each([
+      // One boundary at the tolerated `${chr}?` slot (start↔dash) converts.
+      ["one boundary before dash", `1${sep}-5`, `1${sep}${EN_DASH}5`],
+      ["one boundary after dash", `1-${sep}5`, `1${EN_DASH}${sep}5`],
+      // Two stacked boundaries at that slot exceed the one-separator budget.
+      ["two stacked boundaries before dash", `1${sep}${sep}-5`, `1${sep}${sep}-5`],
+      // A boundary inside the start digits (no slot there) blocks.
+      ["boundary inside start digits", `1${sep}0-5`, `1${sep}0-5`],
+      // 4+ stacked boundaries push the preceding digit past the word-boundary
+      // reach, so the run after the gap becomes the start and converts.
+      ["four boundaries split the start", `20${sep}${sep}${sep}${sep}00-2020`, `20${sep}${sep}${sep}${sep}00${EN_DASH}2020`],
+      // A boundary inside the end digits truncates it; the trailing word boundary
+      // then blocks the (now phone-shaped-free) range.
+      ["boundary inside end digits", `2000-202${sep}0`, `2000-202${sep}0`],
+      // A separator between a currency symbol and its digit severs the end.
+      ["currency severed from end digit", `€${sep}5-€${sep}10`, `€${sep}5-€${sep}10`],
+      // A boundary inside the last phone segment defeats multi-segment detection,
+      // so the leading pair en-dashes (matching the sentinel-weave behavior).
+      ["boundary in last phone segment", `555-123-45${sep}67`, `555${EN_DASH}123-45${sep}67`],
+      // A multiplier suffix carries one tolerated `${chr}?` slot at its head.
+      ["one boundary before suffix", `1-10${sep}x`, `1${EN_DASH}10${sep}x`],
+      ["boundary inside am/pm suffix", `2-3p${sep}m`, `2-3p${sep}m`],
+    ])("%s", (_desc, input, expected) => {
+      expect(enDashNumberRange(input, { separator: sep })).toBe(expected)
+    })
+  })
+
+  describe("negative range", () => {
+    it.each([
+      ["one boundary at the dash", `${MINUS}5${sep}-2`, `${MINUS}5${sep}${EN_DASH}2`],
+      // A boundary inside the negative start digits severs them from the MINUS.
+      ["boundary inside start digits", `${MINUS}5${sep}0-3`, `${MINUS}5${sep}0-3`],
+      // Multi-segment negatives are preserved (the following resolves non-empty).
+      ["multi-segment preserved", `${MINUS}5-3-7`, `${MINUS}5-3-7`],
+    ])("%s", (_desc, input, expected) => {
+      expect(enDashNumberRange(minusReplace(input, { separator: sep }), { separator: sep })).toBe(expected)
+    })
+  })
+
+  describe("date range", () => {
+    it.each([
+      ["one boundary at the dash", `Jan${sep}-Mar`, `Jan${sep}${EN_DASH}Mar`],
+      ["boundary inside the start month blocks", `Ja${sep}n-Mar`, `Ja${sep}n-Mar`],
+    ])("%s", (_desc, input, expected) => {
+      expect(enDashDateRange(input, { separator: sep })).toBe(expected)
+    })
+  })
+
+  describe("minus sign", () => {
+    it.each([
+      // Two stacked separators put a non-digit/letter before the hyphen, so the
+      // separator-led negative (Pattern 2b) fires; one leaves the digit visible.
+      ["two boundaries promote to negative", `1${sep}${sep}-5`, `1${sep}${sep}${MINUS}5`],
+      ["one boundary keeps the digit context", `1${sep}-5`, `1${sep}-5`],
+    ])("%s", (_desc, input, expected) => {
+      expect(minusReplace(input, { separator: sep })).toBe(expected)
+    })
+  })
+
+  describe("parenthetical em-dash (american)", () => {
+    it.each([
+      // The trailing space after a boundary belongs to the next node — kept.
+      ["space after boundary is preserved", `a -${sep} b`, `a${EM_DASH}${sep} b`],
+      // A separator alone leading the dash run still converts (separator is
+      // non-space, satisfying the lookbehind).
+      ["separator-led dash converts", `word${sep}- rest`, `word${sep}${EM_DASH}rest`],
+    ])("%s", (_desc, input, expected) => {
+      expect(hyphenReplace(input, { separator: sep })).toBe(expected)
+    })
+  })
+
+  describe("spaced math subtraction across boundaries", () => {
+    it.each([
+      // One boundary at `num`'s head (the `${chr}?` slot) is tolerated.
+      ["subtraction-of-negative, boundary at num", `5 - -${sep}3`, `5 ${MINUS} ${MINUS}${sep}3`],
+      ["spaced subtraction, boundary at num", `5 - ${sep}3`, `5 ${MINUS} ${sep}3`],
+      // A boundary at the leading digit (the lookbehind `${chr}?` slot).
+      ["spaced subtraction, boundary after digit", `5${sep} - 3`, `5${sep} ${MINUS} 3`],
+      // A boundary strictly inside the ` - ` prefix breaks the lookbehind span.
+      ["boundary inside the prefix blocks", `5 ${sep}- 3`, `5 ${sep}- 3`],
+    ])("%s", (_desc, input, expected) => {
+      expect(minusReplace(input, { separator: sep })).toBe(expected)
+    })
+  })
+
+  describe("parenthetical em-dash across boundaries", () => {
+    it.each([
+      // A boundary inside the leading spaces restarts the spaced match after it.
+      ["boundary in leading spaces", `a${sep} - b`, `a${sep}${EM_DASH}b`],
+      // A boundary inside a hyphen run truncates it (the run stays ≥2 / single).
+      ["boundary truncates trailing dashes", `a--${sep}b`, `a${EM_DASH}${sep}b`],
+      ["multiple-dash run, boundary before run", `a${sep}--b`, `a${sep}${EM_DASH}b`],
+      // A separator alone leads the dash run (boundary-led pattern).
+      ["separator-led run at text start", `${sep}- text`, `${sep}${EM_DASH}text`],
+      // The arrow guard tolerates separators around its hyphen run.
+      ["spaced dash before an arrow stays", `x - ->`, `x${EM_DASH}->`],
+      // Trailing-spaces lookahead is satisfied by end-of-text.
+      ["spaced dash at text end", `x -`, `x${EM_DASH}`],
+    ])("%s", (_desc, input, expected) => {
+      expect(hyphenReplace(input, { separator: sep })).toBe(expected)
+    })
+  })
+
+  describe("british unspaced em-dash across boundaries", () => {
+    it.each([
+      // One boundary on the sepBefore side of the em-dash is tolerated.
+      ["boundary before the em-dash", `word${sep}${EM_DASH}word`, `word${sep} ${EN_DASH} word`],
+    ])("%s", (_desc, input, expected) => {
+      expect(hyphenReplace(input, { separator: sep, dashStyle: "british" })).toBe(expected)
+    })
+  })
+
+  describe("line-leading em-dash spacing across boundaries", () => {
+    it.each([
+      // One boundary at the line-start `${chr}?` slot before the em-dash.
+      ["boundary before a line-leading em-dash", `${sep}${EM_DASH}Apple`, `${sep}${EM_DASH} Apple`],
+    ])("%s", (_desc, input, expected) => {
+      expect(hyphenReplace(input, { separator: sep })).toBe(expected)
+    })
+  })
+
+  describe("negative and multi-segment ranges across boundaries", () => {
+    it.each([
+      // A boundary inside the end digits truncates the end; the trailing word
+      // boundary then blocks the range (matching the sentinel weave).
+      ["boundary inside negative end digits", `${MINUS}5-3${sep}0`, `${MINUS}5-3${sep}0`],
+      // Four stacked boundaries split a negative start past the word-boundary
+      // reach, exposing a later sub-range that converts.
+      ["four boundaries expose a sub-range", `${MINUS}5${sep}${sep}${sep}${sep}0-3`, `${MINUS}5${sep}${sep}${sep}${sep}0${EN_DASH}3`],
+      // A multiplier suffix reached only after stacked boundaries still converts.
+      ["stacked boundaries before suffix", `1-2${sep}${sep}${sep}${sep}${sep}x`, `1${EN_DASH}2${sep}${sep}${sep}${sep}${sep}x`],
+    ])("%s", (_desc, input, expected) => {
+      expect(enDashNumberRange(input, { separator: sep })).toBe(expected)
+    })
+  })
+
+  describe("interior boundaries inside dash-run matches", () => {
+    it.each([
+      // A boundary strictly inside the leading-space run of a spaced dash.
+      ["interior boundary in leading spaces", `x${sep} - b`, `x${sep}${EM_DASH}b`],
+      // A boundary strictly inside a hyphen run that would otherwise pair.
+      ["interior boundary splits a dash pair", `a-${sep}-b quote`, `a-${sep}-b quote`],
+      ["interior boundary inside a long dash run", `a--${sep}--b`, `a--${sep}--b`],
+      // A boundary strictly inside a line-leading dash run.
+      ["interior boundary in a line-leading run", `\n-${sep}- x`, `\n-${sep}${EM_DASH}x`],
+      // A spaced en/em dash that is wholly an arrow ("–->"): no backtracked dash
+      // core escapes the arrow guard, so nothing converts.
+      ["spaced en-dash arrow stays", `a ${EN_DASH}->`, `a ${EN_DASH}->`],
+    ])("%s", (_desc, input, expected) => {
+      expect(hyphenReplace(input, { separator: sep })).toBe(expected)
+    })
+
+    // British unspaced em-dash with a boundary on the sepAfter side (interior to
+    // the `${EM_DASH}(?=[letter])` lookahead span in v4's woven form).
+    it("interior boundary after a british em-dash", () => {
+      expect(hyphenReplace(`word${EM_DASH}${sep}word`, { separator: sep, dashStyle: "british" })).toBe(
+        `word ${EN_DASH} ${sep}word`,
+      )
+    })
+
+    // A boundary between a line-leading em-dash and its following uppercase
+    // breaks v4's contiguous `${EM_DASH}[A-Z0-9]`, so no space is inserted.
+    it("interior boundary blocks line-leading em-dash spacing", () => {
+      expect(hyphenReplace(`\n${EM_DASH}${sep}Apple`, { separator: sep })).toBe(`\n${EM_DASH}${sep}Apple`)
+    })
+
+    it.each([
+      // A boundary strictly inside a two-space run before a spaced dash.
+      ["interior boundary in a two-space run", `a ${sep} - b`, `a ${sep}${EM_DASH}b`],
+      // The trailing `(?:${chr} [ ]*)?` consumes one boundary plus its kept
+      // post-boundary spaces; the lookahead is then satisfied by the next word.
+      ["trailing separator with kept spaces", `a - ${sep} b`, `a${EM_DASH}${sep} b`],
+      // The full "---" run is an em-dash candidate whose trailing `\n` fails the
+      // `(?=\S|$)` lookahead at the longest length; the run backtracks to a
+      // shorter dash core that converts, leaving the final hyphen.
+      ["dash run backtracks past a failing trailing lookahead", `a ---\n`, `a${EM_DASH}-\n`],
+    ])("%s", (_desc, input, expected) => {
+      expect(hyphenReplace(input, { separator: sep })).toBe(expected)
+    })
+  })
+
+  describe("range tail and date-range edge offsets", () => {
+    it.each([
+      // A boundary exactly at the date-range match end blocks it (the trailing
+      // word-boundary lookahead sees the separator, not the woven slot).
+      ["boundary at date-range end blocks", `Jan-Mar${sep}x`, `Jan-Mar${sep}x`],
+      // An interior boundary (in the start month) plus a boundary at the match
+      // end: the match still converts and the end boundary stops the interior
+      // scan early.
+      ["interior boundary with end boundary converts", `Jan${sep}-Mar${sep}`, `Jan${sep}${EN_DASH}Mar${sep}`],
+    ])("%s", (_desc, input, expected) => {
+      expect(enDashDateRange(input, { separator: sep })).toBe(expected)
+    })
+
+    it.each([
+      // A trailing letter that is not a valid suffix fails the word-boundary
+      // end for every `following` candidate, so the negative range is left.
+      ["negative range blocked by trailing letter", `${MINUS}5-3a`, `${MINUS}5-3a`],
+      // A valid single-letter suffix (K) does complete the tail and converts.
+      ["negative range with K suffix converts", `${MINUS}5-3K`, `${MINUS}5${EN_DASH}3K`],
+    ])("%s", (_desc, input, expected) => {
+      expect(enDashNumberRange(input, { separator: sep })).toBe(expected)
+    })
+  })
+
+  describe("greedy end backtracks over a trailing decimal", () => {
+    // v4's `wbe` rejects an end run that ends on a `.`/digit transition before a
+    // suffix letter, backtracking the end to the last all-digit run. A bare `\b`
+    // would settle at the `.` and leave the dash unconverted.
+    it.each([
+      ["decimal then suffix run", `${MINUS}5-5.xK`, `${MINUS}5${EN_DASH}5.xK`],
+      ["decimal then single suffix", `${MINUS}5-5.x`, `${MINUS}5${EN_DASH}5.x`],
+      ["decimal value with suffix", `${MINUS}5-5.5K`, `${MINUS}5${EN_DASH}5.5K`],
+    ])("%s", (_desc, input, expected) => {
+      expect(enDashNumberRange(input, { separator: sep })).toBe(expected)
+    })
+  })
+
+  describe("separator-truncated end run in a negative range", () => {
+    // The negative end run stops at the first boundary; separators between the
+    // first end digit and the rest must not fuse into one clean run.
+    it.each([
+      // Four+ stacked boundaries push the trailing digits past the wbe's
+      // separator reach, so the leading single-digit end converts.
+      ["stacked boundaries after the first end digit", `${MINUS}1${sep}-8${sep}${sep}${sep}${sep}${sep}0${sep}0w`, `${MINUS}1${sep}${EN_DASH}8${sep}${sep}${sep}${sep}${sep}0${sep}0w`],
+    ])("%s", (_desc, input, expected) => {
+      expect(enDashNumberRange(input, { separator: sep })).toBe(expected)
+    })
+  })
+
+  describe("phone area code invalidated by a boundary", () => {
+    // A boundary where v4's `rangeStart` would begin (just past a `\d{3}-` area
+    // code) invalidates the area-code reading; the digits become the range start.
+    it.each([
+      ["boundary after the area-code dash", `800-${sep}10-2,000`, `800-${sep}10-2,000`],
+      ["area-code reading falls back to range start", `800-${sep}10---2,000`, `800${EN_DASH}${sep}10---2,000`],
+    ])("%s", (_desc, input, expected) => {
+      expect(enDashNumberRange(input, { separator: sep })).toBe(expected)
+    })
+  })
+
+  describe("direct-negative num truncated by a boundary", () => {
+    // v4's Pattern 2/2b `num` (`\d*\.?\d+`) has no separator slot; it stops at the
+    // first interior boundary and must still form a number.
+    it.each([
+      ["boundary strips the mandatory digit", `-.${sep}1`, `-.${sep}1`],
+      ["boundary right after the hyphen", `-${sep}5`, `-${sep}5`],
+      ["boundary past a valid number converts", `-5${sep}5`, `${MINUS}5${sep}5`],
+    ])("%s", (_desc, input, expected) => {
+      expect(minusReplace(input, { separator: sep })).toBe(expected)
+    })
+  })
+
+  describe("spaced math subtraction num truncated by a boundary", () => {
+    // v4's `num` (`${chr}?\d*\.?\d+`) stops at the first interior boundary; a
+    // boundary that strips its mandatory `\d+` breaks the match, but one that
+    // leaves a valid number keeps it.
+    it.each([
+      ["boundary strips the mandatory digit", `5 - .${sep}5`, `5 - .${sep}5`],
+      ["boundary leaves a valid num", `5 - 12${sep}5`, `5 ${MINUS} 12${sep}5`],
+      ["boundary inside a longer num", `5 - 12${sep}5x`, `5 ${MINUS} 12${sep}5x`],
+      // A boundary exactly at the num end stops the num-body walk via its
+      // `>= numEnd` exit (vs. a boundary strictly inside num, which truncates).
+      ["boundary at the num end", `5 - 3${sep}`, `5 ${MINUS} 3${sep}`],
+      ["boundary strictly inside num", `5 - 3${sep}0`, `5 ${MINUS} 3${sep}0`],
+    ])("%s", (_desc, input, expected) => {
+      expect(minusReplace(input, { separator: sep })).toBe(expected)
+    })
+  })
+
+  // Two stacked separators exceed every single-`${chr}?` weave slot, so each
+  // pattern's boundary guard rejects the match (matching the sentinel weave).
+  describe("two stacked boundaries block each pattern", () => {
+    it.each([
+      // Positive range: two boundaries after the dash run.
+      ["enDashNumberRange", `1-${sep}${sep}5`, `1-${sep}${sep}5`, "american"],
+      // Negative range slots: end head, suffix.
+      ["enDashNumberRange", `${MINUS}5-${sep}${sep}3`, `${MINUS}5-${sep}${sep}3`, "american"],
+      ["enDashNumberRange", `${MINUS}5-3${sep}${sep}K`, `${MINUS}5-3${sep}${sep}K`, "american"],
+      // A `${MINUS}` directly before the negative start blocks (no digit follows).
+      ["enDashNumberRange", `${MINUS}-5-3`, `${MINUS}-5-3`, "american"],
+      // Spaced subtraction slots.
+      ["minusReplace", `5 - -${sep}${sep}3`, `5 - -${sep}${sep}3`, "american"],
+      ["minusReplace", `5${sep}${sep} - 3`, `5${sep}${sep} - 3`, "american"],
+      ["minusReplace", `5 - ${sep}${sep}3`, `5 - ${sep}${sep}3`, "american"],
+      // Spaced dash: two boundaries before the leading spaces / before the dash.
+      ["hyphenReplace", `a ${sep}- b`, `a ${sep}- b`, "american"],
+      // Multiple-dash run: two boundaries on either edge.
+      ["hyphenReplace", `a${sep}${sep}--b`, `a${sep}${sep}--b`, "american"],
+      ["hyphenReplace", `a--${sep}${sep}b`, `a--${sep}${sep}b`, "american"],
+      // British unspaced em-dash: two boundaries on either side.
+      ["hyphenReplace", `word${sep}${sep}${EM_DASH}word`, `word${sep}${sep}${EM_DASH}word`, "british"],
+      ["hyphenReplace", `word${EM_DASH}${sep}${sep}word`, `word${EM_DASH}${sep}${sep}word`, "british"],
+      // Line-leading em-dash spacing: two boundaries before the em-dash.
+      ["hyphenReplace", `${sep}${sep}${EM_DASH}Apple`, `${sep}${sep}${EM_DASH}Apple`, "american"],
+    ])("%s blocks: %s", (fn, input, expected, dashStyle) => {
+      const run = { enDashNumberRange, minusReplace, hyphenReplace }[fn as "hyphenReplace"]
+      expect(run(input, { separator: sep, dashStyle: dashStyle as "american" })).toBe(expected)
+    })
+  })
+
+  // Stacked separators in following/suffix/arrow slots that still resolve to a
+  // converting (or arrow-preserving) match, exercising the boundary-walk paths.
+  describe("stacked boundaries inside tails and dash runs", () => {
+    it.each([
+      // Negative following: two boundaries split the segment, leaving the leading
+      // pair to en-dash.
+      ["enDashNumberRange", `${MINUS}5-3${sep}${sep}-7`, `${MINUS}5${EN_DASH}3${sep}${sep}-7`, "american"],
+      ["enDashNumberRange", `${MINUS}5-3-${sep}${sep}7`, `${MINUS}5${EN_DASH}3-${sep}${sep}7`, "american"],
+      // Spaced math num past two boundaries still converts (boundary outside num).
+      ["minusReplace", `5 - 12${sep}${sep}3`, `5 ${MINUS} 12${sep}${sep}3`, "american"],
+      // Spaced dash with two boundaries in the leading spaces converts after them.
+      ["hyphenReplace", `a${sep}${sep} - b`, `a${sep}${sep}${EM_DASH}b`, "american"],
+      ["hyphenReplace", `a ${sep}${sep}- b`, `a ${sep}${sep}${EM_DASH}b`, "american"],
+      // Arrow guard with two boundaries in / around the hyphen run: the `>` is too
+      // far past the slots, so the dash converts.
+      ["hyphenReplace", `a -${sep}${sep}->`, `a${EM_DASH}${sep}${sep}->`, "american"],
+      ["hyphenReplace", `a - ${sep}${sep}>`, `a${EM_DASH}${sep}${sep}>`, "american"],
+      ["hyphenReplace", `a - -${sep}${sep}>`, `a${EM_DASH}-${sep}${sep}>`, "american"],
+      // A boundary-led dash run followed by another consumes only the first.
+      ["hyphenReplace", `x${sep}- ${sep}- y`, `x${sep}${EM_DASH}${sep}- y`, "american"],
+      // Em-dash spacing: spaces directly around the em-dash are removed.
+      ["hyphenReplace", `a ${EM_DASH} b`, `a${EM_DASH}b`, "american"],
+      ["hyphenReplace", `a${EM_DASH} b`, `a${EM_DASH}b`, "american"],
+    ])("%s: %s", (fn, input, expected, dashStyle) => {
+      const run = { enDashNumberRange, minusReplace, hyphenReplace }[fn as "hyphenReplace"]
+      expect(run(input, { separator: sep, dashStyle: dashStyle as "american" })).toBe(expected)
+    })
+  })
+
+  // Structural variants of the clean (separator-free) paths the golden corpus
+  // does not exercise: am/pm suffixes, currency-led end runs, the parenthesised
+  // area code, and em-dash space removal.
+  describe("clean structural variants", () => {
+    it.each([
+      ["am/pm suffix", `2-3am`, `2${EN_DASH}3am`],
+      ["pm suffix", `9-10pm`, `9${EN_DASH}10pm`],
+      ["uppercase PM suffix", `2-3PM`, `2${EN_DASH}3PM`],
+      ["currency-led end run", `5-$10`, `5${EN_DASH}$10`],
+      ["currency on both sides", `$5-$10`, `$5${EN_DASH}$10`],
+      ["currency end with no digit stays", `5-$x`, `5-$x`],
+      // The parenthesised area code is consumed but the phone number is preserved.
+      ["parenthesised area code phone", `(555) 123-4567`, `(555) 123-4567`],
+      // A non-digit in the parens defeats the area code, so the inner range converts.
+      ["broken parens area code converts inner", `(55a) 1-2`, `(55a) 1${EN_DASH}2`],
+      // A `\d{3}-` area-code candidate whose head is not all digits falls through.
+      ["letter in area-code head", `12a-5`, `12a-5`],
+    ])("%s", (_desc, input, expected) => {
+      expect(enDashNumberRange(input, { separator: sep })).toBe(expected)
+    })
+
+    it.each([
+      // Em-dash with a space on each side: both spaces are removed.
+      ["spaces around em-dash removed", `word ${EM_DASH} word`, `word${EM_DASH}word`],
+      // A line-leading spaced hyphen run with two leading spaces converts.
+      ["two leading spaces before a dash", `a  - b`, `a${EM_DASH}b`],
+      // Two consecutive negatives both convert to the minus sign.
+      ["two negatives in a row", `-5 -6`, `${MINUS}5 ${MINUS}6`],
+    ])("%s", (_desc, input, expected) => {
+      expect(hyphenReplace(input, { separator: sep })).toBe(expected)
+    })
+
+    it("two consecutive negatives via minusReplace", () => {
+      expect(minusReplace(`-5 -6`, { separator: sep })).toBe(`${MINUS}5 ${MINUS}6`)
+    })
+
+    it.each([
+      // The `num` boundary walk reaches a boundary at/after the num end and stops.
+      ["boundary right after the negative num", `-5${sep} -`, `${MINUS}5${sep} -`],
+      ["negative num then trailing boundary", `-5${sep}`, `${MINUS}5${sep}`],
+      // A subtraction whose num is followed by a boundary exits the num-body walk.
+      ["double-dash subtraction then boundary", `1--0${sep}`, `1--0${sep}`],
+    ])("direct negative num run ends before a boundary: %s", (_desc, input, expected) => {
+      expect(minusReplace(input, { separator: sep })).toBe(expected)
+    })
+  })
+
+  // Inputs that flip individual operands of the structural guards (a suffix
+  // letter that is not am/pm, an area-code candidate that fails late, a tail
+  // segment with no digit, currency/end edges) — the branch halves the golden
+  // corpus leaves unevaluated.
+  describe("structural guard branch edges", () => {
+    it.each([
+      // `[ap]` with no following `m`, and an over-long am/pm suffix: both stay.
+      ["a-suffix without m", `2-3a`, `2-3a`],
+      ["am suffix with trailing letter", `2-3amx`, `2-3amx`],
+      ["pm suffix converts", `2-3pm`, `2${EN_DASH}3pm`],
+      // `\d{3}` area-code candidate whose 4th char is not `-`.
+      ["three digits then space", `123 4-5`, `123 4${EN_DASH}5`],
+      ["four-digit start is no area code", `1234-5`, `1234${EN_DASH}5`],
+      // `(` then three digits but no closing `)`.
+      ["open paren without close", `(123-4`, `(123${EN_DASH}4`],
+      ["short paren group", `(12)-3`, `(12)-3`],
+      // Negative range whose end run resolves to no digit.
+      ["negative double dash then letter", `${MINUS}5--x`, `${MINUS}5--x`],
+      ["negative dash then letter", `${MINUS}5-a`, `${MINUS}5-a`],
+      // Negative following segment whose digit slot holds a letter.
+      ["negative following with letter", `${MINUS}5-3-a`, `${MINUS}5${EN_DASH}3-a`],
+      // Currency-led end with no digit / a boundary severing the digit.
+      ["currency end with no digit", `5-$`, `5-$`],
+      ["currency severed from end digit", `5-$${sep}10`, `5-$${sep}10`],
+      // A non-ASCII currency on the end run exercises the currency-end branch.
+      ["euro range converts", `€5-€10`, `€5${EN_DASH}€10`],
+      // A negative range whose `--neg` end run has no digit (a `(`).
+      ["negative neg-dash then non-digit", `${MINUS}5--(.`, `${MINUS}5--(.`],
+      // A negative range whose following segment digit slot is non-numeric.
+      ["negative following non-digit then currency", `${MINUS}2-5--1€`, `${MINUS}2${EN_DASH}5--1€`],
+      // Dash at end-of-string: the end run reads past the end (no currency/digit).
+      ["positive dash at end of string", `5-`, `5-`],
+      ["negative dash at end of string", `${MINUS}5-`, `${MINUS}5-`],
+      // A lone MINUS at end-of-string: the negative scan reads past the end.
+      ["lone minus", `${MINUS}`, `${MINUS}`],
+      ["minus at end of string", `5${MINUS}`, `5${MINUS}`],
+      // A trailing dash with no following digit ends the `following` walk at the end.
+      ["negative trailing dash", `${MINUS}5-3-`, `${MINUS}5${EN_DASH}3-`],
+      ["positive trailing dash", `1-2-`, `1${EN_DASH}2-`],
+    ])("%s", (_desc, input, expected) => {
+      expect(enDashNumberRange(input, { separator: sep })).toBe(expected)
+    })
+
+    it.each([
+      // A negative number with a trailing suffix letter (minusReplace).
+      ["negative with suffix letter", `-5x`, `${MINUS}5x`],
+      // A spaced dash run with two trailing spaces and nothing after (end anchor).
+      ["spaced dash with two trailing spaces", `a -  `, `a${EM_DASH}`],
+      // A spaced dash directly after a non-word, non-space char.
+      ["spaced dash after a paren", `${MINUS}) -  `, `${MINUS})${EM_DASH}`],
+      // A line-leading single hyphen before a word char (suspended hyphen): the
+      // leading spaces are consumed but the dash core rejects, so nothing changes.
+      ["leading spaces then suspended hyphen", `  -x`, `  -x`],
+      // Two leading spaces at the start of text before a spaced dash.
+      ["two leading spaces at text start", `  - b`, `${EM_DASH}b`],
+      // A word char then two spaces before the dash.
+      ["word then two spaces before dash", `x  - b`, `x${EM_DASH}b`],
+      // A spaced dash whose single trailing separator is followed by a hyphen.
+      ["spaced dash with trailing separator", `a - ${sep}-`, `a${EM_DASH}${sep}-`],
+      // A hyphen in the arrow run with two boundaries at the second `${chr}?` slot.
+      ["arrow hyphen with two trailing boundaries", `a --${sep}${sep}>`, `a${EM_DASH}-${sep}${sep}>`],
+      // Two stacked leading spaces / a boundary inside them restart the match.
+      ["boundary then two leading spaces", `a${sep}  - b`, `a${sep}${EM_DASH}b`],
+      ["leading space, boundary, space", ` ${sep} - b`, ` ${sep}${EM_DASH}b`],
+      // A trailing separator with kept spaces then a second boundary.
+      ["trailing separators with kept spaces", `a - ${sep}  ${sep}b`, `a${EM_DASH}${sep}  ${sep}b`],
+      // Arrow guard with three boundaries (no hyphens) past the slots converts.
+      ["three boundaries before arrow gt", `a - ${sep}${sep}${sep}>`, `a${EM_DASH}${sep}${sep}${sep}>`],
+      // An arrow guard split so the `>` becomes its own spaced dash candidate.
+      ["boundary-split arrow becomes dash", `a -${sep}${sep}- >`, `a${EM_DASH}${sep}${sep}${EM_DASH}>`],
+      // A boundary-led run overlapping a following boundary-led run.
+      ["overlapping boundary-led runs", `x${sep}-- ${sep}- y`, `x${sep}${EM_DASH}${sep}- y`],
+      // An em-dash with a space only on its left.
+      ["space only left of em-dash", `word ${EM_DASH}word`, `word${EM_DASH}word`],
+      // Arrow guard: a boundary inside the trailing hyphen run defeats the arrow.
+      ["boundary inside arrow hyphen run", ` ---${sep}->  Jana`, `${EM_DASH}-${sep}->  Jana`],
+      // Arrow guard with no hyphens and three boundaries before `>` (over budget).
+      ["three boundaries before arrow", `(${EM_DASH}3  ${EM_DASH}${sep}${sep}${sep}`, `(${EM_DASH}3${EM_DASH}${sep}${sep}${sep}`],
+      // Two boundaries after a hyphen in the arrow run defeat the second slot.
+      ["two boundaries after arrow hyphen", `a - -${sep}${sep}>`, `a${EM_DASH}-${sep}${sep}>`],
+      // A line-leading em-dash followed by an arrow keeps its single space removal.
+      ["em-dash run before arrow at start", `555  ${EM_DASH}->Marx`, `555${EM_DASH}->Marx`],
+    ])("%s", (_desc, input, expected) => {
+      expect(hyphenReplace(input, { separator: sep })).toBe(expected)
+    })
+
+    it("overlapping boundary-led runs (british)", () => {
+      expect(hyphenReplace(`a---.${sep}${sep}-- - word`, { separator: sep, dashStyle: "british" })).toBe(
+        `a---.${sep}${sep} ${EN_DASH} ${EN_DASH} word`,
+      )
+    })
   })
 })
 

--- a/src/tests/prose-view.test.ts
+++ b/src/tests/prose-view.test.ts
@@ -1,4 +1,5 @@
 import {
+  boundaryCountAt,
   buildProseView,
   type ProseNode,
   type ProseView,
@@ -363,5 +364,21 @@ describe("runLegacyPass", () => {
     const view = buildProseView(nodes("a", "b"))
     view.replace(0, 1, "X")
     expect(() => runLegacyPass(view, (m) => m)).toThrow(/uncommitted/)
+  })
+})
+
+describe("boundaryCountAt", () => {
+  // "ab" | "" | "cd" | "e": boundaries at 2 (doubled by the empty node) and 4.
+  const view = buildProseView([{ value: "ab" }, { value: "" }, { value: "cd" }, { value: "e" }])
+
+  it.each([
+    [0, 0],
+    [1, 0],
+    [2, 2],
+    [3, 0],
+    [4, 1],
+    [5, 0],
+  ])("offset %d has %d boundaries", (offset, expected) => {
+    expect(boundaryCountAt(view, offset)).toBe(expected)
   })
 })


### PR DESCRIPTION
Stage 4 of the v5 rollout (tracking: #219), stacked on #222. Migrates all dash passes (`hyphenReplace`, `enDashNumberRange`, `enDashDateRange`, `minusReplace`) off the v4 sentinel-separator weaves onto the ProseView layer, byte-identical to v4 with public contracts unchanged. `dashWordJoiner` needed no migration (v4 had no weave there).

## How
Each v4 `${escapedSep}?` weave position becomes an explicit boundary-tolerance decision: passes run over clean view text via `replaceAllInView`, and per-pattern `allowBoundaries`/hand-scan checks admit exactly ONE node boundary at exactly the positions where v4 carried a weave (two stacked boundaries block, matching v4's single optional sentinel). Sub-pass sequencing inside `hyphenReplace` is preserved with a commit between sub-passes.

Also extracts the shared `withProseView(markedText, separator, run)` split/rejoin helper into `prose-view.ts` (quote-classifier refactored onto it; the nbsp/symbols stages adopt it next) and promotes `boundaryCountAt` to `prose-view.ts` alongside `hasBoundary`. Deletes the now-dead `wordBoundaryStart` from constants.ts.

## Verification
- Differential fuzz vs the saved v4 build: **7.4M comparisons, 0 mismatches** (golden inputs + dash-dense randoms — ranges, dates, phones, toll-free, currency, model names, scientific notation — × both dashStyles × separator placements incl. empty fragments).
- Full suite green at 100% coverage; golden corpus untouched; `benchmark --min-passes 150`: 150/151, failing set unchanged.
- New parametrized boundary tests pin the tolerance map (one boundary at a slot converts; two block; wrong position blocks).

https://claude.ai/code/session_01JurYodPWZhfCQ2FoJ2Ek22

---
_Generated by [Claude Code](https://claude.ai/code/session_01JurYodPWZhfCQ2FoJ2Ek22)_