### PR TITLE
fix: make transform idempotent for tabs mixed into dash spacing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Fixed
+- `transform()` is now idempotent when a tab (or other non-space whitespace) is mixed into the spaces around a dash, e.g. `"word \t- word"`. The dash now converts on the first pass, matching the result a fully space-padded dash already produced; previously the tab blocked conversion until `collapseSpaces` normalized the whitespace, so a second pass changed the output.
+
 ## [4.1.1] - 2026-06-10
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 ### Fixed
-- `transform()` is now idempotent when a tab (or other non-space whitespace) is mixed into the spaces around a dash, e.g. `"word \t- word"`. The dash now converts on the first pass, matching the result a fully space-padded dash already produced; previously the tab blocked conversion until `collapseSpaces` normalized the whitespace, so a second pass changed the output.
+- `transform()` is now idempotent when a tab sits in the whitespace around a dash, e.g. `"word \t- word"`. The dash now converts on the first pass, matching the result a fully space-padded dash already produced; previously the tab blocked conversion until `collapseSpaces` normalized the whitespace to a plain space, so a second pass changed the output.
 
 ## [4.1.1] - 2026-06-10
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -232,6 +232,16 @@ export function transform(text: string, options: TransformOptions = {}): string 
   const original = text
   const { symbols, fractions, degrees, superscript, ligatures, nbsp, collapseSpaces, checkIdempotency, ...pipelineOpts } = { ...defaultOpts, ...filterUndefined(options) }
 
+  // Collapse whitespace before the whitespace-sensitive dash and symbol passes.
+  // Those passes recognize dashes by their surrounding spaces (`[ ]+`), so a tab
+  // mixed into a space run (e.g. "word \t- word") would block conversion on the
+  // first pass; collapsing it to a single space afterwards would then let a
+  // second pass convert the dash, breaking idempotency. Normalizing first means
+  // every pass sees the same spacing.
+  if (collapseSpaces) {
+    text = collapseSpacesTransform(text)
+  }
+
   text = hyphenReplace(text, pipelineOpts)
   if (pipelineOpts.punctuationStyle !== "none") {
     text = primeMarks(text, pipelineOpts)
@@ -258,6 +268,9 @@ export function transform(text: string, options: TransformOptions = {}): string 
     text = ligaturesTransform(text, pipelineOpts)
   }
 
+  // Collapse again after the quote passes: localized styles (French guillemets,
+  // German low-9 quotes) pad with narrow/no-break spaces that can land next to
+  // an existing space, forming a run the up-front collapse never saw.
   if (collapseSpaces) {
     text = collapseSpacesTransform(text)
   }

--- a/src/tests/index.test.ts
+++ b/src/tests/index.test.ts
@@ -467,10 +467,9 @@ describe("transform", () => {
       "the 5x10-20 pack",
       "buy 3x5-10 cards",
       "give or take +/-1-5 units",
-      // A tab mixed into the spaces around a dash used to block conversion on
-      // the first pass while collapseSpaces (running last) normalized it, so a
-      // second pass converted the dash. Collapsing before the dash pass fixes
-      // it. (regression: these threw "Transform is not idempotent".)
+      // A tab in the whitespace around a dash must not defer conversion to a
+      // later pass. (regression: these threw "Transform is not idempotent"
+      // when collapseSpaces only ran after the dash pass.)
       "word \t- word",
       "word \t-- word",
       "a \t- b \t- c",

--- a/src/tests/index.test.ts
+++ b/src/tests/index.test.ts
@@ -467,10 +467,24 @@ describe("transform", () => {
       "the 5x10-20 pack",
       "buy 3x5-10 cards",
       "give or take +/-1-5 units",
+      // A tab mixed into the spaces around a dash used to block conversion on
+      // the first pass while collapseSpaces (running last) normalized it, so a
+      // second pass converted the dash. Collapsing before the dash pass fixes
+      // it. (regression: these threw "Transform is not idempotent".)
+      "word \t- word",
+      "word \t-- word",
+      "a \t- b \t- c",
     ])('is idempotent: "%s"', (input) => {
       const first = transform(input, { fractions: true, degrees: true, superscript: true, ligatures: true })
       const second = transform(first, { fractions: true, degrees: true, superscript: true, ligatures: true })
       expect(second).toBe(first)
+    })
+
+    it("converts a dash padded by tab-and-space whitespace on the first pass", () => {
+      // The mixed space+tab run collapses to one space, then the dash converts —
+      // the same result a fully space-padded dash would already produce.
+      expect(transform("word \t- word")).toBe(`word${EM_DASH}word`)
+      expect(transform("word \t- word", { dashStyle: "british" })).toBe(`word ${EN_DASH} word`)
     })
 
     it.each([


### PR DESCRIPTION
## Summary

Fuzzing `transform()` with `checkIdempotency` revealed that the pipeline is **not** idempotent for a class of inputs the README promises always holds — specifically when a tab (or other non-space whitespace) is mixed into the spaces around a dash:

```js
transform("word \t- word")              // pass 1 → "word - word"
transform(transform("word \t- word"))   // pass 2 → "word—word"   ❌ differs
```

### Root cause

The dash passes recognize a parenthetical dash by its surrounding spaces, using `[ ]+` (literal space). A tab adjacent to the dash never matches, so the dash is left alone on the first pass. `collapseSpaces` runs *last* in the pipeline and normalizes the mixed `space+tab` run down to a single space — which then lets a **second** pass convert the dash. The two passes disagree, so the result is non-idempotent (and with `checkIdempotency: true`, throws).

### Fix

Run `collapseSpaces` once **up front**, before the whitespace-sensitive dash/symbol passes, in addition to the existing trailing pass. Now every pass sees the same normalized spacing, and the dash converts on the first pass — producing exactly the result a fully space-padded dash already produced.

The trailing collapse is still required: the French (guillemet) and German (low-9) quote styles pad with narrow/no-break spaces that can land next to an existing space, forming a collapsible run only *after* the quote pass runs. Removing the trailing pass reintroduced non-idempotency there, so both passes are kept and commented.

### Scope / what this does not fix

A 200k-iteration fuzz over random punctuation across all five punctuation styles and three dash styles went from **1126 → 1018** non-idempotent cases. The entire non-quote class (`punctuationStyle: "none"`: 19 → 0) is eliminated. The remaining cases are all the inherent apostrophe / closing-single-quote ambiguity (e.g. a lone `'.` rendered as `’.` reads as a closing quote on re-input) — already documented in the README's "Known limitations" and out of scope here, since resolving it requires semantics, not whitespace handling.

## Testing

- Added regression cases to the idempotency suites in `src/tests/index.test.ts`, plus an explicit assertion that a tab-padded dash converts on the first pass (`word \t- word` → `word—word`; British → `word – word`).
- Full suite: **1947 passed** (4 new), **100% branch/line/function/statement coverage** preserved.
- `eslint` clean.
- Verified `collapseSpaces: false` still leaves tab-padded dashes untouched and idempotent, and that normal (non-tab) outputs are byte-for-byte unchanged.


---
_Generated by [Claude Code](https://claude.ai/code/session_01PjmvF8xwre3yrD5FWTFghX)_