### PR TITLE
ci: run template sync weekly instead of daily

### DIFF
--- a/.github/workflows/template-sync.yaml
+++ b/.github/workflows/template-sync.yaml
@@ -32,8 +32,8 @@ on:
         default: "false"
         type: boolean
   schedule:
-    # Run daily at 9am UTC
-    - cron: "0 9 * * *"
+    # Run weekly on Mondays at 9am UTC
+    - cron: "0 9 * * 1"
 
 env:
   TEMPLATE_REPO: "alexander-turner/claude-automation-template"


### PR DESCRIPTION
## Summary
- The template-sync workflow ran on a daily cron, which is more frequent than needed for picking up upstream template changes.
- Switch it to a weekly cadence (Mondays 9am UTC) to cut noise and CI usage while still keeping the repo current with the template.

## Changes
- `.github/workflows/template-sync.yaml`: change the `schedule:` cron from `0 9 * * *` (daily) to `0 9 * * 1` (weekly, Mondays), and update the adjacent comment accordingly.

## Testing
- No behavioral code change; manual workflow dispatch and the on-demand sync path are unaffected. Verified the diff is limited to the cron expression and its comment.