### PR TITLE
docs: self-updating README pre-commit pin and a consumer-first v5 migration guide

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,6 +19,9 @@ jobs:
       - name: Run ESLint
         run: pnpm lint
 
+      - name: Typecheck release scripts
+        run: pnpm typecheck:scripts
+
       - name: Check GitHub Actions are SHA-pinned
         run: |
           UNPINNED=$(grep -rn 'uses:.*@v[0-9]' .github/workflows/ .github/actions/ || true)

--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ A `.pre-commit-hooks.yaml` ships in the package, so [pre-commit](https://pre-com
 # .pre-commit-config.yaml
 repos:
   - repo: https://github.com/alexander-turner/punctilio
-    rev: v3.10.0
+    rev: v5.0.0
     hooks:
       - id: punctilio          # rewrites *.md / *.html in place
       - id: punctilio-check    # or: fail without writing (CI-friendly)

--- a/docs/migrating-to-v5.md
+++ b/docs/migrating-to-v5.md
@@ -1,9 +1,60 @@
 # Migrating to v5
 
-v5 removes the sentinel-separator architecture. Passes no longer weave a
-marker character through flattened text; they run over a _ProseView_ — a
-boundary-aware view of an element's text nodes — and commit offset edits back
-onto the source nodes. For most consumers the visible changes are:
+## Main takeaways
+
+**If you only call `transform()`, the CLI, or the `rehype`/`remark`/`markdown`
+plugins with their default options, you don't need to change anything.** v5's
+output is byte-identical to v4 except for two deliberate quote fixes (below),
+so for most consumers upgrading is just bumping the version.
+
+You only need to make changes if you touched punctilio's internals. Use this
+table to find out:
+
+| Did you… | Then in v5… |
+| --- | --- |
+| set the `separator` option anywhere? | Delete it — it no longer exists (and isn't needed). |
+| set `checkIdempotency`? | Delete it — the option is gone. |
+| call `primeMarks` (usually before `niceQuotes`)? | Delete the `primeMarks` call — `niceQuotes` now does primes itself. Pass `primes: false` to opt out. |
+| import a single rule like `ellipsis`, `fractions`, `arrows`, `minusReplace`, or an `nbspAfter…` helper? | Use the composed pass (`symbolTransform`, `nbspTransform`, `hyphenReplace`) or the matching `transform()` option instead — see the [removed-exports tables](#5-removed-symbols-and-replacements). |
+| call `transformElement(...)` to process your own HTML nodes? | Switch to [`applyPasses(element, passes, options)`](#1-sentinel--marker-character-removal). |
+| run your own regexes over punctilio's flattened text? | Wrap each one in [`definePass`](#2-site-specific-regexes--definepass). |
+
+The two intentional output changes (both restoring more correct behavior):
+
+1. A straight double quote that merely starts a text node (e.g. right after
+   `</a>`) now **closes** instead of opening, when a later quote pair follows
+   in the same block.
+2. A quoted multi-digit number like `'37'` is a **quote pair** again, not a
+   decade elision — restoring the pre-4.1.1 output.
+
+That's everything a consumer needs. The rest of this document explains the
+underlying change and gives precise before/after recipes for each case.
+
+## Why it changed (optional background)
+
+Punctilio often has to transform text that's split across several HTML text
+nodes — a word broken up by `<em>`, say. A rule needs to see the whole string
+to decide correctly, but then write its edits back into the right original
+pieces.
+
+Through v4 this used a **sentinel**: punctilio joined the text nodes into one
+string with a special marker character standing in for each node boundary, ran
+the rules over that joined string, and split back on the marker afterward.
+Putting a real character into the text was inherently fragile — the marker
+could collide with real content, leak into output, or be miscounted when a
+match spanned it.
+
+v5 removes the marker entirely. Rules now run over a **ProseView**: the
+combined text is still presented as one string, but node boundaries are
+tracked as numeric **offsets alongside** the string instead of as a character
+inside it. Because a boundary is a position rather than a character, it can
+never collide, leak, or be miscounted. Everything below — `applyPasses`,
+`definePass`'s boundary decisions, `PassEntry` skip sets — follows from that
+one shift.
+
+## Detailed migration reference
+
+The breaking changes in full:
 
 1. [`transformElement` and marker characters are gone](#1-sentinel--marker-character-removal) — use `applyPasses`.
 2. [Custom regexes become passes via `definePass`](#2-site-specific-regexes--definepass), with an explicit per-pattern boundary decision.
@@ -11,13 +62,6 @@ onto the source nodes. For most consumers the visible changes are:
 4. [`primeMarks` is folded into `niceQuotes`](#4-standalone-primemarks--nicequotes).
 5. [Several symbols and helpers were removed](#5-removed-symbols-and-replacements).
 6. [Per-rule sub-passes left the root export](#6-sub-passes-left-the-root-contract).
-
-Default-option `transform()` output is byte-identical to v4, with two
-deliberate classifier fixes: a straight double quote that merely starts a
-node (e.g. directly after `</a>`) now closes instead of opening when a later
-quote pair follows in the same block, and a quoted multi-digit number like
-`'37'` is a quote pair again rather than a decade elision (restoring the
-pre-4.1.1 output).
 
 ## 1. Sentinel / marker-character removal
 

--- a/docs/migrating-to-v5.md
+++ b/docs/migrating-to-v5.md
@@ -32,25 +32,40 @@ underlying change and gives precise before/after recipes for each case.
 
 ## Why it changed (optional background)
 
-Punctilio often has to transform text that's split across several HTML text
-nodes — a word broken up by `<em>`, say. A rule needs to see the whole string
-to decide correctly, but then write its edits back into the right original
-pieces.
+**The problem.** Punctilio often transforms text that HTML has split across
+several text nodes — the word in `so<em>met</em>hing`, for example, is three
+separate nodes. A rule like curly-quoting or dash conversion has to read the
+whole string `something` to decide correctly, but then it has to write each
+edit back into the _right_ original node. So every rule needs two things at
+once: one combined string to read, and a way to map any position in that
+string back to the node it came from.
 
-Through v4 this used a **sentinel**: punctilio joined the text nodes into one
-string with a special marker character standing in for each node boundary, ran
-the rules over that joined string, and split back on the marker afterward.
-Putting a real character into the text was inherently fragile — the marker
-could collide with real content, leak into output, or be miscounted when a
-match spanned it.
+**The v4 answer: a marker character (the "sentinel").** Punctilio glued the
+nodes into one string, inserting a special marker character at each node
+boundary — a stand-in that means "a node edge is here." Rules ran over that
+glued string, and afterward punctilio split on the marker to hand each
+node back its share of the edited text.
 
-v5 removes the marker entirely. Rules now run over a **ProseView**: the
-combined text is still presented as one string, but node boundaries are
-tracked as numeric **offsets alongside** the string instead of as a character
-inside it. Because a boundary is a position rather than a character, it can
-never collide, leak, or be miscounted. Everything below — `applyPasses`,
-`definePass`'s boundary decisions, `PassEntry` skip sets — follows from that
-one shift.
+The trouble is that the boundary was now a real character living _inside_ the
+text, and that's fragile in three ways:
+
+- it can **collide** with a marker character that was already in the content;
+- it can **leak** into the output if a rule fails to strip it;
+- it can be **miscounted** when a rule's match spans it, throwing off the
+  split that maps text back to nodes.
+
+**The v5 answer: a ProseView.** v5 deletes the marker. A rule still reads one
+combined string, but the node boundaries now live _beside_ the string as a
+list of numeric positions (offsets), not as characters within it. The view
+answers "which node does offset _N_ belong to?" by arithmetic, and a rule
+expresses an edit as "replace characters _X_–_Y_," which the view commits onto
+the underlying nodes.
+
+Because a boundary is a position rather than a character, it simply can't
+collide, leak, or be miscounted — the three failure modes are gone by
+construction. Everything else in this guide — `applyPasses` owning the view,
+`definePass` asking what to do when a match crosses a boundary, `PassEntry`
+skip sets — follows from that one shift.
 
 ## Detailed migration reference
 

--- a/package.json
+++ b/package.json
@@ -51,7 +51,8 @@
   "scripts": {
     "build": "tsc",
     "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js",
-    "lint": "eslint src",
+    "lint": "eslint src scripts",
+    "typecheck:scripts": "tsc --noEmit -p tsconfig.scripts.json",
     "benchmark": "pnpm run build && node benchmark.mjs",
     "mutation": "STRYKER_RUN=1 stryker run",
     "prepare": "if [ -d src ]; then tsc; else true; fi",

--- a/scripts/atomic-write.ts
+++ b/scripts/atomic-write.ts
@@ -1,0 +1,8 @@
+import { renameSync, writeFileSync } from "node:fs"
+
+/** Write `contents` to `path` via a temp file + rename so the replacement is atomic. */
+export function atomicWrite(path: string, contents: string): void {
+  const tmpPath = `${path}.tmp`
+  writeFileSync(tmpPath, contents)
+  renameSync(tmpPath, path)
+}

--- a/scripts/pin-readme-rev.impl.ts
+++ b/scripts/pin-readme-rev.impl.ts
@@ -1,0 +1,41 @@
+/**
+ * Pure logic for pinning the README's pre-commit `rev:` to a released version.
+ *
+ * The filesystem/environment wrapper lives in `pin-readme-rev.ts`; keeping the
+ * decision here lets it be unit-tested without touching disk.
+ */
+
+export const README_PATH = "README.md"
+
+const SEMVER = /^\d+\.\d+\.\d+$/
+
+/**
+ * The `rev:` line inside punctilio's pre-commit repo block. Horizontal
+ * whitespace and the single line break are matched explicitly (no `\s*` that
+ * could span lines) so the match can't drift onto an unrelated `rev:`.
+ */
+export const REV_LINE =
+  /(?<prefix>repo:[^\S\n]*https:\/\/github\.com\/alexander-turner\/punctilio[^\S\n]*\n[^\S\n]*rev:[^\S\n]*)v\d+\.\d+\.\d+/
+
+export type PinOutcome =
+  | { pinned: true; readme: string; message: string }
+  | { pinned: false; message: string }
+
+/**
+ * Decide how to pin `readme` to `version`. Returns the rewritten README when a
+ * change is needed, or a skip reason (malformed version, block not found, or
+ * already current) otherwise — never throws and never reads the environment.
+ */
+export function pinReadmeRev(readme: string, version: string | undefined): PinOutcome {
+  if (!version || !SEMVER.test(version)) {
+    return { pinned: false, message: `missing or malformed NEW_VERSION (${String(version)}); skipping.` }
+  }
+  if (!REV_LINE.test(readme)) {
+    return { pinned: false, message: `pre-commit rev pattern not found in ${README_PATH}; leaving it unchanged.` }
+  }
+  const updated = readme.replace(REV_LINE, `$<prefix>v${version}`)
+  if (updated === readme) {
+    return { pinned: false, message: `pre-commit rev already at v${version} in ${README_PATH}; nothing to do.` }
+  }
+  return { pinned: true, readme: updated, message: `Pinned pre-commit rev to v${version} in ${README_PATH}` }
+}

--- a/scripts/pin-readme-rev.ts
+++ b/scripts/pin-readme-rev.ts
@@ -1,40 +1,24 @@
 /**
  * Pin the README's pre-commit `rev:` to the version being released.
  *
- * Invoked from `scripts/version-bump.sh` after a successful `pnpm publish`,
- * so the version documented in the pre-commit example never lags behind what
- * is actually published. Reads the target version from the environment:
- *
- *   NEW_VERSION — the semver string, e.g. "1.2.3"
+ * Invoked from `scripts/version-bump.sh` after a successful `pnpm publish`, so
+ * the version documented in the pre-commit example never lags behind what is
+ * actually published. Reads the target version from `NEW_VERSION` and delegates
+ * the decision to `pinReadmeRev`; this file only does IO.
  *
  * Behavior:
- * - Rewrites only the `rev:` line inside punctilio's own pre-commit repo
- *   block, so nothing else in the README can be disturbed.
- * - If that block can't be found, warns and leaves the file untouched rather
- *   than failing: `npm publish` has already succeeded by this point, and a
- *   docs hiccup must not abort the surrounding bash script (which still needs
- *   to commit, push, and tag).
- * - Writes diagnostics to stderr; exits 0 even on unexpected errors.
+ * - Rewrites only the `rev:` line inside punctilio's own pre-commit repo block.
+ * - On any skip (missing/malformed version, block not found, already current)
+ *   or unexpected error it warns to stderr and exits 0: `npm publish` has
+ *   already succeeded by this point, and a docs hiccup must not abort the
+ *   surrounding bash script (which still needs to commit, push, and tag).
  * - File write is atomic (temp file + rename) so a crash mid-write leaves the
  *   original README intact.
  */
 
 import { readFileSync, renameSync, writeFileSync } from "node:fs"
 
-const README_PATH = "README.md"
-const SEMVER = /^\d+\.\d+\.\d+$/
-
-/**
- * The `rev:` line inside punctilio's pre-commit repo block. Horizontal
- * whitespace and the single line break are matched explicitly (no `\s*` that
- * could span lines) so the match can't drift onto an unrelated `rev:`.
- */
-const REV_LINE =
-  /(?<prefix>repo:[^\S\n]*https:\/\/github\.com\/alexander-turner\/punctilio[^\S\n]*\n[^\S\n]*rev:[^\S\n]*)v\d+\.\d+\.\d+/
-
-function warn(message: string): void {
-  process.stderr.write(`README rev pin: ${message}\n`)
-}
+import { pinReadmeRev, README_PATH } from "./pin-readme-rev.impl.js"
 
 /** Write `contents` to `path` via a temp file + rename so the replacement is atomic. */
 function atomicWrite(path: string, contents: string): void {
@@ -43,31 +27,18 @@ function atomicWrite(path: string, contents: string): void {
   renameSync(tmpPath, path)
 }
 
-function pinReadmeRev(): void {
-  const version = process.env.NEW_VERSION
-  if (!version || !SEMVER.test(version)) {
-    warn(`missing or malformed NEW_VERSION (${String(version)}); skipping.`)
-    return
-  }
-
-  const source = readFileSync(README_PATH, "utf8")
-  if (!REV_LINE.test(source)) {
-    warn(`pre-commit rev pattern not found in ${README_PATH}; leaving it unchanged.`)
-    return
-  }
-
-  const updated = source.replace(REV_LINE, `$<prefix>v${version}`)
-  if (updated === source) return
-
-  atomicWrite(README_PATH, updated)
-  process.stdout.write(`Pinned pre-commit rev to v${version} in ${README_PATH}\n`)
-}
-
 try {
-  pinReadmeRev()
+  const outcome = pinReadmeRev(readFileSync(README_PATH, "utf8"), process.env.NEW_VERSION)
+  if (outcome.pinned) {
+    atomicWrite(README_PATH, outcome.readme)
+    process.stdout.write(`${outcome.message}\n`)
+  } else {
+    process.stderr.write(`README rev pin: ${outcome.message}\n`)
+  }
 } catch (err) {
-  // Exit 0 deliberately: npm publish has already succeeded at this point in
-  // the release flow; a README hiccup must not abort the surrounding bash
-  // script and skip the tag push.
-  warn(`failed: ${err instanceof Error ? err.stack ?? err.message : String(err)}`)
+  // Exit 0 deliberately: npm publish has already succeeded at this point in the
+  // release flow; a README hiccup must not abort the surrounding bash script.
+  process.stderr.write(
+    `README rev pin: failed: ${err instanceof Error ? (err.stack ?? err.message) : String(err)}\n`,
+  )
 }

--- a/scripts/pin-readme-rev.ts
+++ b/scripts/pin-readme-rev.ts
@@ -1,0 +1,73 @@
+/**
+ * Pin the README's pre-commit `rev:` to the version being released.
+ *
+ * Invoked from `scripts/version-bump.sh` after a successful `pnpm publish`,
+ * so the version documented in the pre-commit example never lags behind what
+ * is actually published. Reads the target version from the environment:
+ *
+ *   NEW_VERSION — the semver string, e.g. "1.2.3"
+ *
+ * Behavior:
+ * - Rewrites only the `rev:` line inside punctilio's own pre-commit repo
+ *   block, so nothing else in the README can be disturbed.
+ * - If that block can't be found, warns and leaves the file untouched rather
+ *   than failing: `npm publish` has already succeeded by this point, and a
+ *   docs hiccup must not abort the surrounding bash script (which still needs
+ *   to commit, push, and tag).
+ * - Writes diagnostics to stderr; exits 0 even on unexpected errors.
+ * - File write is atomic (temp file + rename) so a crash mid-write leaves the
+ *   original README intact.
+ */
+
+import { readFileSync, renameSync, writeFileSync } from "node:fs"
+
+const README_PATH = "README.md"
+const SEMVER = /^\d+\.\d+\.\d+$/
+
+/**
+ * The `rev:` line inside punctilio's pre-commit repo block. Horizontal
+ * whitespace and the single line break are matched explicitly (no `\s*` that
+ * could span lines) so the match can't drift onto an unrelated `rev:`.
+ */
+const REV_LINE =
+  /(?<prefix>repo:[^\S\n]*https:\/\/github\.com\/alexander-turner\/punctilio[^\S\n]*\n[^\S\n]*rev:[^\S\n]*)v\d+\.\d+\.\d+/
+
+function warn(message: string): void {
+  process.stderr.write(`README rev pin: ${message}\n`)
+}
+
+/** Write `contents` to `path` via a temp file + rename so the replacement is atomic. */
+function atomicWrite(path: string, contents: string): void {
+  const tmpPath = `${path}.tmp`
+  writeFileSync(tmpPath, contents)
+  renameSync(tmpPath, path)
+}
+
+function pinReadmeRev(): void {
+  const version = process.env.NEW_VERSION
+  if (!version || !SEMVER.test(version)) {
+    warn(`missing or malformed NEW_VERSION (${String(version)}); skipping.`)
+    return
+  }
+
+  const source = readFileSync(README_PATH, "utf8")
+  if (!REV_LINE.test(source)) {
+    warn(`pre-commit rev pattern not found in ${README_PATH}; leaving it unchanged.`)
+    return
+  }
+
+  const updated = source.replace(REV_LINE, `$<prefix>v${version}`)
+  if (updated === source) return
+
+  atomicWrite(README_PATH, updated)
+  process.stdout.write(`Pinned pre-commit rev to v${version} in ${README_PATH}\n`)
+}
+
+try {
+  pinReadmeRev()
+} catch (err) {
+  // Exit 0 deliberately: npm publish has already succeeded at this point in
+  // the release flow; a README hiccup must not abort the surrounding bash
+  // script and skip the tag push.
+  warn(`failed: ${err instanceof Error ? err.stack ?? err.message : String(err)}`)
+}

--- a/scripts/pin-readme-rev.ts
+++ b/scripts/pin-readme-rev.ts
@@ -16,16 +16,10 @@
  *   original README intact.
  */
 
-import { readFileSync, renameSync, writeFileSync } from "node:fs"
+import { readFileSync } from "node:fs"
 
+import { atomicWrite } from "./atomic-write.js"
 import { pinReadmeRev, README_PATH } from "./pin-readme-rev.impl.js"
-
-/** Write `contents` to `path` via a temp file + rename so the replacement is atomic. */
-function atomicWrite(path: string, contents: string): void {
-  const tmpPath = `${path}.tmp`
-  writeFileSync(tmpPath, contents)
-  renameSync(tmpPath, path)
-}
 
 try {
   const outcome = pinReadmeRev(readFileSync(README_PATH, "utf8"), process.env.NEW_VERSION)
@@ -36,8 +30,6 @@ try {
     process.stderr.write(`README rev pin: ${outcome.message}\n`)
   }
 } catch (err) {
-  // Exit 0 deliberately: npm publish has already succeeded at this point in the
-  // release flow; a README hiccup must not abort the surrounding bash script.
   process.stderr.write(
     `README rev pin: failed: ${err instanceof Error ? (err.stack ?? err.message) : String(err)}\n`,
   )

--- a/scripts/promote-changelog.ts
+++ b/scripts/promote-changelog.ts
@@ -19,7 +19,9 @@
  *   the original CHANGELOG intact.
  */
 
-import { readFileSync, renameSync, writeFileSync } from "node:fs"
+import { readFileSync } from "node:fs"
+
+import { atomicWrite } from "./atomic-write.js"
 
 const CHANGELOG_PATH = "CHANGELOG.md"
 
@@ -74,13 +76,6 @@ function splitAroundUnreleased(
     before: source.slice(0, markerMatch.index),
     afterBlock: source.slice(bodyEnd),
   }
-}
-
-/** Write `contents` to `path` via a temp file + rename so the replacement is atomic. */
-function atomicWrite(path: string, contents: string): void {
-  const tmpPath = `${path}.tmp`
-  writeFileSync(tmpPath, contents)
-  renameSync(tmpPath, path)
 }
 
 function promoteUnreleased(): void {

--- a/scripts/promote-changelog.ts
+++ b/scripts/promote-changelog.ts
@@ -19,7 +19,7 @@
  *   the original CHANGELOG intact.
  */
 
-import { readFileSync, writeFileSync, renameSync } from "node:fs"
+import { readFileSync, renameSync, writeFileSync } from "node:fs"
 
 const CHANGELOG_PATH = "CHANGELOG.md"
 
@@ -51,9 +51,7 @@ function readEnv(): { newVersion: string; releaseDate: string; section: string }
  * string if nothing substantive is left.
  */
 function normalizeBody(raw: string): string {
-  return raw
-    .replace(/^\s*## \[[^\]]+\][^\n]*\n+/, "")
-    .replace(/\s+$/, "")
+  return raw.replace(/^\s*## \[[^\]]+\][^\n]*\n+/, "").trimEnd()
 }
 
 /**

--- a/scripts/version-bump.sh
+++ b/scripts/version-bump.sh
@@ -240,23 +240,11 @@ log "$PUBLISH_OUTPUT"
 log "✅ Published $PACKAGE_NAME@$NEW_VERSION"
 
 # Pin the README's pre-commit `rev:` to this release so the documented version
-# never lags behind what's published. Only the line inside punctilio's own
-# pre-commit repo block is touched; a missing pattern warns rather than failing
-# the (already-published) release.
+# never lags behind what's published. The helper touches only the line inside
+# punctilio's own pre-commit repo block, and warns rather than failing the
+# (already-published) release if it can't find that block.
 if [ -f README.md ]; then
-  NEW_VERSION="$NEW_VERSION" node -e '
-const fs = require("fs");
-const path = "README.md";
-const tag = "v" + process.env.NEW_VERSION;
-const pattern = /(repo:\s*https:\/\/github\.com\/alexander-turner\/punctilio\s*\n\s*rev:\s*)v[0-9]+\.[0-9]+\.[0-9]+/;
-const before = fs.readFileSync(path, "utf8");
-if (!pattern.test(before)) {
-  console.error("⚠️ README pre-commit rev pattern not found; leaving README unchanged.");
-  process.exit(0);
-}
-const after = before.replace(pattern, "$1" + tag);
-if (after !== before) fs.writeFileSync(path, after);
-'
+  NEW_VERSION="$NEW_VERSION" pnpm exec tsx scripts/pin-readme-rev.ts
 fi
 
 # Promote "## Unreleased" to a dated version section in CHANGELOG.md, using

--- a/scripts/version-bump.sh
+++ b/scripts/version-bump.sh
@@ -239,48 +239,68 @@ fi
 log "$PUBLISH_OUTPUT"
 log "✅ Published $PACKAGE_NAME@$NEW_VERSION"
 
+# Pin the README's pre-commit `rev:` to this release so the documented version
+# never lags behind what's published. Only the line inside punctilio's own
+# pre-commit repo block is touched; a missing pattern warns rather than failing
+# the (already-published) release.
+if [ -f README.md ]; then
+  NEW_VERSION="$NEW_VERSION" node -e '
+const fs = require("fs");
+const path = "README.md";
+const tag = "v" + process.env.NEW_VERSION;
+const pattern = /(repo:\s*https:\/\/github\.com\/alexander-turner\/punctilio\s*\n\s*rev:\s*)v[0-9]+\.[0-9]+\.[0-9]+/;
+const before = fs.readFileSync(path, "utf8");
+if (!pattern.test(before)) {
+  console.error("⚠️ README pre-commit rev pattern not found; leaving README unchanged.");
+  process.exit(0);
+}
+const after = before.replace(pattern, "$1" + tag);
+if (after !== before) fs.writeFileSync(path, after);
+'
+fi
+
 # Promote "## Unreleased" to a dated version section in CHANGELOG.md, using
-# the drafted body. Committed back to main so users see the release notes
-# in the repo. Tag is created AFTER this commit (and only if the commit reached
-# main) so HEAD == tag SHA and the resulting push doesn't re-trigger this
-# workflow meaningfully — the next run sees "HEAD is already tagged" and exits.
-CHANGELOG_PUSH_FAILED=0
+# the drafted body.
 if [ -f CHANGELOG.md ] && [ -n "$CHANGELOG_SECTION" ]; then
   RELEASE_DATE=$(date -u +%Y-%m-%d)
   NEW_VERSION="$NEW_VERSION" \
   RELEASE_DATE="$RELEASE_DATE" \
   CHANGELOG_SECTION="$CHANGELOG_SECTION" \
     pnpm exec tsx scripts/promote-changelog.ts
+fi
 
-  # Commit only CHANGELOG.md; package.json stays dirty (npm is the source of
-  # truth for version). Use a bot identity and `[skip ci]` so the resulting
-  # push doesn't spawn another workflow run.
-  git config user.name "github-actions[bot]"
-  git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-  if git diff --quiet CHANGELOG.md; then
-    log "No CHANGELOG.md changes to commit."
-  else
-    git add CHANGELOG.md
-    git commit -m "docs(changelog): release $NEW_VERSION [skip ci]"
-    # Push to main explicitly so this works whether actions/checkout left us on
-    # a branch or in detached HEAD state.
-    if ! git push origin HEAD:main; then
-      log "⚠️ Failed to push CHANGELOG update. Release was published; CHANGELOG can be updated manually."
-      CHANGELOG_PUSH_FAILED=1
-    fi
+# Commit the release docs (CHANGELOG entry + README rev pin) back to main so
+# users see the release notes and an up-to-date pre-commit pin. package.json
+# stays dirty (npm is the source of truth for version). A bot identity and
+# `[skip ci]` keep the resulting push from spawning another workflow run. The
+# tag is created AFTER this commit (and only if it reached main) so HEAD == tag
+# SHA and the next run sees "HEAD is already tagged" and exits.
+RELEASE_DOCS_PUSH_FAILED=0
+git config user.name "github-actions[bot]"
+git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+if git diff --quiet -- CHANGELOG.md README.md; then
+  log "No release-docs changes to commit."
+else
+  git add -- CHANGELOG.md README.md
+  git commit -m "docs: release $NEW_VERSION [skip ci]"
+  # Push to main explicitly so this works whether actions/checkout left us on
+  # a branch or in detached HEAD state.
+  if ! git push origin HEAD:main; then
+    log "⚠️ Failed to push release-docs update. Release was published; docs can be updated manually."
+    RELEASE_DOCS_PUSH_FAILED=1
   fi
 fi
 
-# Tag only when the CHANGELOG commit (if any) actually reached main. Otherwise
-# the local HEAD is an orphan commit that nobody can see, and tagging it would
-# leave v$NEW_VERSION pointing at a SHA outside the main-branch history.
-if [ "$CHANGELOG_PUSH_FAILED" = "1" ]; then
-  log "⚠️ Skipping tag v$NEW_VERSION because the CHANGELOG commit did not reach main."
-  log "    Release was published to npm; reconcile by pushing the CHANGELOG commit and tagging manually."
+# Tag only when the release-docs commit (if any) actually reached main.
+# Otherwise the local HEAD is an orphan commit that nobody can see, and tagging
+# it would leave v$NEW_VERSION pointing at a SHA outside the main-branch history.
+if [ "$RELEASE_DOCS_PUSH_FAILED" = "1" ]; then
+  log "⚠️ Skipping tag v$NEW_VERSION because the release-docs commit did not reach main."
+  log "    Release was published to npm; reconcile by pushing the release-docs commit and tagging manually."
   exit 1
 fi
 
 # Tag the release for future commit range detection. Tag HEAD (which now
-# includes the CHANGELOG commit, if any) so a re-trigger sees HEAD == tag SHA.
+# includes the release-docs commit, if any) so a re-trigger sees HEAD == tag SHA.
 git tag "v$NEW_VERSION"
 git push origin "v$NEW_VERSION" || log "⚠️ Failed to push tag v$NEW_VERSION. Next run may re-analyze these commits."

--- a/src/tests/pin-readme-rev.test.ts
+++ b/src/tests/pin-readme-rev.test.ts
@@ -1,0 +1,63 @@
+import { pinReadmeRev, README_PATH } from "../../scripts/pin-readme-rev.impl.js"
+
+const README = `# punctilio
+
+### pre-commit
+
+\`\`\`yaml
+# .pre-commit-config.yaml
+repos:
+  - repo: https://github.com/alexander-turner/punctilio
+    rev: v5.0.0
+    hooks:
+      - id: punctilio
+\`\`\`
+`
+
+describe("pinReadmeRev", () => {
+  it("rewrites the rev line to the new version", () => {
+    const outcome = pinReadmeRev(README, "5.2.3")
+    expect(outcome.pinned).toBe(true)
+    if (!outcome.pinned) throw new Error("expected a pin")
+    expect(outcome.readme).toContain("rev: v5.2.3")
+    expect(outcome.readme).not.toContain("rev: v5.0.0")
+    expect(outcome.message).toContain("v5.2.3")
+  })
+
+  it("touches only the rev line, leaving the rest byte-identical", () => {
+    const outcome = pinReadmeRev(README, "5.2.3")
+    if (!outcome.pinned) throw new Error("expected a pin")
+    expect(outcome.readme).toBe(README.replace("rev: v5.0.0", "rev: v5.2.3"))
+  })
+
+  it.each([
+    ["undefined version", undefined, "missing or malformed"],
+    ["malformed version", "5.x", "missing or malformed"],
+  ])("skips on %s", (_name, version, expected) => {
+    const outcome = pinReadmeRev(README, version)
+    expect(outcome.pinned).toBe(false)
+    expect(outcome.message).toContain(expected)
+  })
+
+  it("skips and warns when the pre-commit block is absent", () => {
+    const outcome = pinReadmeRev("# punctilio\n\nNo hooks here.\n", "5.2.3")
+    expect(outcome.pinned).toBe(false)
+    expect(outcome.message).toContain(`pattern not found in ${README_PATH}`)
+  })
+
+  it("is a no-op when the rev already matches", () => {
+    const outcome = pinReadmeRev(README, "5.0.0")
+    expect(outcome.pinned).toBe(false)
+    expect(outcome.message).toContain("already at v5.0.0")
+  })
+
+  it("does not match a rev line under a different repo", () => {
+    const other = README.replace(
+      "https://github.com/alexander-turner/punctilio",
+      "https://github.com/someone-else/other-tool",
+    )
+    const outcome = pinReadmeRev(other, "5.2.3")
+    expect(outcome.pinned).toBe(false)
+    expect(outcome.message).toContain("pattern not found")
+  })
+})

--- a/src/tests/pin-readme-rev.test.ts
+++ b/src/tests/pin-readme-rev.test.ts
@@ -51,6 +51,17 @@ describe("pinReadmeRev", () => {
     expect(outcome.message).toContain("already at v5.0.0")
   })
 
+  it.each([
+    ["trailing space after the repo URL", "/punctilio", "/punctilio  "],
+    ["tab indentation before rev", "    rev:", "\trev:"],
+    ["extra spaces after rev:", "rev: v5.0.0", "rev:   v5.0.0"],
+  ])("tolerates %s", (_name, from, to) => {
+    const outcome = pinReadmeRev(README.replace(from, to), "5.2.3")
+    expect(outcome.pinned).toBe(true)
+    if (!outcome.pinned) throw new Error("expected a pin")
+    expect(outcome.readme).toContain("v5.2.3")
+  })
+
   it("does not match a rev line under a different repo", () => {
     const other = README.replace(
       "https://github.com/alexander-turner/punctilio",

--- a/tsconfig.scripts.json
+++ b/tsconfig.scripts.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": ".",
+    "declaration": false,
+    "declarationMap": false,
+    "sourceMap": false
+  },
+  "include": ["scripts/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary

- The README's pre-commit `rev:` was stale (`v3.10.0`) and would silently drift on every release. It now stays pinned to the latest published tag automatically, so the documented version never lags behind npm.
- `docs/migrating-to-v5.md` led with the architecture; most consumers don't need it. It now leads with a "do I need to change anything?" answer, with the conceptual background made optional.
- New release tooling is held to the same bar as `src/`: linted, typechecked, and unit-tested.

## Changes

**Keep the README pre-commit pin current**
- Pin the example to `v5.0.0` (was `v3.10.0`; the `rev: latest` some users tried never resolves — pre-commit needs a real tag).
- `scripts/version-bump.sh` now rewrites the README `rev:` line to the new tag inside the release-docs commit it already pushes to `main` (alongside the CHANGELOG promotion). The existing "tag only if the docs commit reached main" safety is preserved (variable renamed `CHANGELOG_PUSH_FAILED` → `RELEASE_DOCS_PUSH_FAILED`; the diff/add now covers both files).

**Extract + harden the script**
- The rewrite moved out of an inline `node -e` heredoc into `scripts/pin-readme-rev.ts` (thin IO entrypoint) + `scripts/pin-readme-rev.impl.ts` (pure logic). The split lets the logic hit 100% coverage without mocking `fs`/`process`.
- Shared `scripts/atomic-write.ts` now backs both `pin-readme-rev.ts` and `promote-changelog.ts` (was duplicated).
- The rev-line regex is anchored to punctilio's own pre-commit repo block, uses a named capture group, and matches whitespace explicitly (no `\s*` spanning lines) — clean under `eslint-plugin-regexp`/`redos`.

**Bring `scripts/` under static checking**
- `lint` is now `eslint src scripts`; new `tsconfig.scripts.json` + `typecheck:scripts` script, run as a step in `lint.yml`.
- Fixed the violations this surfaced in the previously-unlinted `promote-changelog.ts` (import order; a ReDoS-prone `/\s+$/` replaced with `.trimEnd()`).

**Docs**
- `docs/migrating-to-v5.md` restructured: Main takeaways (a "Did you…? / Then in v5…" table + the two intentional output changes) → optional "Why it changed" (concrete split-node example, the three failure modes of the marker character, and how the ProseView offset model removes them) → the full breaking-change reference.

## Testing

- `pnpm test` — 2407 passing, 100% coverage including `scripts/pin-readme-rev.impl.ts`. New cases cover rewrite, byte-identical non-target lines, missing/malformed version, missing block, no-op when already current, a different repo's `rev:`, and whitespace tolerance (tabs, extra/trailing spaces).
- `pnpm lint` and `pnpm typecheck:scripts` pass.
- Ran `scripts/pin-readme-rev.ts` end-to-end via `tsx` against the real README (pins correctly; restored afterward).


---
_Generated by [Claude Code](https://claude.ai/code/session_01Se8KxuWqxCDkPL4pApiPuC)_