### PR TITLE
refactor(symbols): run symbol passes over ProseView instead of sentinel weaves

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,7 +1,4 @@
-import escapeStringRegexp from "escape-string-regexp"
 import QuickLRU from "quick-lru"
-
-export { escapeStringRegexp }
 
 export const UNICODE_SYMBOLS = {
   ELLIPSIS: "\u2026",
@@ -115,41 +112,9 @@ export const LATIN_LETTERS = "A-Za-z\\u00C0-\\u00D6\\u00D8-\\u00F6\\u00F8-\\u00F
  * internals, PDF-to-text output, and icon fonts that repurpose U+E000.
  */
 export const DEFAULT_SEPARATOR = "\uE000\uE001"
-const ESCAPED_DEFAULT_SEPARATOR = escapeStringRegexp(DEFAULT_SEPARATOR)
-
-/**
- * Regex-escaped separator wrapped in `(?:...)` so quantifiers apply to
- * the entire multi-character sequence.
- */
-export function getEscapedSeparator(options: { separator?: string }): string {
-  const escaped = options.separator
-    ? escapeStringRegexp(options.separator)
-    : ESCAPED_DEFAULT_SEPARATOR
-  return `(?:${escaped})`
-}
 
 /** Regex-special characters, used for testing separator escaping. */
 export const REGEX_SPECIAL_CHARS = [".", "*", "+", "?", "^", "$", "[", "]", "\\", "|", "(", ")"] as const
-
-/**
- * Maximum stack of adjacent separator markers tolerated in the boundary
- * lookarounds. Three covers any realistic depth of nested HTML element
- * boundaries; the bound also keeps the variable-width lookbehind in a
- * range that static ReDoS analyzers can prove safe.
- */
-const MAX_BOUNDARY_SEPARATORS = 3
-
-/**
- * Marker-aware word boundary pattern for the END of a match.
- *
- * Standard `\b` can create false boundaries when separator markers appear
- * between word characters (e.g., `ReLU\uE000x` has a false `\b` after `U`).
- * This pattern rejects matches followed by up to `MAX_BOUNDARY_SEPARATORS`
- * markers and then a word character.
- */
-export function wordBoundaryEnd(escapedSeparator: string): string {
-  return `\\b(?!${escapedSeparator}{0,${MAX_BOUNDARY_SEPARATORS}}\\w)`
-}
 
 /** Space chars for regex `[...]`: regular space, tab, NBSP, NNBSP. */
 export const SPACE_CHARS = ` \t${UNICODE_SYMBOLS.NBSP}${UNICODE_SYMBOLS.NNBSP}`

--- a/src/dashes.ts
+++ b/src/dashes.ts
@@ -12,7 +12,7 @@ export interface DashOptions {
   dashStyle?: DashStyle
 }
 
-const { EN_DASH, EM_DASH, MINUS, MULTIPLICATION, PLUS_MINUS, LEFT_DOUBLE_QUOTE, RIGHT_DOUBLE_QUOTE, LEFT_SINGLE_QUOTE, RIGHT_SINGLE_QUOTE } = UNICODE_SYMBOLS
+const { EN_DASH, EM_DASH, MINUS, MULTIPLICATION, PLUS_MINUS, SUPERSCRIPT_ST, SUPERSCRIPT_ND, SUPERSCRIPT_RD, SUPERSCRIPT_TH, LEFT_DOUBLE_QUOTE, RIGHT_DOUBLE_QUOTE, LEFT_SINGLE_QUOTE, RIGHT_SINGLE_QUOTE } = UNICODE_SYMBOLS
 
 // Prevents false-positive ranges in model names like "Llama-2-7B".
 export const numberRangeDisallowedPrefixes = ["-", EN_DASH, EM_DASH, MINUS] as const
@@ -452,17 +452,33 @@ function followingCandidates(view: ProseView, endSpanEnd: number, allowMinus: bo
   return candidates
 }
 
+// First characters of the four superscript ordinal pairs. \w does not match these
+// Unicode chars, so wordBoundaryEndOk treats them as non-word — but they carry the
+// same blocking semantics as the plain letters they render (st/nd/rd/th).
+const SUPERSCRIPT_ORDINAL_FIRST_RE = new RegExp(
+  `[${SUPERSCRIPT_ST[0]}${SUPERSCRIPT_ND[0]}${SUPERSCRIPT_RD[0]}${SUPERSCRIPT_TH[0]}]`,
+)
+
 /**
  * v4's `(?<suffix>${chr}?(?:[AaPp][Mm]|[xKBTM]))?${wbe}` at `pos`. Returns the
  * end offset after the optional suffix when the tail completes (wbe passes), or
- * null when it does not.
+ * null when it does not. Two non-`\w` glyphs the v5 symbol passes emit
+ * (superscript ordinals, `×`) abut the digit run and must block conversion even
+ * though `wbe` would read them as a clean word boundary; both return null first.
  */
 function suffixWbeEnd(view: ProseView, pos: number, allowAmPm: boolean): number | null {
+  const text = view.text
+  // A superscript ordinal immediately following the digit run blocks conversion:
+  // `52ⁿᵈ` is an ordinal, not a range endpoint (same semantics as `52nd`).
+  if (SUPERSCRIPT_ORDINAL_FIRST_RE.test(text[pos] ?? "")) return null
+  // `×` (MULTIPLICATION) is the Unicode form of `x` produced by the symbols pass.
+  // It is non-\w so wordBoundaryEndOk would treat it as a clean boundary, but
+  // `55×5` is multiplication, not a range endpoint — block the same as `52nd`.
+  if (text[pos] === MULTIPLICATION) return null
   if (wordBoundaryEndOk(view, pos)) return pos
   // An optional suffix: one ${chr}? (zero-width, ≤1 boundary) then am/pm or one
   // of x/K/B/T/M, followed by wbe. The suffix letters sit at the clean `pos`.
   if (boundaryCountAt(view, pos) > 1) return null
-  const text = view.text
   // `[AaPp][Mm]` is contiguous in v4 — a boundary between the two letters breaks
   // the suffix.
   if (allowAmPm && /[ap]/i.test(text[pos] ?? "") && /m/i.test(text[pos + 1] ?? "") && !view.hasBoundary(pos + 1)) {

--- a/src/symbols.ts
+++ b/src/symbols.ts
@@ -1,9 +1,9 @@
-import { cachedRegExp, DEFAULT_SEPARATOR, getEscapedSeparator, LATIN_LETTERS, SPACE_CHARS, UNICODE_SYMBOLS, wordBoundaryEnd } from "./constants.js"
+import { cachedRegExp, DEFAULT_SEPARATOR, LATIN_LETTERS, SPACE_CHARS, UNICODE_SYMBOLS } from "./constants.js"
+import { boundaryCountAt, type ProseView, replaceAllInView, withProseView } from "./prose-view.js"
 import { convertPrimeMarks } from "./quote-classifier.js"
-import { namedGroups } from "./utils.js"
 
 export interface SymbolOptions {
-  /** Boundary marker for HTML element boundaries. Default: "\uE000\uE001" */
+  /** Boundary marker for HTML element boundaries. Default: "" */
   separator?: string
   /** Include arrow transforms (-> → →). Default: true */
   includeArrows?: boolean
@@ -36,134 +36,420 @@ const {
   EXCLAMATION_QUESTION,
 } = UNICODE_SYMBOLS
 
+const LATIN_LETTER_RE = new RegExp(`[${LATIN_LETTERS}]`)
+const WORD_RE = /\w/
+
 /** Convert "..." or ". . ." to "…". */
 export function ellipsis(text: string, options: SymbolOptions = {}): string {
-  const chr = getEscapedSeparator(options)
-
-  // Convert consecutive or spaced dots: ... or . . . → …
-  // Each gap allows EITHER a space (same-text-node spaced dots) OR a separator
-  // (cross-boundary contiguous dots), but never both — a space adjacent to a
-  // separator means the dots straddle a text-node boundary and shouldn't fold
-  // into one ellipsis.
-  const pattern = cachedRegExp(`\\.(?:[${SPACE_CHARS}]|(?<sep1>${chr}))?\\.(?:[${SPACE_CHARS}]?|(?<sep2>${chr})?)\\.`, "g")
-  text = text.replace(pattern, (...args) => {
-    const { sep1, sep2 } = namedGroups<{ sep1?: string; sep2?: string }>(args)
-    return ELLIPSIS + (sep1 ?? "") + (sep2 ?? "")
-  })
-
-  text = text.replace(cachedRegExp(`${ELLIPSIS}(?=[${LATIN_LETTERS}\\d])`, "gu"), `${ELLIPSIS} `)
-
-  return text
+  return withProseView(text, options.separator ?? DEFAULT_SEPARATOR, ellipsisOverView)
 }
+
+const SPACE_CHAR_RE = new RegExp(`[${SPACE_CHARS}]`)
+
+function ellipsisOverView(view: ProseView): void {
+  ellipsisFoldDots(view)
+  view.commit()
+
+  // A space is inserted only when a letter or digit directly follows the
+  // ellipsis. v4's lookahead `(?=[A-Za-z…\d])` saw the sentinel as an ordinary
+  // non-letter, so a node boundary between the ellipsis and the letter blocks
+  // the space; re-check the boundary at the lookahead position.
+  const trailing = cachedRegExp(`${ELLIPSIS}(?=[${LATIN_LETTERS}\\d])`, "gu")
+  replaceAllInView(view, trailing, (match, v) => {
+    if (v.hasBoundary(match.index + match[0].length)) return null
+    return `${ELLIPSIS} `
+  })
+  view.commit()
+}
+
+/**
+ * Offset of the dot following one inter-dot gap that begins at `afterDot`, or
+ * -1 when no dot is reachable. v4's gap was `(?:[space]|sep)?` /
+ * `(?:[space]?|sep?)?`: nothing, one space character, or one node boundary —
+ * never two and never a space-plus-boundary mix. A dot is reachable only when
+ * no unconsumed boundary shadows it (the sentinel `\.` could not cross one).
+ */
+function ellipsisNextDot(view: ProseView, text: string, afterDot: number): number {
+  const boundariesHere = boundaryCountAt(view, afterDot)
+  if (text[afterDot] === ".") {
+    // Empty gap (no boundary) or a single-boundary gap consuming exactly one.
+    return boundariesHere <= 1 ? afterDot : -1
+  }
+  // Space gap: one space character with no boundary, then a non-shadowed dot.
+  if (boundariesHere === 0 && text[afterDot] !== undefined && SPACE_CHAR_RE.test(text[afterDot])) {
+    const dot = afterDot + 1
+    if (text[dot] === "." && boundaryCountAt(view, dot) === 0) return dot
+  }
+  return -1
+}
+
+/**
+ * Fold `...`, `. . .`, and the cross-boundary variants into `…`, scanning
+ * left-to-right so a blocked leftmost triple still lets the next valid triple
+ * fold (v4's marked regex re-matched past a blocking sentinel). Each fold
+ * replaces the whole `. gap . gap .` span with `…`; interior boundaries
+ * collapse after the ellipsis, matching v4's `… ${sep1}${sep2}` re-emission.
+ */
+function ellipsisFoldDots(view: ProseView): void {
+  const text = view.text
+  let i = 0
+  while (i < text.length) {
+    if (text[i] !== ".") { i++; continue }
+    const secondDot = ellipsisNextDot(view, text, i + 1)
+    if (secondDot < 0) { i++; continue }
+    const thirdDot = ellipsisNextDot(view, text, secondDot + 1)
+    if (thirdDot < 0) { i++; continue }
+    view.replace(i, thirdDot + 1, ELLIPSIS)
+    i = thirdDot + 1
+  }
+}
+
 
 /** Convert "5x5" to "5×5". Skips hex (0x5F). */
 export function multiplication(text: string, options: SymbolOptions = {}): string {
-  const chr = getEscapedSeparator(options)
-
-  // After a digit run, either a prime mark (10′) or a length/size unit may
-  // attach before the multiplication operator. Allowing both lets dimensions
-  // like "5m × 5m", "210mm × 297mm", or "1920px × 1080px" convert, matching
-  // Chicago §9.17's preference for × in dimension notation.
-  //
-  // Only length/size units that plausibly appear in two-dimensional
-  // dimensions are listed — mass/time/electrical units (kg, min, V, …) don't
-  // participate in "N × N" constructions and excluding them avoids false
-  // matches on words ending in those letters.
-  const dimensionUnits = "rem|vh|vw|km|cm|mm|nm|pm|mi|ft|yd|in|px|pt|em|m"
-  // Word-boundary lookahead: the unit must be followed by whitespace, a
-  // separator marker, the multiplication operator, end-of-string, or
-  // sentence punctuation — never another letter (which would mean the
-  // "unit" is actually a word prefix like "mold").
-  const unitBoundary = `(?=\\s|${chr}|[xX*.,;!?)}]|$)`
-  const unitAlt = `(?:\\s|${chr})?(?:${dimensionUnits})${unitBoundary}`
-  const primeAlt = `${chr}?[${PRIME}${DOUBLE_PRIME}]`
-  const digitSuffix = `(?:${primeAlt}|${unitAlt})?`
-
-  // Match entire multiplication chains in one pass: "5 x 5 x 5" or "5x5x5"
-  // Pattern matches: digit(s), then one or more (operator, digit(s)) groups
-  // The (?<!\d[eE]) lookbehind prevents matching inside ambiguous unsigned
-  // scientific notation (1e5x3 — could also be a model SKU). Signed exponents
-  // (1e-5x3, 3.5E+10x2) are unambiguously scientific so the multiplication
-  // is converted. The Latin-letter lookbehind blocks model-name identifiers
-  // (Surface5x3, RTX3060x2).
-  const chainPattern = cachedRegExp(
-    `(?<!\\d[eE])(?<![${LATIN_LETTERS}\\d])(?<firstNum>\\d+${digitSuffix})(?<rest>(?:${chr}?\\s*[xX*]\\s*${chr}?\\d+${digitSuffix})+)`,
-    "g"
-  )
-
-  text = text.replace(chainPattern, (...args) => {
-    const { firstNum, rest } = namedGroups<{ firstNum: string; rest: string }>(args)
-    // Skip hexadecimal: 0x... or 0X...
-    if (firstNum === "0" && /^x/i.test(rest)) return args[0] as string
-
-    // Replace each "operator + next digit group" segment in lockstep.
-    // Consuming the digit-suffix as part of each segment keeps the inner
-    // replace from misreading the `x` inside a trailing unit like `px` as
-    // another operator.
-    // Sticky flag (`y`) anchors each segment at the previous one's end.
-    // `rest` always starts with a chain segment from the outer match, so
-    // the engine never tries multiple start positions across whitespace.
-    const converted = rest.replace(
-      cachedRegExp(
-        `(?<pre>${chr}?)(?<spaceBefore>\\s*)[xX*](?<spaceAfter>\\s*)(?<post>${chr}?)(?<num>\\d+${digitSuffix})`,
-        "gy"
-      ),
-      (...innerArgs) => {
-        const groups = namedGroups<{
-          pre: string
-          spaceBefore: string
-          spaceAfter: string
-          post: string
-          num: string
-        }>(innerArgs)
-        const space = groups.spaceBefore || groups.spaceAfter ? " " : ""
-        return `${groups.pre}${space}${MULTIPLICATION}${space}${groups.post}${groups.num}`
-      }
-    )
-    return `${firstNum}${converted}`
-  })
-
-  // Trailing multiplier: 5x (followed by word boundary - space, punctuation, etc.)
-  const wbe = wordBoundaryEnd(chr)
-  const trailingPattern = cachedRegExp(`(?<!\\d[eE])(?<![${LATIN_LETTERS}\\d])(?<num>\\d+${chr}?)[xX*]${wbe}`, "g")
-  text = text.replace(trailingPattern, (match, num: string) => {
-    // Skip if this looks like start of hexadecimal
-    if (num === "0") return match
-    return `${num}${MULTIPLICATION}`
-  })
-
-  return text
+  return withProseView(text, options.separator ?? DEFAULT_SEPARATOR, multiplicationOverView)
 }
 
-type MathLookaheadBuilder = (escapedSeparator: string) => string
+// After a digit run, either a prime mark (10′) or a length/size unit may
+// attach before the multiplication operator. Allowing both lets dimensions
+// like "5m × 5m", "210mm × 297mm", or "1920px × 1080px" convert, matching
+// Chicago §9.17's preference for × in dimension notation.
+//
+// Only length/size units that plausibly appear in two-dimensional dimensions
+// are listed — mass/time/electrical units (kg, min, V, …) don't participate in
+// "N × N" constructions and excluding them avoids false matches on words
+// ending in those letters.
+const DIMENSION_UNITS = "rem|vh|vw|km|cm|mm|nm|pm|mi|ft|yd|in|px|pt|em|m"
+// Word-boundary lookahead: the unit must be followed by whitespace, the
+// multiplication operator, end-of-string, or sentence punctuation — never
+// another letter (which would mean the "unit" is actually a word prefix like
+// "mold"). v4 also accepted a separator here; over clean text a node boundary
+// directly after the unit is permitted by allowBoundaries, so it is dropped
+// from the literal lookahead.
+const UNIT_BOUNDARY = `(?=\\s|[xX*.,;!?)}]|$)`
+const UNIT_ALT = `\\s?(?:${DIMENSION_UNITS})${UNIT_BOUNDARY}`
+const PRIME_ALT = `[${PRIME}${DOUBLE_PRIME}]`
+const DIGIT_SUFFIX = `(?:${PRIME_ALT}|${UNIT_ALT})?`
 
-type MathSymbolRule = [string, string, MathLookaheadBuilder, string]
+// Match entire multiplication chains in one pass: "5 x 5 x 5" or "5x5x5".
+// Pattern matches: digit(s), then one or more (operator, digit(s)) groups.
+// The (?<!\d[eE]) lookbehind prevents matching inside ambiguous unsigned
+// scientific notation (1e5x3 — could also be a model SKU). Signed exponents
+// (1e-5x3, 3.5E+10x2) are unambiguously scientific so the multiplication is
+// converted. The Latin-letter lookbehind blocks model-name identifiers
+// (Surface5x3, RTX3060x2).
+const MULTIPLICATION_CHAIN = `(?<firstNum>\\d+${DIGIT_SUFFIX})(?<rest>(?:\\s*[xX*]\\s*\\d+${DIGIT_SUFFIX})+)`
+const MULTIPLICATION_SEGMENT = `(?<spaceBefore>\\s*)[xX*](?<spaceAfter>\\s*)(?<num>\\d+${DIGIT_SUFFIX})`
+
+/** A `\s*[xX*]\s*\d+suffix` segment located by absolute clean-text offsets. */
+interface ChainSegment {
+  /** Absolute offset of the operator character. */
+  operatorOffset: number
+  /** Absolute offset where the right operand's digits begin. */
+  operandStart: number
+  /** Absolute offset just past the right operand (including any suffix). */
+  operandEnd: number
+  spaceBefore: string
+  spaceAfter: string
+}
+
+/** Locate each operator segment of `rest` (absolute offsets via `chainStart`). */
+function chainSegments(chainStart: number, firstNum: string, rest: string): ChainSegment[] {
+  const segments: ChainSegment[] = []
+  const segmentRe = cachedRegExp(MULTIPLICATION_SEGMENT, "gy")
+  segmentRe.lastIndex = 0
+  let m: RegExpExecArray | null
+  while ((m = segmentRe.exec(rest)) !== null) {
+    const groups = m.groups as { spaceBefore: string; spaceAfter: string; num: string }
+    const operatorAbs = chainStart + firstNum.length + m.index + groups.spaceBefore.length
+    segments.push({
+      operatorOffset: operatorAbs,
+      operandStart: operatorAbs + 1 + groups.spaceAfter.length,
+      operandEnd: chainStart + firstNum.length + m.index + m[0].length,
+      spaceBefore: groups.spaceBefore,
+      spaceAfter: groups.spaceAfter,
+    })
+  }
+  return segments
+}
+
+/**
+ * v4 wove `${chr}?` directly before and after each operator's spacing slot
+ * (`${chr}?\s*[xX*]\s*${chr}?`): one node boundary tolerated at each outer edge,
+ * none inside the spacing, and a second adjacent boundary broke the segment.
+ * The operator's slot is the span [slotStart, slotEnd) covering its surrounding
+ * spaces and the operator itself.
+ */
+function operatorSlotClean(view: ProseView, slotStart: number, slotEnd: number): boolean {
+  // No boundary strictly inside the spacing-plus-operator slot.
+  for (const boundary of view.boundaries) {
+    if (boundary > slotStart && boundary < slotEnd) return false
+  }
+  // At most one boundary hugging each outer edge (duplicates at an offset come
+  // from empty nodes and each counts as one sentinel).
+  return boundaryCountAt(view, slotStart) <= 1 && boundaryCountAt(view, slotEnd) <= 1
+}
+
+/**
+ * The chain's leading lookbehinds at `operandStart`. v4 wove
+ * `(?<!\d[eE])(?<![A-Za-z…\d])`; the Latin-letter arm already rejects any
+ * operand preceded by `e`/`E`, so the scientific-notation arm adds nothing for
+ * the operand's immediate left character and is folded in here. A node boundary
+ * right before the operand shadows the clean character (a sentinel is not a
+ * letter or digit), satisfying the lookbehind — v4's marked regex re-matched
+ * there.
+ */
+function chainGuardOk(view: ProseView, operandStart: number): boolean {
+  if (view.hasBoundary(operandStart)) return true
+  const prior = view.text[operandStart - 1]
+  return prior === undefined || !(LATIN_LETTER_RE.test(prior) || /\d/.test(prior))
+}
+
+/**
+ * The hex skip `firstNum === "0" && /^x/i.test(rest)`, checked in v4's replace
+ * callback after the regex matched: a `0` operand directly followed (no
+ * boundary) by `x`/`X` skips the whole matched chain without re-anchoring.
+ */
+function chainHexBlocked(view: ProseView, operandStart: number, operandText: string): boolean {
+  if (operandText !== "0") return false
+  const after = operandStart + operandText.length
+  // Hex requires `x`/`X` directly after the `0` (a unit between them is not hex).
+  // `after` always indexes the operator/unit reached by the match, so it is in
+  // bounds.
+  return !view.hasBoundary(after) && /x/i.test(view.text[after])
+}
+
+/**
+ * Start offset of the maximal boundary-free digit run ending at `digitsEnd`
+ * (exclusive), not crossing below `lowerBound`. v4's `\d+` stopped at a
+ * sentinel, so a node boundary inside a digit run truncates the operand an
+ * operator actually sees; that truncated run drives the hex and guard checks.
+ */
+function leftDigitRunStart(view: ProseView, text: string, digitsEnd: number, lowerBound: number): number {
+  let start = digitsEnd
+  // A boundary at `digitsEnd` sits between the last digit and the operator and
+  // does not split the run; only boundaries strictly inside the digits do.
+  while (start > lowerBound && /\d/.test(text[start - 1]) && (start === digitsEnd || !view.hasBoundary(start))) start--
+  return start
+}
+
+/**
+ * End offset of the digit run of the left operand whose operator spacing slot
+ * begins at `slotStart`: walk back over the operand's optional suffix (a prime,
+ * or a unit's letters, possibly with one space) to the last digit.
+ */
+function leftDigitsEnd(text: string, slotStart: number): number {
+  let i = slotStart
+  while (i > 0 && !/\d/.test(text[i - 1])) i--
+  return i
+}
+
+/**
+ * True iff the operand's unit suffix between `digitsEnd` and `slotStart` is not
+ * split by a node boundary. v4's `(?:\s|${chr})?(?:unit)` allowed a single
+ * boundary before the unit but matched the unit's letters contiguously, so a
+ * boundary between two unit letters detaches the operator from the operand.
+ */
+function leftSuffixUnsplit(view: ProseView, text: string, digitsEnd: number, slotStart: number): boolean {
+  // A prime or unit suffix begins after one optional space-or-boundary slot;
+  // a second boundary in that slot (before the suffix) leaves v4's `\d+suffix`
+  // matching only the digits, detaching the operator.
+  if (slotStart > digitsEnd && boundaryCountAt(view, digitsEnd) > 1) return false
+  for (let i = digitsEnd + 1; i < slotStart; i++) {
+    if (LATIN_LETTER_RE.test(text[i - 1]) && LATIN_LETTER_RE.test(text[i]) && view.hasBoundary(i)) return false
+  }
+  return true
+}
+
+/**
+ * True iff a node boundary falls strictly inside the leading digit run of the
+ * operand starting at `operandStart` (v4's `\d+` could not cross a sentinel, so
+ * such a boundary truncates the operand and ends the chain there).
+ */
+function runHasInteriorBoundary(view: ProseView, operandStart: number, operandEnd: number): boolean {
+  const text = view.text
+  let i = operandStart + 1
+  while (i < operandEnd && /\d/.test(text[i])) {
+    if (view.hasBoundary(i)) return true
+    i++
+  }
+  return false
+}
+
+function multiplicationOverView(view: ProseView): void {
+  // The chain is matched with a sticky regex driven by a manual left-to-right
+  // scan. Sticky anchoring keeps the nested `\d+(…\d+)+` quantifier ReDoS-safe
+  // without the leading lookbehinds v4 relied on; dropping those lookbehinds
+  // lets a chain anchor on an operand whose preceding letter/digit is shadowed
+  // by a node boundary (v4's marked regex re-matched there). Boundary-aware
+  // guard/hex/operand checks below reproduce v4's per-operand decisions.
+  const chainPattern = cachedRegExp(MULTIPLICATION_CHAIN, "y")
+  const chainText = view.text
+  let scan = 0
+  while (scan < chainText.length) {
+    chainPattern.lastIndex = scan
+    const match = chainPattern.exec(chainText)
+    if (match === null) { scan++; continue }
+    const { firstNum, rest } = match.groups as { firstNum: string; rest: string }
+    const text = chainText
+    const chainStart = match.index
+    const segments = chainSegments(chainStart, firstNum, rest)
+
+    // Edit each operator's spacing slot in place, leaving the digit operands
+    // (and any node boundaries inside them) untouched so boundary positions are
+    // preserved.
+    //
+    // v4's marked regex matched a contiguous chain, then its replace callback
+    // applied the hex skip. Two outcomes propagate differently:
+    //   - Leading-guard failure lives in the regex, so v4 re-tried the match at
+    //     the next operand: keep retrying each operator until one anchors.
+    //   - Hex skip and a successful anchor consume the matched chain, so no
+    //     operator inside it converts or re-anchors until a STRUCTURAL break (a
+    //     boundary inside an operator's spacing slot or splitting an operand's
+    //     digit run) lets the regex re-match at a later operand.
+    let chainActive = false
+    let anchored = false
+    segments.forEach((segment, index) => {
+      const slotStart = segment.operatorOffset - segment.spaceBefore.length
+      const slotEnd = segment.operatorOffset + 1 + segment.spaceAfter.length
+      const digitsEnd = leftDigitsEnd(text, slotStart)
+      // The left operand's unit suffix must be a contiguous match: a boundary
+      // splitting the unit's letters breaks v4's `\d+suffix`, detaching the
+      // operator from any operand (its left side is no longer `\d+unit`).
+      const slotClean = operatorSlotClean(view, slotStart, slotEnd) && leftSuffixUnsplit(view, text, digitsEnd, slotStart)
+      if (!anchored) {
+        const lowerBound = index === 0 ? chainStart : segments[index - 1].operandStart
+        const runStart = leftDigitRunStart(view, text, digitsEnd, lowerBound)
+        const operand = text.slice(runStart, digitsEnd)
+        if (!chainGuardOk(view, runStart)) {
+          // Regex did not match here; it re-tries at the next operand.
+          chainActive = false
+        } else {
+          anchored = true
+          chainActive = !chainHexBlocked(view, runStart, operand)
+        }
+      }
+      if (!slotClean) {
+        // Structural break: the matched chain ends; the next operand re-anchors.
+        chainActive = false
+        anchored = false
+        return
+      }
+      if (chainActive) {
+        const space = segment.spaceBefore || segment.spaceAfter ? " " : ""
+        view.replace(slotStart, slotEnd, `${space}${MULTIPLICATION}${space}`)
+      }
+      // A boundary inside this operand's digit run truncates it (v4's `\d+`
+      // stopped there): a structural break, so the next operand re-anchors.
+      if (runHasInteriorBoundary(view, segment.operandStart, segment.operandEnd)) {
+        chainActive = false
+        anchored = false
+      }
+    })
+    scan = chainStart + match[0].length
+  }
+  view.commit()
+
+  // Trailing multiplier: 5x (followed by a word boundary). v4's pattern was
+  // `(?<!\d[eE])(?<![A-Za-z…\d])\d+${chr}?[xX*]\b(?!${chr}{0,3}\w)`. The leading
+  // guard, the `${chr}?` before the operator, the hex skip, and the trailing
+  // word boundary are all evaluated against the marked text, so node boundaries
+  // are consulted at exactly those weave positions. `*` never trails because
+  // it is not a word character, so the closing `\b` cannot anchor on it.
+  const trailingPattern = cachedRegExp(`(?<num>\\d+)(?<op>[xX*])`, "y")
+  const trailingText = view.text
+  let trailingScan = 0
+  while (trailingScan < trailingText.length) {
+    trailingPattern.lastIndex = trailingScan
+    const match = trailingPattern.exec(trailingText)
+    if (match === null) { trailingScan++; continue }
+    const num = match.groups!.num
+    const op = match.groups!.op
+    const operatorOffset = match.index + num.length
+    trailingScan = match.index + match[0].length
+    // One optional boundary may sit between the digits and the operator.
+    if (boundaryCountAt(view, operatorOffset) > 1) continue
+    // Leading guard and hex skip, on the boundary-free digit run ending at the
+    // operator (a sentinel inside the digits truncates the operand v4 saw).
+    const runStart = leftDigitRunStart(view, trailingText, operatorOffset, 0)
+    const operand = trailingText.slice(runStart, operatorOffset)
+    if (!chainGuardOk(view, runStart) || chainHexBlocked(view, runStart, operand)) continue
+    // Trailing word boundary `\b(?!${chr}{0,3}\w)`: `*` is not a word character
+    // so it never anchors a trailing `\b`; otherwise reject when a word
+    // character follows the operator through at most three boundaries.
+    if (op === "*") continue
+    const afterOp = operatorOffset + 1
+    const followChar = trailingText[afterOp]
+    if (boundaryCountAt(view, afterOp) <= 3 && followChar !== undefined && WORD_RE.test(followChar)) continue
+    view.replace(operatorOffset, afterOp, MULTIPLICATION)
+  }
+  view.commit()
+}
+
+/** `[left, right, forbiddenFollow, replacement]`; forbiddenFollow is "" when none. */
+type MathSymbolRule = [string, string, string, string]
 
 const MATH_SYMBOL_MAP: MathSymbolRule[] = [
-  ["!", "=", (chr) => `(?!${chr}?=)`, NOT_EQUAL],
-  ["\\+/", "-", () => "", PLUS_MINUS],
-  ["\\+", "-", () => "", PLUS_MINUS],
-  ["<", "=", (chr) => `(?!${chr}?=)`, LESS_EQUAL],
-  [">", "=", (chr) => `(?!${chr}?=)`, GREATER_EQUAL],
-  ["~", "=", () => "", APPROXIMATE],
-  ["=", "~", () => "", APPROXIMATE],
+  ["!", "=", "=", NOT_EQUAL],
+  ["\\+/", "-", "", PLUS_MINUS],
+  ["\\+", "-", "", PLUS_MINUS],
+  ["<", "=", "=", LESS_EQUAL],
+  [">", "=", "=", GREATER_EQUAL],
+  ["~", "=", "", APPROXIMATE],
+  ["=", "~", "", APPROXIMATE],
 ]
 
 /** Convert !=, <=, >=, +/-, ~= to Unicode equivalents. */
 export function mathSymbols(text: string, options: SymbolOptions = {}): string {
-  const chr = getEscapedSeparator(options)
+  return withProseView(text, options.separator ?? DEFAULT_SEPARATOR, mathSymbolsOverView)
+}
 
-  for (const [left, right, lookahead, replacement] of MATH_SYMBOL_MAP) {
-    // Capture an optional separator between left and right so a cross-boundary
-    // match (e.g., `!<SEP>=`) re-emits the separator alongside the replacement
-    // and preserves the text-node-count invariant in transformTextNodes.
-    const pattern = cachedRegExp(`${left}(?<sep>${chr})?${right}${lookahead(chr)}`, "g")
-    text = text.replace(pattern, (...args) => {
-      const { sep } = namedGroups<{ sep?: string }>(args)
-      return `${replacement}${sep ?? ""}`
+function mathSymbolsOverView(view: ProseView): void {
+  for (const [left, right, forbiddenFollow, replacement] of MATH_SYMBOL_MAP) {
+    // Re-read after each rule's commit: prior rules mutate the clean text.
+    const text = view.text
+    // v4 captured an optional separator between left and right so a
+    // cross-boundary match (e.g. `!<SEP>=`) re-emitted the separator. Over
+    // clean text position editing keeps the surrounding fragments (and so the
+    // boundary) intact; allowBoundaries permits the one boundary at the
+    // left/right junction. The negative lookahead `(?!${chr}?=)` is checked
+    // manually because it tolerated one boundary before the forbidden `=`: with
+    // two or more boundaries the `${chr}?` cannot reach the `=`, so the match
+    // is not blocked.
+    const pattern = cachedRegExp(`${left}${right}`, "g")
+    replaceAllInView(view, pattern, (match, v) => {
+      if (forbiddenFollow && mathLookaheadBlocks(text, v, match.index + match[0].length, forbiddenFollow)) {
+        return null
+      }
+      return replacement
+    }, {
+      allowBoundaries: (m, v) => mathOperatorAllowBoundary(m, v),
     })
+    view.commit()
   }
-  return text
+}
+
+/**
+ * v4's `(?!${chr}?=)`: the match is blocked when the forbidden character
+ * follows through at most one boundary. Two or more boundaries put the
+ * character out of the single-`${chr}?` reach, so the match proceeds.
+ */
+function mathLookaheadBlocks(text: string, view: ProseView, end: number, forbidden: string): boolean {
+  return text[end] === forbidden && boundaryCountAt(view, end) <= 1
+}
+
+/**
+ * v4 wove a single `(?<sep>${chr})?` only between the `left` operator string
+ * and the single-character `right`, so the only tolerated interior boundary
+ * sits at that junction (one boundary; the `right` char ends the match). A
+ * boundary inside a multi-character `left` like `+/` broke the operator.
+ */
+function mathOperatorAllowBoundary(match: RegExpExecArray, view: ProseView): boolean {
+  const junction = match.index + match[0].length - 1
+  for (const boundary of view.boundaries) {
+    if (boundary > match.index && boundary < match.index + match[0].length && boundary !== junction) return false
+  }
+  return boundaryCountAt(view, junction) <= 1
 }
 
 type ContextPredicate = (before: string, after: string) => boolean
@@ -179,98 +465,265 @@ const isPathContext = (before: string): boolean => {
 }
 
 function contextAwareLegalReplace(
-  text: string,
+  view: ProseView,
   pattern: RegExp,
   replacement: string,
   shouldConvert: ContextPredicate,
-  separator: string,
-): string {
-  return text.replace(pattern, (match: string, offset: number, str: string) => {
-    const before = str
-      .slice(Math.max(0, offset - LEGAL_SYMBOL_CONTEXT_WINDOW), offset)
-      .replaceAll(separator, "")
-    const after = str
-      .slice(offset + match.length, offset + match.length + LEGAL_SYMBOL_CONTEXT_WINDOW)
-      .replaceAll(separator, "")
-    return shouldConvert(before, after) ? replacement : match
+  separatorLength: number,
+): void {
+  const text = view.text
+  replaceAllInView(view, pattern, (match, v) => {
+    const offset = match.index
+    const before = legalContextBefore(text, v, offset, separatorLength)
+    const after = legalContextAfter(text, v, offset + match[0].length, separatorLength)
+    return shouldConvert(before, after) ? replacement : null
+  }, {
+    // The `(c)`/`(r)`/`(tm)` token itself never spans a boundary in v4 (the
+    // pattern had no separator weave inside it), so a match containing an
+    // interior boundary is skipped, exactly as the default behavior.
+    allowBoundaries: undefined,
   })
 }
 
-const LEGAL_COPYRIGHT_RE = /\(c\)/gi
-const LEGAL_REGISTERED_RE = /\(r\)/gi
-const LEGAL_TRADEMARK_RE = /\(tm\)/gi
+/**
+ * Clean-text context preceding `offset`, spanning v4's 25-character window
+ * measured in MARKED coordinates: each node boundary cost `separatorLength`
+ * marked characters there, so a region dense with boundaries exposes fewer
+ * clean characters of context (v4 sliced the marked string, then stripped the
+ * separators).
+ */
+function legalContextBefore(text: string, view: ProseView, offset: number, separatorLength: number): string {
+  let cost = 0
+  let i = offset
+  while (i > 0) {
+    // Cost of stepping back over this clean char plus the boundaries hugging it.
+    cost += boundaryCountAt(view, i) * separatorLength + 1
+    if (cost > LEGAL_SYMBOL_CONTEXT_WINDOW) break
+    i--
+  }
+  return text.slice(i, offset)
+}
+
+/** Mirror of {@link legalContextBefore} for the text following `end`. */
+function legalContextAfter(text: string, view: ProseView, end: number, separatorLength: number): string {
+  let cost = 0
+  let i = end
+  while (i < text.length) {
+    cost += boundaryCountAt(view, i) * separatorLength + 1
+    if (cost > LEGAL_SYMBOL_CONTEXT_WINDOW) break
+    i++
+  }
+  return text.slice(end, i)
+}
+
+const LEGAL_COPYRIGHT_RE = "\\(c\\)"
+const LEGAL_REGISTERED_RE = "\\(r\\)"
+const LEGAL_TRADEMARK_RE = "\\(tm\\)"
 
 /** Convert (c), (r), (tm) to ©, ®, ™. */
 export function legalSymbols(text: string, options: SymbolOptions = {}): string {
+  // legalSymbols sizes its context window in MARKED coordinates, so the pass
+  // needs the separator's length; close over the separator we resolve here.
   const separator = options.separator ?? DEFAULT_SEPARATOR
-  // (c) → © only with positive copyright evidence (year or "copyright" keyword)
-  // and not in a path context (e.g., example.com/path(c))
-  text = contextAwareLegalReplace(text, LEGAL_COPYRIGHT_RE, COPYRIGHT, (before, after) =>
-    !isPathContext(before) && (/^\s*(?:19|20)\d{2}\b/.test(after) || /\bcopyright\s*$/i.test(before)),
-    separator
-  )
-
-  // (r) → ® unless in enumeration "(q), (r)", legal citation "(r)(1)", or path context
-  text = contextAwareLegalReplace(text, LEGAL_REGISTERED_RE, REGISTERED, (before, after) =>
-    !/\([a-z]\)[,;]\s*$/i.test(before) && !/^\(\d/.test(after) && !isPathContext(before),
-    separator
-  )
-
-  // (tm) → ™ unless in a path context
-  text = contextAwareLegalReplace(text, LEGAL_TRADEMARK_RE, TRADEMARK, (before) =>
-    !isPathContext(before),
-    separator
-  )
-
-  return text
+  return withProseView(text, separator, (view) => legalSymbolsOverView(view, separator.length))
 }
 
-type ArrowPatternBuilder = (escapedSeparator: string) => string
+function legalSymbolsOverView(view: ProseView, separatorLength: number): void {
+  // (c) → © only with positive copyright evidence (year or "copyright"
+  // keyword) and not in a path context (e.g. example.com/path(c)).
+  contextAwareLegalReplace(view, cachedRegExp(LEGAL_COPYRIGHT_RE, "gi"), COPYRIGHT, (before, after) =>
+    !isPathContext(before) && (/^\s*(?:19|20)\d{2}\b/.test(after) || /\bcopyright\s*$/i.test(before)),
+    separatorLength
+  )
+  view.commit()
 
-// Leading `<` on bidi anchors the dash-run group for linear time.
-const ARROW_RULES: readonly [ArrowPatternBuilder, string][] = [
-  [(sep) => `<${sep}?-+(?:${sep}-+)*${sep}?>`, ARROW_LEFT_RIGHT],
-  [(sep) => `-+${sep}?>`, ARROW_RIGHT],
-  [(sep) => `<${sep}?-+`, ARROW_LEFT],
+  // (r) → ® unless in enumeration "(q), (r)", legal citation "(r)(1)", or path context.
+  contextAwareLegalReplace(view, cachedRegExp(LEGAL_REGISTERED_RE, "gi"), REGISTERED, (before, after) =>
+    !/\([a-z]\)[,;]\s*$/i.test(before) && !/^\(\d/.test(after) && !isPathContext(before),
+    separatorLength
+  )
+  view.commit()
+
+  // (tm) → ™ unless in a path context.
+  contextAwareLegalReplace(view, cachedRegExp(LEGAL_TRADEMARK_RE, "gi"), TRADEMARK, (before) =>
+    !isPathContext(before),
+    separatorLength
+  )
+  view.commit()
+}
+
+/** Matches one arrow shape starting at `start`; returns its end offset or -1. */
+type ArrowMatcher = (view: ProseView, text: string, start: number) => number
+
+const SPACE_OR_TAB_RE = /\s/
+
+/**
+ * v4 wove a single `${chr}?` after `<`, between dash runs, and before `>`, and
+ * a boundary could not split a dash run (`-+`). Each helper walks the clean
+ * text and consults boundaries at exactly those weave positions, tolerating at
+ * most one boundary per slot.
+ */
+const ARROW_MATCHERS: readonly [ArrowMatcher, string][] = [
+  [matchLeftRightArrow, ARROW_LEFT_RIGHT],
+  [matchRightArrow, ARROW_RIGHT],
+  [matchLeftArrow, ARROW_LEFT],
 ]
+
+/** Length of a `-+` dash run at `pos` (no boundary may split it); 0 if none. */
+function dashRunLength(view: ProseView, text: string, pos: number): number {
+  let i = pos
+  while (text[i] === "-" && (i === pos || boundaryCountAt(view, i) === 0)) i++
+  return i - pos
+}
+
+/** Skip at most one boundary slot at `pos`; returns the offset after it. -1 on a double boundary. */
+function arrowSepSlot(view: ProseView, pos: number): number {
+  const count = boundaryCountAt(view, pos)
+  return count <= 1 ? pos : -1
+}
+
+/** `-+${sep}?>`: a dash run, an optional boundary, then `>`. */
+function matchRightArrow(view: ProseView, text: string, start: number): number {
+  const run = dashRunLength(view, text, start)
+  if (run === 0) return -1
+  const beforeGt = start + run
+  if (arrowSepSlot(view, beforeGt) < 0) return -1
+  return text[beforeGt] === ">" ? beforeGt + 1 : -1
+}
+
+/** `<${sep}?-+`: `<`, an optional boundary, then a dash run. */
+function matchLeftArrow(view: ProseView, text: string, start: number): number {
+  if (text[start] !== "<") return -1
+  const afterLt = start + 1
+  if (arrowSepSlot(view, afterLt) < 0) return -1
+  const run = dashRunLength(view, text, afterLt)
+  return run === 0 ? -1 : afterLt + run
+}
+
+/** `<${sep}?-+(?:${sep}-+)*${sep}?>`: bidirectional arrow with dash runs. */
+function matchLeftRightArrow(view: ProseView, text: string, start: number): number {
+  if (text[start] !== "<") return -1
+  let i = start + 1
+  if (arrowSepSlot(view, i) < 0) return -1
+  let run = dashRunLength(view, text, i)
+  if (run === 0) return -1
+  i += run
+  // Additional `${sep}-+` runs: each separated by exactly one boundary.
+  while (boundaryCountAt(view, i) === 1) {
+    run = dashRunLength(view, text, i)
+    if (run === 0) break
+    i += run
+  }
+  if (arrowSepSlot(view, i) < 0) return -1
+  return text[i] === ">" ? i + 1 : -1
+}
+
+/** Left context `(^|\s|${chr})`: start of text, a space, or a node boundary. */
+function arrowLeftContextOk(view: ProseView, text: string, start: number): boolean {
+  if (start === 0 || view.hasBoundary(start)) return true
+  return SPACE_OR_TAB_RE.test(text[start - 1])
+}
+
+/** Right context `(?=\s|${chr}|$)`: end of text, a space, or a node boundary. */
+function arrowRightContextOk(view: ProseView, text: string, end: number): boolean {
+  if (end >= text.length || view.hasBoundary(end)) return true
+  return SPACE_OR_TAB_RE.test(text[end])
+}
 
 /** Convert -> and <-> to arrows. */
 export function arrows(text: string, options: SymbolOptions = {}): string {
-  const chr = getEscapedSeparator(options)
-  const sepPattern = cachedRegExp(chr, "g")
-  // Boundary on the left is a capturing group rather than a lookbehind so
-  // the alternation stays out of the assertion (recheck-safe); the captured
-  // boundary char is re-emitted before the replacement.
-  const startBoundary = `(^|\\s|${chr})`
-  const endBoundary = `(?=\\s|${chr}|$)`
+  return withProseView(text, options.separator ?? DEFAULT_SEPARATOR, arrowsOverView)
+}
 
-  for (const [buildArrow, replacement] of ARROW_RULES) {
-    const pattern = cachedRegExp(`${startBoundary}${buildArrow(chr)}${endBoundary}`, "g")
-    // Re-emit every separator the arrow body consumed; dropping any would
-    // break the text-node-count invariant in transformTextNodes.
-    text = text.replace(pattern, (match: string, boundary: string) => {
-      const arrowPart = match.slice(boundary.length)
-      const seps = arrowPart.match(sepPattern) ?? []
-      return `${boundary}${replacement}${seps.join("")}`
-    })
+function arrowsOverView(view: ProseView): void {
+  // Each arrow shape is matched by a left-to-right scan so a boundary that
+  // splits a dash run still lets the valid suffix match (v4's marked regex
+  // re-matched past the sentinel). The whole shape span is replaced with the
+  // arrow; consumed boundaries collapse after it, matching v4's re-emission.
+  for (const [matcher, replacement] of ARROW_MATCHERS) {
+    const text = view.text
+    let i = 0
+    while (i < text.length) {
+      if (!arrowLeftContextOk(view, text, i)) { i++; continue }
+      const end = matcher(view, text, i)
+      if (end < 0 || !arrowRightContextOk(view, text, end)) { i++; continue }
+      view.replace(i, end, replacement)
+      i = end
+    }
+    view.commit()
   }
-
-  return text
 }
 
 export function degrees(text: string, options: SymbolOptions = {}): string {
-  const chr = getEscapedSeparator(options)
+  return withProseView(text, options.separator ?? DEFAULT_SEPARATOR, degreesOverView)
+}
 
-  // Temperature with optional space before C or F (uppercase only)
-  // Handles separator between digit and unit
-  // Uses marker-aware boundary to avoid false matches like "20C\uE000elsius"
-  const wbe = wordBoundaryEnd(chr)
-  // Reject C/F followed by hyphen+letter ("C-compiler"), +/# ("C++", "F#")
-  const notCompound = `(?!-[${LATIN_LETTERS}]|[+#])`
-  return text.replace(
-    cachedRegExp(`(?<num>\\d${chr}?) ?(?<unit>[CF])${notCompound}${wbe}`, "g"),
-    (_, num, unit) => `${num} ${DEGREE}${unit}`
-  )
+function degreesOverView(view: ProseView): void {
+  // Temperature with optional space before C or F (uppercase only). v4 wove a
+  // separator between the digit and the unit (`${chr}?`) and followed the unit
+  // with `(?!-[A-Za-z…]|[+#])` (reject "C-compiler", "C++", "F#") plus a
+  // marker-aware word boundary. Those trailing assertions are checked manually
+  // so a node boundary right after the unit shadows the compound character (as
+  // the sentinel did) and the word-boundary arm sees through up to three
+  // boundaries.
+  const pattern = cachedRegExp(`\\d ?(?<unit>[CF])`, "g")
+  const text = view.text
+  replaceAllInView(view, pattern, (match, v) => {
+    const unitEnd = match.index + match[0].length
+    if (!degreeUnitFollowOk(text, v, unitEnd)) return null
+    const { unit } = match.groups!
+    // Replace everything after the leading digit (the optional space and the
+    // unit) with ` °C`/` °F`, leaving the digit and any boundary right after it
+    // in place so the boundary keeps the position v4 gave it (captured in
+    // `num`).
+    v.replace(match.index + 1, unitEnd, ` ${DEGREE}${unit}`)
+    return null
+  }, {
+    allowBoundaries: (match, v) => digitSuffixBoundaryOk(match, v),
+  })
+  view.commit()
+}
+
+/**
+ * The `(?!-[A-Za-z…]|[+#])` compound guard plus `\b(?!${chr}{0,3}\w)` word
+ * boundary that follow the unit. A node boundary directly after the unit
+ * shadows a `+`/`#`/`-`, satisfying the compound guard; the word boundary
+ * blocks only when a word character follows the unit through at most three
+ * boundaries.
+ */
+function degreeUnitFollowOk(text: string, view: ProseView, unitEnd: number): boolean {
+  const boundaryAfterUnit = view.hasBoundary(unitEnd)
+  // Compound guard: `+`/`#` directly after the unit (no boundary shadowing it),
+  // or `-` directly followed by a Latin letter (boundary-aware).
+  if (!boundaryAfterUnit) {
+    const next = text[unitEnd]
+    if (next === "+" || next === "#") return false
+    if (next === "-" && !view.hasBoundary(unitEnd + 1) && LATIN_LETTER_RE.test(text[unitEnd + 1] ?? "")) return false
+  }
+  // Word boundary: reject when a word character follows the unit across up to
+  // three boundaries (v4's `\b(?!${chr}{0,3}\w)`); with no boundary a word
+  // character directly after the unit also removes the `\b`. Consecutive
+  // boundaries pile at the same clean offset, so count them there.
+  const followChar = text[unitEnd]
+  if (boundaryCountAt(view, unitEnd) <= 3 && followChar !== undefined && WORD_RE.test(followChar)) return false
+  return true
+}
+
+/**
+ * Tolerate at most one boundary directly after the leading digit (the v4
+ * single `${chr}?` between `\d` and the rest); a second adjacent boundary broke
+ * the slot. The digit is the first match character, so the only legal
+ * interior-boundary offset is match.index + 1.
+ */
+function digitSuffixBoundaryOk(match: RegExpExecArray, view: ProseView): boolean {
+  const digitEnd = match.index + 1
+  const matchEnd = match.index + match[0].length
+  for (const boundary of view.boundaries) {
+    // Reject any interior boundary that is not the single tolerated slot after
+    // the leading digit.
+    if (boundary > match.index && boundary < matchEnd && boundary !== digitEnd) return false
+  }
+  return boundaryCountAt(view, digitEnd) <= 1
 }
 
 /** Convert 5'10" to 5′10″ (prime marks). Call before smart quotes. */
@@ -302,32 +755,75 @@ const FRACTION_MAP = Object.fromEntries(FRACTION_TUPLES.map(([n, d, u]) => [`${n
 
 /** Convert 1/2, 1/4, etc. to ½, ¼, etc. Single-pass using alternation. */
 export function fractions(text: string, options: SymbolOptions = {}): string {
-  const chr = getEscapedSeparator(options)
+  return withProseView(text, options.separator ?? DEFAULT_SEPARATOR, fractionsOverView)
+}
 
-  // Build alternation of exact valid pairs: `1${sep}?/${sep}?4|1${sep}?/${sep}?2|...`
-  // Only exact pairs from FRACTION_TUPLES match — no cross-product.
-  const pairAlternation = FRACTION_TUPLES.map(([n, d]) =>
-    `${n}${chr}?/${chr}?${d}`
-  ).join("|")
-
-  // - (?<![/.\d]) prevents matching after slashes, dots, or digits
-  // - (?![/\d]|\.\d) prevents matching before slashes, digits, or decimal points
-  const pattern = cachedRegExp(
-    `(?<![/\\.\\d])(?:${pairAlternation})(?![/\\d]|\\.\\d)`,
-    "g"
-  )
-
-  const sepPattern = cachedRegExp(chr, "g")
-
-  return text.replace(pattern, (match) => {
-    // Split on separator to isolate the raw fraction and preserve markers.
-    // e.g. "1\uE000/\uE0002" → parts ["1", "/", "2"], separators ["\uE000", "\uE000"]
-    const parts = match.split(sepPattern)
-    const raw = parts.join("")
-    const separators = match.match(sepPattern) ?? []
-    // Distribute separators: first goes before the unicode char, second after
-    return `${separators[0] ?? ""}${FRACTION_MAP[raw]}${separators[1] ?? ""}`
+function fractionsOverView(view: ProseView): void {
+  // Build alternation of exact valid pairs: `1/4|1/2|...`. Only exact pairs
+  // from FRACTION_TUPLES match — no cross-product. v4 wove `${chr}?` around the
+  // slash (numerator${chr}?/${chr}?denominator) and surrounded the pair with
+  // bare lookarounds `(?<![/.\d])` and `(?![/\d]|\.\d)`. Over clean text the
+  // lookarounds are checked manually so a node boundary at the numerator's left
+  // edge or the denominator's right edge stands in for the sentinel character
+  // and satisfies them, exactly as the marked lookarounds did.
+  const pairAlternation = FRACTION_TUPLES.map(([n, d]) => `${n}/${d}`).join("|")
+  const pattern = cachedRegExp(`(?:${pairAlternation})`, "g")
+  const text = view.text
+  replaceAllInView(view, pattern, (match, v) => {
+    const start = match.index
+    const end = start + match[0].length
+    if (!fractionLookbehindOk(text, v, start)) return null
+    if (!fractionLookaheadOk(text, v, end)) return null
+    // Distribute interior boundaries: the first lands before the unicode char,
+    // any remaining after it (v4's separators[0]/separators[1] split).
+    let firstBoundary = end
+    for (const boundary of v.boundaries) {
+      if (boundary > start && boundary < end) { firstBoundary = boundary; break }
+    }
+    if (firstBoundary > start) v.replace(start, firstBoundary, "")
+    v.replace(firstBoundary, end, FRACTION_MAP[match[0]])
+    return null
+  }, {
+    allowBoundaries: (match, v) => fractionSlotBoundaryOk(match, v),
   })
+  view.commit()
+}
+
+/**
+ * `(?<![/.\d])` at the numerator's left edge. A node boundary immediately
+ * before the numerator shadows the clean character (the sentinel was not
+ * `/`, `.`, or a digit), so the lookbehind passes.
+ */
+function fractionLookbehindOk(text: string, view: ProseView, start: number): boolean {
+  if (start === 0 || view.hasBoundary(start)) return true
+  return !/[/.\d]/.test(text[start - 1])
+}
+
+/**
+ * `(?![/\d]|\.\d)` at the denominator's right edge. A node boundary immediately
+ * after the denominator shadows the clean characters, satisfying the lookahead.
+ */
+function fractionLookaheadOk(text: string, view: ProseView, end: number): boolean {
+  if (view.hasBoundary(end)) return true
+  const next = text[end]
+  if (next === undefined) return true
+  if (/[/\d]/.test(next)) return false
+  // `\.\d`: a dot directly followed by a digit (a node boundary between them
+  // breaks the pair, so re-test for the boundary).
+  if (next === "." && !view.hasBoundary(end + 1) && /\d/.test(text[end + 1] ?? "")) return false
+  return true
+}
+
+/**
+ * A fraction tolerates one boundary on each side of the slash (v4's two
+ * `${chr}?` slots). The numerator and denominator are single digits, so the
+ * match spans exactly `digit/digit` and the only interior-boundary offsets are
+ * right before the slash (match.index + 1) and right after it (match.index + 2);
+ * each accepts at most one boundary.
+ */
+function fractionSlotBoundaryOk(match: RegExpExecArray, view: ProseView): boolean {
+  const slashOffset = match.index + 1
+  return boundaryCountAt(view, slashOffset) <= 1 && boundaryCountAt(view, slashOffset + 1) <= 1
 }
 
 const ORDINAL_MAP: Record<string, string> = {
@@ -339,21 +835,25 @@ const ORDINAL_MAP: Record<string, string> = {
 
 /** Convert 1st, 2nd, 3rd, 4th to superscript ordinals. */
 export function superscriptOrdinal(text: string, options: SymbolOptions = {}): string {
-  const chr = getEscapedSeparator(options)
+  return withProseView(text, options.separator ?? DEFAULT_SEPARATOR, superscriptOrdinalOverView)
+}
 
-  // Match number + optional separator + ordinal suffix at word boundary
-  // Use case-insensitive matching for the suffix
-  // Uses marker-aware boundary to avoid false matches like "1st\uE000ly"
-  const wbe = wordBoundaryEnd(chr)
-  const pattern = cachedRegExp(
-    `(?<num>\\d${chr}?)(?<suffix>st|nd|rd|th)${wbe}`,
-    "gi"
-  )
-
-  return text.replace(pattern, (_match, num, suffix) => {
-    const superscriptSuffix = ORDINAL_MAP[suffix.toLowerCase()]
-    return num + superscriptSuffix
+function superscriptOrdinalOverView(view: ProseView): void {
+  // Match number + ordinal suffix at word boundary, case-insensitively. v4
+  // tolerated a separator between the digit and the suffix (`${chr}?`) and used
+  // a marker-aware word boundary after the suffix. Only the suffix is replaced,
+  // leaving the digit and any boundary between them untouched so the boundary
+  // keeps its position (v4 re-emitted the captured `num` including its sep).
+  const pattern = cachedRegExp(`(?<num>\\d)(?<suffix>st|nd|rd|th)\\b(?![${LATIN_LETTERS}\\d])`, "gi")
+  replaceAllInView(view, pattern, (match, v) => {
+    const { num, suffix } = match.groups!
+    const suffixStart = match.index + num.length
+    v.replace(suffixStart, match.index + match[0].length, ORDINAL_MAP[suffix.toLowerCase()])
+    return null
+  }, {
+    allowBoundaries: (match, v) => digitSuffixBoundaryOk(match, v),
   })
+  view.commit()
 }
 
 // Preserves highest-priority space type (NBSP > NNBSP > regular) and leading indentation.
@@ -365,34 +865,47 @@ export function collapseSpaces(text: string): string {
   })
 }
 
+/** `[first, repeated, replacement]` with literal punctuation characters. */
 type LigatureRule = [string, string, string]
 
 // Order matters: mixed punctuation first, then repeated.
 const PUNCTUATION_LIGATURE_MAP: LigatureRule[] = [
-  ["\\?", "!", QUESTION_EXCLAMATION],  // ?!+ → ⁈
-  ["!", "\\?", EXCLAMATION_QUESTION],  // !?+ → ⁉
-  ["\\?", "\\?", DOUBLE_QUESTION],     // ??+ → ⁇
-  ["!", "!", "!"],                      // !!+ → ! (normalize)
+  ["?", "!", QUESTION_EXCLAMATION],  // ?!+ → ⁈
+  ["!", "?", EXCLAMATION_QUESTION],  // !?+ → ⁉
+  ["?", "?", DOUBLE_QUESTION],       // ??+ → ⁇
+  ["!", "!", "!"],                   // !!+ → ! (normalize)
 ]
 
 /** Convert ?? to ⁇, ?! to ⁈, !? to ⁉. Disabled by default (poor font support). */
 export function punctuationLigatures(text: string, options: SymbolOptions = {}): string {
-  const chr = getEscapedSeparator(options)
-  const sepPattern = cachedRegExp(chr, "g")
+  return withProseView(text, options.separator ?? DEFAULT_SEPARATOR, punctuationLigaturesOverView)
+}
 
+function punctuationLigaturesOverView(view: ProseView): void {
   for (const [first, repeated, replacement] of PUNCTUATION_LIGATURE_MAP) {
-    const pattern = cachedRegExp(`${first}(?:${chr}?${repeated})+`, "g")
-    // Re-emit every separator that fell inside the match. The repeat group
-    // can swallow more than one (e.g. across 3+ split text nodes), and
-    // dropping any of them breaks transformTextNodes's text-node-count
-    // invariant.
-    text = text.replace(pattern, (match) => {
-      const seps = match.match(sepPattern) ?? []
-      return replacement + seps.join("")
-    })
+    // v4 matched `${first}(?:${chr}?${repeated})+`: the leading char, then one
+    // or more repeated chars each preceded by at most one boundary (a second
+    // adjacent boundary broke the run). A left-to-right scan replaces the whole
+    // run with the ligature; consumed boundaries collapse after it, matching
+    // v4's re-emission, and a broken run re-anchors at the next leading char.
+    const text = view.text
+    let i = 0
+    while (i < text.length) {
+      if (text[i] !== first) { i++; continue }
+      let end = i + 1
+      let consumed = 0
+      for (;;) {
+        const afterSep = arrowSepSlot(view, end)
+        if (afterSep < 0 || text[afterSep] !== repeated) break
+        end = afterSep + 1
+        consumed++
+      }
+      if (consumed === 0) { i++; continue }
+      view.replace(i, end, replacement)
+      i = end
+    }
+    view.commit()
   }
-
-  return text
 }
 
 export function symbolTransform(text: string, options: SymbolOptions = {}): string {

--- a/src/tests/dashes.test.ts
+++ b/src/tests/dashes.test.ts
@@ -358,6 +358,7 @@ describe("enDashNumberRange preserves", () => {
     "2024-01-15", "2024-01", "1999-12", // ISO dates
     "192-168-1-1", "12-34-5678", // IPs
     `5${UNICODE_SYMBOLS.MULTIPLICATION}10-20`, `2${UNICODE_SYMBOLS.MULTIPLICATION}5-10`, // × (from "x") before a range start: a multiplication operand, not a range
+    `1-55${UNICODE_SYMBOLS.MULTIPLICATION}5`, `10-20${UNICODE_SYMBOLS.MULTIPLICATION}3`, // × after a range end: the trailing side
     `${UNICODE_SYMBOLS.PLUS_MINUS}1-5`, // ± (from "+/-") before a range start: not a range
   ])('"%s"', (input) => {
     expect(enDashNumberRange(input)).toBe(input)

--- a/src/tests/index.test.ts
+++ b/src/tests/index.test.ts
@@ -486,6 +486,16 @@ describe("transform", () => {
       expect(second).toBe(first)
     })
 
+    // The superscript pass turns trailing ordinal letters (st/nd/rd/th) into
+    // non-word superscripts, which can flip a range's trailing word boundary.
+    it.each([
+      "5--1st",
+      "items 1-52nd",
+    ])('range abutting a superscript ordinal is idempotent: "%s"', (input) => {
+      const first = transform(input, { superscript: true })
+      expect(transform(first, { superscript: true })).toBe(first)
+    })
+
     it.each([
       `${LEFT_DOUBLE_QUOTE}Hello${RIGHT_DOUBLE_QUOTE}`,
       `word${EM_DASH}word`,

--- a/src/tests/symbols-boundaries.test.ts
+++ b/src/tests/symbols-boundaries.test.ts
@@ -1,0 +1,237 @@
+import {
+  arrows,
+  degrees,
+  ellipsis,
+  fractions,
+  mathSymbols,
+  multiplication,
+  punctuationLigatures,
+  superscriptOrdinal,
+} from "../symbols.js"
+import { legalSymbols } from "../symbols.js"
+import { DEFAULT_SEPARATOR as S, UNICODE_SYMBOLS } from "../constants.js"
+
+const {
+  MULTIPLICATION: X,
+  ELLIPSIS,
+  NOT_EQUAL,
+  LESS_EQUAL,
+  PLUS_MINUS,
+  DEGREE,
+  FRACTION_1_2,
+  FRACTION_1_4,
+  ARROW_RIGHT,
+  ARROW_LEFT,
+  ARROW_LEFT_RIGHT,
+  DOUBLE_QUESTION,
+  SUPERSCRIPT_ND,
+  COPYRIGHT,
+} = UNICODE_SYMBOLS
+
+const opts = { separator: S }
+
+// These exercise the boundary-tolerance paths added when the passes moved onto
+// the ProseView layer: a single node boundary at a v4 weave position is
+// tolerated, two adjacent boundaries (v4's single `${chr}?`) block, and a
+// boundary inside a digit run / unit / lookaround re-derives v4's behavior.
+
+describe("multiplication boundary tolerance", () => {
+  it.each([
+    // Boundary splitting a digit operand keeps the chain v4 saw: 0x stays hex.
+    [`1${S}0x2${S}0x30`, `1${S}0x2${S}0x30`],
+    // Boundary breaks the 0x hex token, so the operator converts.
+    [`0${S}x5F`, `0${S}${X}5F`],
+    [`0${S}x`, `0${S}${X}`],
+    // Boundary shadows the scientific-notation lookbehind (`(?<!\d[eE])`).
+    [`1e${S}5x3`, `1e${S}5${X}3`],
+    // Boundary inside an operand re-anchors the chain at the next operand.
+    [`12x3${S}4x5`, `12${X}3${S}4${X}5`],
+    // Two adjacent boundaries before the operator block the operator slot.
+    [`5${S}${S}x5`, `5${S}${S}x5`],
+    // One boundary after the operator is tolerated.
+    [`10x${S}20x30`, `10${X}${S}20${X}30`],
+    // Two boundaries before a unit suffix detach the operator.
+    [`210${S}${S}mm*1999`, `210${S}${S}mm*1999`],
+    // Two boundaries before a prime suffix detach the operator.
+    [`5${S}${S}″x4th`, `5${S}${S}″x4th`],
+    // Trailing multiplier: one boundary before/after the operator.
+    [`2${S}x`, `2${S}${X}`],
+    [`2x${S}`, `2${X}${S}`],
+    // A word character after the trailing operator (through a boundary) blocks.
+    [`2x${S}a`, `2x${S}a`],
+    // Scientific-notation lookbehind fires with no boundary present.
+    [`1e5x3`, `1e5x3`],
+    // Hex stays hex with no boundary breaking the `0x`.
+    [`0x5`, `0x5`],
+    // A boundary inside a multi-letter unit detaches the operator.
+    [`10c${S}mx3`, `10c${S}mx3`],
+    // A boundary inside the operator's spacing slot blocks conversion.
+    [`5 ${S}x 5`, `5 ${S}x 5`],
+    // Trailing `*` is not a word character, so it never converts.
+    [`5*`, `5*`],
+    // A `0` operand with a unit before the operator is not hex.
+    [`0mm x 5`, `0mm ${X} 5`],
+  ])("converts %j to %j", (input, expected) => {
+    expect(multiplication(input, opts)).toBe(expected)
+  })
+
+  it("accepts an empty separator (no boundaries)", () => {
+    expect(multiplication("5x5", { separator: "" })).toBe(`5${X}5`)
+  })
+})
+
+describe("mathSymbols boundary tolerance", () => {
+  it.each([
+    [`!${S}=`, `${NOT_EQUAL}${S}`],
+    // Two adjacent boundaries between the operator chars block the match.
+    [`!${S}${S}=`, `!${S}${S}=`],
+    // Two boundaries before the forbidden `=` let the lookahead pass.
+    [`<=${S}${S}=`, `${LESS_EQUAL}${S}${S}=`],
+    // A boundary inside the multi-character left `+/` breaks the operator.
+    [`+${S}/-`, `+${S}/-`],
+    [`+/${S}-`, `${PLUS_MINUS}${S}`],
+    // A boundary before the match (outside its span) does not block conversion.
+    [`x${S}!=`, `x${S}${NOT_EQUAL}`],
+  ])("converts %j to %j", (input, expected) => {
+    expect(mathSymbols(input, opts)).toBe(expected)
+  })
+})
+
+describe("degrees boundary tolerance", () => {
+  it.each([
+    // A boundary after the unit shadows the `#` compound guard.
+    [`20C${S}#`, `20 ${DEGREE}C${S}#`],
+    [`20C${S}${S}#`, `20 ${DEGREE}C${S}${S}#`],
+    // A boundary between the digit and the unit is tolerated.
+    [`100${S} C`, `100${S} ${DEGREE}C`],
+    // A boundary between the space and the unit blocks the match.
+    [`100 ${S}C`, `100 ${S}C`],
+    // `C` directly before a hyphen-letter compound is not a temperature.
+    [`20C-x`, `20C-x`],
+    // `C` before a hyphen-digit is still a temperature (not a compound word).
+    [`20C-5`, `20 ${DEGREE}C-5`],
+  ])("converts %j to %j", (input, expected) => {
+    expect(degrees(input, opts)).toBe(expected)
+  })
+})
+
+describe("fractions boundary tolerance", () => {
+  it.each([
+    // A boundary shadows the numerator lookbehind `(?<![/.\d])`.
+    [`3.${S}1/4`, `3.${S}${FRACTION_1_4}`],
+    [`1${S}/2`, `${S}${FRACTION_1_2}`],
+    // Two adjacent boundaries at the slash slot block the fraction.
+    [`1/${S}${S}2`, `1/${S}${S}2`],
+    // A boundary breaks the `\.\d` lookahead, so the fraction converts.
+    [`1/2${S}.5`, `${FRACTION_1_2}${S}.5`],
+    // A boundary strictly inside the numerator (not at the slash) blocks it.
+    // (Multi-digit numerators never match, but a leading boundary is allowed.)
+    [`x${S}1/2`, `x${S}${FRACTION_1_2}`],
+  ])("converts %j to %j", (input, expected) => {
+    expect(fractions(input, opts)).toBe(expected)
+  })
+})
+
+describe("ellipsis boundary tolerance", () => {
+  it.each([
+    [`.${S}..`, `${ELLIPSIS}${S}`],
+    // Two adjacent boundaries in a gap block the fold.
+    [`..${S}${S}.`, `..${S}${S}.`],
+    // A space-plus-boundary gap does not fold.
+    [`. ${S}. .`, `. ${S}. .`],
+    // A boundary after the ellipsis blocks the trailing space.
+    [`...${S}a`, `${ELLIPSIS}${S}a`],
+  ])("converts %j to %j", (input, expected) => {
+    expect(ellipsis(input, opts)).toBe(expected)
+  })
+})
+
+describe("arrows boundary tolerance", () => {
+  it.each([
+    // A boundary splitting the dash run matches only the valid suffix.
+    [`--${S}->`, `--${S}${ARROW_RIGHT}`],
+    [`-${S}${S}->`, `-${S}${S}${ARROW_RIGHT}`],
+    [`<${S}-> `, `${ARROW_LEFT_RIGHT}${S} `],
+    // Two boundaries after `<` block the bidi shape; `->` still matches as a
+    // right arrow.
+    [`a <${S}${S}-> b`, `a <${S}${S}${ARROW_RIGHT} b`],
+    [`a <${S}${S}- b`, `a <${S}${S}- b`],
+    [`a -${S}${S}> b`, `a -${S}${S}> b`],
+    // Left arrow with one boundary after `<`.
+    [`a <${S}- b`, `a ${ARROW_LEFT}${S} b`],
+    // `<` with no dash run matches no arrow shape.
+    [`a < b`, `a < b`],
+    [`a <> b`, `a <> b`],
+  ])("converts %j to %j", (input, expected) => {
+    expect(arrows(input, opts)).toBe(expected)
+  })
+})
+
+describe("legalSymbols boundary-measured context window", () => {
+  it.each([
+    // A long boundary-free path keeps the slash inside the 25-char window, so
+    // the path context blocks the conversion.
+    [`a/${"x".repeat(23)}(c) 2024`, `a/${"x".repeat(23)}(c) 2024`],
+    // A boundary inside the path costs window space, pushing the slash out so
+    // the year evidence converts it.
+    [`a/${S}${"x".repeat(23)}(c) 2024`, `a/${S}${"x".repeat(23)}${COPYRIGHT} 2024`],
+  ])("converts %j to %j", (input, expected) => {
+    expect(legalSymbols(input, opts)).toBe(expected)
+  })
+})
+
+describe("punctuationLigatures boundary tolerance", () => {
+  it.each([
+    [`?${S}?`, `${DOUBLE_QUESTION}${S}`],
+    // Two adjacent boundaries break the repeat run.
+    [`?${S}${S}?`, `?${S}${S}?`],
+    [`?${S}?${S}?`, `${DOUBLE_QUESTION}${S}${S}`],
+  ])("converts %j to %j", (input, expected) => {
+    expect(punctuationLigatures(input, opts)).toBe(expected)
+  })
+})
+
+describe("superscriptOrdinal boundary tolerance", () => {
+  it.each([
+    [`2${S}nd`, `2${S}${SUPERSCRIPT_ND}`],
+    // Two adjacent boundaries between digit and suffix block the match.
+    [`2${S}${S}nd`, `2${S}${S}nd`],
+    // Boundaries outside the ordinal's span (before and after) are ignored.
+    [`x ${S}2nd`, `x ${S}2${SUPERSCRIPT_ND}`],
+    [`2nd${S} x`, `2${SUPERSCRIPT_ND}${S} x`],
+    // A boundary inside the suffix (not the digit slot) blocks the match.
+    [`2n${S}d`, `2n${S}d`],
+  ])("converts %j to %j", (input, expected) => {
+    expect(superscriptOrdinal(input, opts)).toBe(expected)
+  })
+})
+
+// Plain (no-boundary) variants that exercise the same boundary-aware helpers
+// down their non-boundary arms.
+describe("plain-text arms of boundary-aware helpers", () => {
+  it.each([
+    [`a <--> b`, `a ${ARROW_LEFT_RIGHT} b`],
+    [`a <---> b`, `a ${ARROW_LEFT_RIGHT} b`],
+    // Two boundaries before the closing `>` block the bidi arrow's `>` slot;
+    // the leading `<--` still matches as a left arrow.
+    [`a <--${S}${S}> b`, `a ${ARROW_LEFT}${S}${S}> b`],
+  ])("arrows %j to %j", (input, expected) => {
+    expect(arrows(input, opts)).toBe(expected)
+  })
+
+  it.each([
+    [`20C-5`, `20 ${DEGREE}C-5`],
+    [`20C#`, `20C#`],
+    // A trailing hyphen at end of string is not a compound; converts.
+    [`20C-`, `20 ${DEGREE}C-`],
+  ])("degrees %j to %j", (input, expected) => {
+    expect(degrees(input)).toBe(expected)
+  })
+
+  it.each([
+    // A `0` operand followed by a space (not `x`) is not hex.
+    [`0 x 5`, `0 ${X} 5`],
+  ])("multiplication %j to %j", (input, expected) => {
+    expect(multiplication(input)).toBe(expected)
+  })
+})


### PR DESCRIPTION
Stage 6 of the v5 rollout (tracking: #219), stacked on #224. Migrates all symbol passes (`ellipsis`, `multiplication`, `mathSymbols`, `legalSymbols`, `arrows`, `degrees`, `fractions`, `superscriptOrdinal`, `punctuationLigatures`) off the sentinel weaves onto the ProseView layer, byte-identical to v4 with public contracts unchanged. (`primeMarks` was already migrated in #222 and is untouched.)

## How
Same per-position discipline as #223/#224. Notables:
- **multiplication** moves to a sticky-regex manual scan — sticky anchoring keeps the nested digit-run quantifier ReDoS-safe, which is what allows dropping the v4 lookbehind chain while staying boundary-aware on operands, operators, hex skips, and unit/prime suffixes;
- **legalSymbols** keeps its 25-char context windows measured in *marked* coordinates (each boundary costs `separator.length`) for v4 fidelity;
- **ellipsis** dot gaps accept nothing / one space / one boundary (never two, never space+boundary);
- consumed boundaries collapse after the produced glyph (arrows, ligatures), matching where v4's re-emitted sentinels landed.

With this stage no module consumes the sentinel-regex machinery, so constants.ts drops `getEscapedSeparator`, `wordBoundaryEnd`, `ESCAPED_DEFAULT_SEPARATOR`, and the `escape-string-regexp` re-export (coverage-enforced).

## Verification
- Differential fuzz vs the saved v4 build: **>1.5M comparisons, 0 mismatches** (per-pass + `symbolTransform` + full `transform`, symbol-dense randoms × separator placements incl. empty fragments).
- Full suite green at 100% coverage (2461 tests on the stack tip); golden corpus untouched; benchmark 150/151, failing set unchanged. Existing symbols.test.ts unmodified; new `symbols-boundaries.test.ts` pins the tolerance map.

https://claude.ai/code/session_01JurYodPWZhfCQ2FoJ2Ek22

---
_Generated by [Claude Code](https://claude.ai/code/session_01JurYodPWZhfCQ2FoJ2Ek22)_