### PR TITLE
fix(rehype): stop quotes pairing across block boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- `collectProseBlocks` no longer treats the whitespace text nodes a parser leaves between block siblings as direct text, so containers like `<blockquote>`/`<li>`/`<div>` recurse into their block children instead of merging them. This stops quote classification from pairing across a paragraph boundary (e.g. an interrupted line ending in `—"` no longer flips to an opening quote when the next paragraph starts with `"`).
+
 ## [5.0.8] - 2026-06-23
 
 ### Changed

--- a/src/rehype.ts
+++ b/src/rehype.ts
@@ -462,7 +462,14 @@ function collectProseBlocksImpl(
     return []
   }
 
-  const hasDirectText = node.children.some((child) => child.type === "text")
+  // Whitespace-only text nodes between block siblings (the newlines a parser
+  // leaves between <p>s inside a <blockquote>, <li>, or <div>) are not prose.
+  // Counting them as direct text would make a block container look like a leaf
+  // and merge its blocks into one transform unit, pairing quotes across the
+  // paragraph boundary. Real (non-whitespace) direct text still marks a leaf.
+  const hasDirectText = node.children.some(
+    (child) => child.type === "text" && child.value.trim() !== ""
+  )
   // Only check for block children and text descendants when there's no direct text
   // (short-circuit avoids unnecessary tree traversal)
   const hasBlockChildren = !hasDirectText && node.children.some(

--- a/src/tests/rehype.test.ts
+++ b/src/tests/rehype.test.ts
@@ -138,6 +138,19 @@ describe("rehypePunctilio", () => {
     })
   })
 
+  describe("quotes do not pair across block boundaries", () => {
+    // Whitespace text nodes between block siblings must not merge the blocks
+    // into one transform unit: an interrupted line ending in `—"` would then
+    // see the next paragraph's opening `"` and flip to an opener.
+    it("closes an interrupted line ending before a new quoted paragraph", async () => {
+      const html =
+        '<blockquote>\n<p>Riesz spoke. "We make them do analysis, because they deserve --"</p>\n<p>"Frigyes, some might do that."</p>\n</blockquote>'
+      const expected =
+        `<blockquote>\n<p>Riesz spoke. ${LDQ}We make them do analysis, because they deserve${EM_DASH}${RDQ}</p>\n<p>${LDQ}Frigyes, some might do that.${RDQ}</p>\n</blockquote>`
+      expect(await processHtml(html, { nbsp: false })).toEqual(expected)
+    })
+  })
+
   describe("dashes across element boundaries", () => {
     it.each([
       ["multi-segment number preserved", "<p>1-<em>2</em>-3</p>", "<p>1-<em>2</em>-3</p>"],
@@ -607,6 +620,27 @@ describe("rehypePunctilio", () => {
         expect(result).toHaveLength(2)
         expect(result[0].tagName).toBe("p")
         expect(result[1].tagName).toBe("p")
+      })
+
+      it("recurses past whitespace-only text between block children", () => {
+        // Parsers leave newline text nodes between block siblings. They must
+        // not make the container a leaf, or its blocks merge into one unit and
+        // quotes pair across the paragraph boundary.
+        const tree: Element = {
+          type: "element",
+          tagName: "blockquote",
+          properties: {},
+          children: [
+            { type: "text", value: "\n" },
+            h("p", "First") as ElementContent,
+            { type: "text", value: "\n" },
+            h("p", "Second") as ElementContent,
+            { type: "text", value: "\n" },
+          ],
+        }
+        const result = collectProseBlocks(tree)
+        expect(result).toHaveLength(2)
+        expect(result.map((b) => b.tagName)).toEqual(["p", "p"])
       })
 
       it("collects inline-only div as single unit", () => {


### PR DESCRIPTION
## Summary

A blockquote of dialogue rendered a misdirected closing quote: an interrupted line ending in `—"` came out with an **opening** curly quote (`—“`) instead of a closing one (`—”`).

Root cause is in `collectProseBlocks`. It decided whether an element was a single "prose block" or a container to recurse into by checking for *any* direct text child:

```ts
const hasDirectText = node.children.some((child) => child.type === "text")
```

Real parsers leave whitespace text nodes (the newlines between `<p>` siblings) as direct children of a `<blockquote>`/`<li>`/`<div>`. Those whitespace nodes made `hasDirectText` true, so the whole container was collected as **one** merged prose block instead of recursing into each paragraph — contradicting the function's own docstring ("Elements with block-level children recurse so each block transforms independently").

With the paragraphs merged into one transform unit, quote classification ran across the paragraph boundary: the closing `"` of one paragraph saw the opening `"` of the next and flipped to an opener.

## Fix

Count only **non-whitespace** direct text, so block containers recurse into their children as documented. Real (non-whitespace) direct text still marks a leaf, so mixed-content containers are unaffected.

```ts
const hasDirectText = node.children.some(
  (child) => child.type === "text" && child.value.trim() !== ""
)
```

## Verification

- `collectProseBlocks` over a `<blockquote>` with newline text nodes between two `<p>`s now returns 2 blocks (`["p", "p"]`) instead of 1.
- End-to-end: `…they deserve --"` followed by a new `"…"` paragraph now renders `…they deserve—”` (closing) and `“…”` (opening).
- Full suite: 2403 tests pass, 100% coverage; `pnpm lint` and `pnpm build` clean.
- Added a unit test (whitespace between block children recurses) and an end-to-end test (closer before a new quoted paragraph).

This is the upstream fix for the misdirected quote mark in the turntrout.com "A Friendly Approach to Functional Analysis" review; turntrout picks it up via a punctilio version bump once released.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UGrBv4me3kvx5KnwwUKzGN)_