### PR TITLE
chore: code-clarity refactors, least-privilege CI tokens, and Node-version alignment

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -3,9 +3,11 @@ description: Setup Node.js, pnpm, and install dependencies
 
 inputs:
   node-version:
-    description: Node.js version to install
+    description: Node.js version to install.
     required: false
-    default: "24"
+    # Keep in sync with .nvmrc so a workflow that omits node-version runs the
+    # same major as local development (`nvm use`).
+    default: "20"
   registry-url:
     description: npm registry URL (for publishing)
     required: false

--- a/.github/workflows/auto-version.yml
+++ b/.github/workflows/auto-version.yml
@@ -24,6 +24,9 @@ jobs:
       - name: Setup
         uses: ./.github/actions/setup
         with:
+          # Pin the publish runtime explicitly so it doesn't ride on the setup
+          # action's shared default.
+          node-version: 24
           registry-url: https://registry.npmjs.org
 
       - name: Auto Version Bump and Publish

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,6 +5,9 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -6,6 +6,9 @@ on:
     branches: [main]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   mutation:
     name: mutation (${{ matrix.shard }})

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,9 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/docs/perf-test-flakiness.md
+++ b/docs/perf-test-flakiness.md
@@ -10,7 +10,7 @@ baseline, and asserts the ratio stays below 1.5×.
 This is a custom design and it's flaky in CI: shared-runner CPU contention,
 GC pauses, and per-Node-version JIT differences inflate the ratio even for
 truly linear code. Recent example: `test (22)` failed on PR #175 while
-`test (18)`, `test (20)`, and `test (24)` passed the same code.
+`test (20)` and `test (24)` passed the same code.
 
 The premise of the test is sound — we want to catch ReDoS / super-linear
 regex behaviour. But the **mechanism** (wall-clock scaling) is the wrong
@@ -98,7 +98,7 @@ If we keep the current scaling test, we can dampen its noise:
 - `jest.retryTimes(3, { logErrorsBeforeRetry: true })` for the perf
   describe block. Bandaid, not a fix.
 - Run perf tests on a single Node version in a dedicated job (not in the
-  18/20/22/24 matrix). They don't test Node-version-specific behaviour.
+  20/22/24 matrix). They don't test Node-version-specific behaviour.
 - Skip in CI entirely (`it.skipIf(process.env.CI)`) and run them in a
   separate "benchmark" workflow on a self-hosted runner.
 

--- a/src/dashes.ts
+++ b/src/dashes.ts
@@ -1089,7 +1089,7 @@ function convertMultipleDashes(view: ProseView, rendered: string): void {
   const after = `[${LATIN_LETTERS}${QUOTE_CHARS} ]`
   // Upper bound of 50 prevents ReDoS on pathological runs of dashes.
   const pattern = `(?<=${before})[${EN_DASH}${EM_DASH}-]{2,50}(?=${after})`
-  const afterRe = new RegExp(after)
+  const afterRe = cachedRegExp(after, "")
   pass(
     view,
     cachedRegExp(pattern, "g"),

--- a/src/quote-classifier.ts
+++ b/src/quote-classifier.ts
@@ -817,11 +817,6 @@ function classifyDoubles(items: Item[], style: ActiveQuoteStyle): void {
 // ---------------------------------------------------------------------------
 
 /**
- * Run of consecutive CLOSE_* roles (any depth) starting at `start`, with at
- * most one boundary between consecutive closers. Returns the item index just
- * past the run, or -1 when there is no run.
- */
-/**
  * True iff the item at `index` counts as a closing-run member for placement.
  * An APOSTROPHE directly after an `s` is excluded even when the placement
  * alphabet includes apostrophes: the re-run relabels that U+2019 an
@@ -836,6 +831,11 @@ function closingRunMemberAt(items: Item[], index: number, closingSet: ReadonlySe
   return !isCharItem(items, prev, "s") && !isCharItem(items, prev, "S")
 }
 
+/**
+ * Run of consecutive closing-run members (any depth) starting at `start`, with
+ * at most one boundary between consecutive closers. Returns the item index just
+ * past the run, or -1 when there is no run.
+ */
 function scanClosingRun(items: Item[], start: number, closingSet: ReadonlySet<string>): number {
   if (start >= items.length || items[start].boundary || !closingRunMemberAt(items, start, closingSet)) return -1
   let runEnd = start + 1

--- a/src/symbols.ts
+++ b/src/symbols.ts
@@ -548,7 +548,7 @@ function legalSymbolsOverView(view: ProseView): void {
 /** Matches one arrow shape starting at `start`; returns its end offset or -1. */
 type ArrowMatcher = (view: ProseView, text: string, start: number) => number
 
-const SPACE_OR_TAB_RE = /\s/
+const WHITESPACE_RE = /\s/
 
 /**
  * One boundary is tolerated after `<`, between dash runs, and before `>`, and a
@@ -614,13 +614,13 @@ function matchLeftRightArrow(view: ProseView, text: string, start: number): numb
 /** Left context `(^|\s|${chr})`: start of text, a space, or a node boundary. */
 function arrowLeftContextOk(view: ProseView, text: string, start: number): boolean {
   if (start === 0 || view.hasBoundary(start)) return true
-  return SPACE_OR_TAB_RE.test(text[start - 1])
+  return WHITESPACE_RE.test(text[start - 1])
 }
 
 /** Right context `(?=\s|${chr}|$)`: end of text, a space, or a node boundary. */
 function arrowRightContextOk(view: ProseView, text: string, end: number): boolean {
   if (end >= text.length || view.hasBoundary(end)) return true
-  return SPACE_OR_TAB_RE.test(text[end])
+  return WHITESPACE_RE.test(text[end])
 }
 
 /** Convert -> and <-> to arrows. */


### PR DESCRIPTION
## Summary

A focused pass over the repo for genuine defects. This is already a high-quality codebase (2401 tests, CI-enforced 100% coverage, mutation testing, ReDoS static analysis, SHA-pinned actions, supply-chain hardening), so this PR is deliberately small and targeted — no behavior changes to the library output. The changes group into three buckets:

### Source clarity (no behavior change)
- **`quote-classifier.ts`**: a JSDoc block describing `scanClosingRun` was stacked above the wrong function (`closingRunMemberAt`, which already has its own doc); `scanClosingRun` itself had none. Moved it onto the function it describes and updated the wording to match the helper's vocabulary (`closing-run members`).
- **`dashes.ts`**: `convertMultipleDashes` built its trailing-context regex with `new RegExp(after)`, recompiling a constant pattern on every `hyphenReplace` call and bypassing the module's own `cachedRegExp` convention used 12+ times elsewhere in the file. Routed it through `cachedRegExp`. The pattern is `.test()`-only with empty flags, so this is semantically identical.
- **`symbols.ts`**: `SPACE_OR_TAB_RE` was bound to `/\s/`, which matches *all* whitespace, not just space/tab. Renamed to `WHITESPACE_RE` to stop the name from misdescribing the arrow-context check.

### CI least-privilege
- Added `permissions: { contents: read }` to `test.yml`, `lint.yml`, and `mutation.yml`. These workflows only check out and run build/test/lint, but with no `permissions:` block the `GITHUB_TOKEN` got the repo-default (often read/write) scope on every PR, including from forks. Artifact upload and `actions/cache` in the mutation workflow don't use `GITHUB_TOKEN` scopes, so `contents: read` is sufficient. This matches the supply-chain posture already advertised in `SECURITY.md`.

### Node-version single source
- `.nvmrc` pins Node 20 but the composite setup action hard-coded a default of `24`, so any workflow that omitted `node-version` (lint, coverage-badge, security-scan) silently ran a different major than local development. Aligned the setup action's default to `20`.
- To avoid silently moving the **release** runtime, `auto-version.yml` (npm publish) now pins `node-version: 24` explicitly rather than riding on the shared default — its current behavior is preserved and made intent-explicit.

### Docs accuracy
- `docs/perf-test-flakiness.md` referenced an `18/20/22/24` matrix and a `test (18)` job that no longer exist (the matrix is `[20, 22, 24]`). Updated to match.

## Deliberately excluded
Judgment-call items that would change matching behavior with no evidence they're wanted were left out: e.g. adding `]` to `UNIT_BOUNDARY` in `symbols.ts`, and dropping `nm`/`pm` from `DIMENSION_UNITS`.

## Testing
- `pnpm build`, `pnpm lint`, `pnpm typecheck:scripts` — clean.
- `pnpm test` — 2401 passed, 100% branch/line/function/statement coverage maintained (all changes are renames, a doc move, a cache-routing, and CI YAML; none touch runtime branching).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CqAWbxvhjWwaa6KNK2to6k)_