### PR TITLE
fix(nbsp): prefer last-word widow protection over short-word glue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Changed
+
+- Last-word widow protection now wins over an aesthetic short-word glue on the second-to-last word. When the two conflict (e.g. a sentence ending "…in the head."), the short-word glue ("in"+NBSP+"the") yields so the final pair binds ("the"+NBSP+"head.") instead of orphaning the last word onto its own line. The non-breaking run stays two words, and semantic glues (honorifics, abbreviations, units) still hold.
+
 ## [5.0.9] - 2026-06-26
 
 

--- a/src/nbsp.ts
+++ b/src/nbsp.ts
@@ -209,22 +209,24 @@ function precedingGlueNbsp(view: ProseView, spaceOffset: number): number {
 }
 
 /**
- * True when the NBSP at `nbspIndex` glues a 1–2 letter Latin word — an
- * aesthetic short-word glue that yields to last-word protection. Semantic glues
- * (honorifics, abbreviations, units) end in "."/a digit/a symbol before the
- * NBSP and must hold, so they read as not-a-short-word-glue here.
+ * True when the word immediately before the NBSP at `nbspIndex` is a 1–2 letter
+ * Latin word whose own left edge is a word boundary — an aesthetic short-word
+ * glue that yields to last-word protection. Semantic glues (honorific `Dr.`,
+ * abbreviation, unit `12`) carry a "."/digit/symbol right before the NBSP, so
+ * the backward letter scan finds zero letters and returns false. The scan is
+ * capped at three letters so it stays bounded on a long preceding word.
  */
 function isShortWordGlue(view: ProseView, nbspIndex: number): boolean {
   const text = view.text
   let k = nbspIndex - 1
   let letters = 0
-  while (k >= 0 && !view.hasBoundary(k + 1) && LATIN_LETTER_RE.test(text[k])) {
+  while (k >= 0 && letters <= 2 && !view.hasBoundary(k + 1) && LATIN_LETTER_RE.test(text[k])) {
     k--
     letters++
   }
   if (letters === 0 || letters > 2 || view.hasBoundary(k + 1)) return false
   // The short word's left edge must be a real word boundary, matching
-  // nbspAfterShortWords' lookbehind; an NBSP there would be a longer chain.
+  // nbspAfterShortWords' lookbehind — not another NBSP.
   return !(k >= 0 && NBSP_CHARS.includes(text[k]))
 }
 

--- a/src/nbsp.ts
+++ b/src/nbsp.ts
@@ -187,16 +187,16 @@ function nbspBetweenNumberAndUnitOverView(view: ProseView): void {
 
 const MAX_LAST_WORD_LENGTH = 10
 
-// Bounded so the lookbehind stays ReDoS-safe.
+// Bounds the backward second-to-last-word scan so it stays linear.
 const MAX_MIDDLE_WORD_LENGTH = 15
 
 /**
- * The cascade lookbehind `(?<![NBSP][LATIN]{1,15})` over clean text: blocks
- * when an NBSP/NNBSP is followed by 1..15 Latin letters ending at the space. A
- * node boundary anywhere in that backward run breaks the run, re-enabling the
- * match.
+ * Walks back over the second-to-last word to the NBSP gluing it to the word
+ * before it; returns that NBSP's index, or -1 when the word isn't glued
+ * backwards (so the last word is free to bind). A node boundary anywhere in the
+ * backward run breaks the run. Bounded so the scan stays ReDoS-safe.
  */
-function cascadeBlocksLastWord(view: ProseView, spaceOffset: number): boolean {
+function precedingGlueNbsp(view: ProseView, spaceOffset: number): number {
   const text = view.text
   let j = spaceOffset - 1
   let run = 0
@@ -204,16 +204,38 @@ function cascadeBlocksLastWord(view: ProseView, spaceOffset: number): boolean {
     j--
     run++
   }
-  if (run === 0 || view.hasBoundary(j + 1)) return false
-  return j >= 0 && NBSP_CHARS.includes(text[j])
+  if (run === 0 || view.hasBoundary(j + 1)) return -1
+  return j >= 0 && NBSP_CHARS.includes(text[j]) ? j : -1
 }
 
-// Skips when the second-to-last word is already glued backwards via NBSP.
+/**
+ * True when the NBSP at `nbspIndex` glues a 1–2 letter Latin word — an
+ * aesthetic short-word glue that yields to last-word protection. Semantic glues
+ * (honorifics, abbreviations, units) end in "."/a digit/a symbol before the
+ * NBSP and must hold, so they read as not-a-short-word-glue here.
+ */
+function isShortWordGlue(view: ProseView, nbspIndex: number): boolean {
+  const text = view.text
+  let k = nbspIndex - 1
+  let letters = 0
+  while (k >= 0 && !view.hasBoundary(k + 1) && LATIN_LETTER_RE.test(text[k])) {
+    k--
+    letters++
+  }
+  if (letters === 0 || letters > 2 || view.hasBoundary(k + 1)) return false
+  // The short word's left edge must be a real word boundary, matching
+  // nbspAfterShortWords' lookbehind; an NBSP there would be a longer chain.
+  return !(k >= 0 && NBSP_CHARS.includes(text[k]))
+}
+
+// When the second-to-last word is already glued backwards, an aesthetic
+// short-word glue yields (reverts to a space) so the last word binds instead,
+// keeping the non-breaking run to two words; a semantic glue there blocks.
 export const nbspBeforeLastWord = makeProsePass(nbspBeforeLastWordOverView)
 
 function nbspBeforeLastWordOverView(view: ProseView): void {
-  // The `(?<=\w|boundary)` lookbehind and the `[NBSP][LATIN]{1,15}` cascade
-  // lookbehind are enforced in the replacer, where boundaries are visible.
+  // The `(?<=\w|boundary)` lookbehind and the preceding-glue resolution are
+  // enforced in the replacer, where boundaries are visible.
   const pattern = cachedRegExp(
     `${SPACE}(?<lastWord>(?:(?!\\s).){1,${MAX_LAST_WORD_LENGTH}})(?<ending>\\n\\n|$)`,
     "g"
@@ -229,7 +251,12 @@ function nbspBeforeLastWordOverView(view: ProseView): void {
         // `(?<=\w|sep)`: a word char before the space, or a boundary there.
         const precededByWord = start > 0 && /\w/.test(clean[start - 1])
         if (!precededByWord && !view.hasBoundary(start)) return null
-        if (cascadeBlocksLastWord(v, start)) return null
+        const glueNbsp = precedingGlueNbsp(v, start)
+        if (glueNbsp >= 0) {
+          if (!isShortWordGlue(v, glueNbsp)) return null
+          // Revert the short word's glue so the last word binds in its place.
+          v.replace(glueNbsp, glueNbsp + 1, " ")
+        }
         // The `ending` group tolerates exactly one boundary at the slot before
         // `\n\n`/end-of-text; two adjacent boundaries block the match. The
         // end-of-text slot sits at the match end (never an interior boundary),

--- a/src/tests/html-corpus/corpus.json
+++ b/src/tests/html-corpus/corpus.json
@@ -126,9 +126,9 @@
     {
       "input": "<div><p>\"This is the first paragraph of dialogue.</p><p>\"And this is the second.\"</p></div>",
       "outputs": {
-        "american": "<div><p>“This is the first paragraph of dialogue.</p><p>“And this is the second.”</p></div>",
-        "british": "<div><p>“This is the first paragraph of dialogue.</p><p>“And this is the second”.</p></div>",
-        "german": "<div><p>„This is the first paragraph of dialogue.</p><p>„And this is the second“.</p></div>",
+        "american": "<div><p>“This is the first paragraph of dialogue.</p><p>“And this is the second.”</p></div>",
+        "british": "<div><p>“This is the first paragraph of dialogue.</p><p>“And this is the second”.</p></div>",
+        "german": "<div><p>„This is the first paragraph of dialogue.</p><p>„And this is the second“.</p></div>",
         "french": "<div><p>« This is the first paragraph of dialogue.</p><p>« And this is the second ».</p></div>"
       }
     },
@@ -174,7 +174,7 @@
         "american": "<p>“Use <code>transform(\"hello\")</code> to apply.”</p>",
         "british": "<p>“Use <code>transform(\"hello\")</code> to apply”.</p>",
         "german": "<p>„Use <code>transform(\"hello\")</code> to apply“.</p>",
-        "french": "<p>« Use <code>transform(\"hello\")</code> to apply ».</p>"
+        "french": "<p>« Use <code>transform(\"hello\")</code> to apply ».</p>"
       }
     },
     {

--- a/src/tests/nbsp-boundaries.test.ts
+++ b/src/tests/nbsp-boundaries.test.ts
@@ -76,12 +76,12 @@ describe("nbsp boundary tolerance", () => {
     expect(viewTransform(nbspAfterShortWords, "a cat")).toBe(`a${NBSP}cat`)
   })
 
-  it("a boundary breaks the NBSP cascade run, re-enabling the last-word match", () => {
-    // `x` + NBSP + `word` would normally block (cascade), but a boundary between
-    // the run and the space breaks `[NBSP][LATIN]{1,15}`.
+  it("relocates an aesthetic short-word glue so the last word binds", () => {
+    // A boundary between the run and the space stops the backward walk, so the
+    // last word binds directly without disturbing the `x`+NBSP glue.
     expect(viewTransform(nbspBeforeLastWord, `x${NBSP}word${S} end`))
       .toBe(`x${NBSP}word${S}${NBSP}end`)
-    // Without the boundary, the cascade blocks the widow protection.
-    expect(nbspBeforeLastWord(`x${NBSP}word end`)).toBe(`x${NBSP}word end`)
+    // Without the boundary, the short-word glue on `x` yields to the last word.
+    expect(nbspBeforeLastWord(`x${NBSP}word end`)).toBe(`x word${NBSP}end`)
   })
 })

--- a/src/tests/nbsp.test.ts
+++ b/src/tests/nbsp.test.ts
@@ -267,12 +267,13 @@ describe("nbspTransform", () => {
 
   describe("widow-protection cascade", () => {
     it.each([
-      // Existing NBSP chain wins: widow protection skipped so the phrase
-      // doesn't become a 3-word non-breaking atom.
-      ["an Activation Vector", `an${NBSP}Activation Vector`],
-      ["in the cat", `in${NBSP}the cat`],
-      ["On the run", `On${NBSP}the run`],
-      ["by Adding an Activation Vector", `by${NBSP}Adding an${NBSP}Activation Vector`],
+      // An aesthetic short-word glue on the second-to-last word yields so the
+      // last word binds instead; the non-breaking run stays two words.
+      ["an Activation Vector", `an Activation${NBSP}Vector`],
+      ["in the cat", `in the${NBSP}cat`],
+      ["On the run", `On the${NBSP}run`],
+      ["by Adding an Activation Vector", `by${NBSP}Adding an Activation${NBSP}Vector`],
+      // A semantic glue (honorific) holds, so the last word is left unprotected.
       ["Prof. Wilson arrived", `Prof.${NBSP}Wilson arrived`],
       ["Dr. Smith waited", `Dr.${NBSP}Smith waited`],
     ])('"%s" → "%s"', (input, expected) => {

--- a/src/tests/remark.test.ts
+++ b/src/tests/remark.test.ts
@@ -48,7 +48,7 @@ describe("remarkPunctilio", () => {
   describe("basic transformations (nbsp enabled)", () => {
     it.each([
       ["quotes", '"Hello," she said.', `${LDQ}Hello,${RDQ} she${NBSP}said.`],
-      ["apostrophes", "It's a test.", `It${RSQ}s${NBSP}a test.`],
+      ["apostrophes", "It's a test.", `It${RSQ}s a${NBSP}test.`],
       ["em dashes", "Wait -- here it comes.", `Wait${EM_DASH}here it${NBSP}comes.`],
       ["en dashes (number range)", "Pages 1-5", `Pages${NBSP}1${EN_DASH}5`],
       ["ellipses", "Wait...", `Wait${ELLIPSIS}`],


### PR DESCRIPTION
## Summary

- A sentence-final word could orphan onto its own line even though `nbspBeforeLastWord` exists to prevent exactly that. When a short-word glue (e.g. `in`+NBSP+`the`) landed on the second-to-last word, the cascade guard suppressed widow protection entirely to avoid a 3-word non-breaking atom — leaving the last word free to wrap alone (`…shot them in the` / `head.`).
- Now the *aesthetic* short-word glue **yields** to last-word protection: its NBSP reverts to a space so the final pair binds instead (`the`+NBSP+`head.`). The non-breaking run stays two words. *Semantic* glues (honorifics, abbreviations, units) still hold and continue to block the trailing word.

## Changes

- `src/nbsp.ts`: replace the `cascadeBlocksLastWord` predicate with `precedingGlueNbsp` (locates the NBSP gluing the second-to-last word backward) + `isShortWordGlue` (classifies it as a 1–2 letter Latin short-word glue vs. a semantic glue). In `nbspBeforeLastWordOverView`, when the blocker is a short-word glue, revert it to a space and let the last word bind; a semantic glue still returns early. The two single-char edits (`glueNbsp`→space, `start`→NBSP) never overlap.
- Updated expectations to the new behavior: the `widow-protection cascade` cases (`nbsp.test.ts`), the standalone boundary case (`nbsp-boundaries.test.ts`), the `It's a test.` remark case, and two regenerated `html-corpus` entries (dialogue `second.` binds; the French `to apply` case now normalizes consistently with the other French entries).
- `CHANGELOG.md`: note the behavior change under Unreleased.

## Testing

- `pnpm test` — full suite green (2403 passed), 100% statements/branches/functions/lines on `nbsp.ts`.
- `pnpm lint` clean; `node scripts/generate-html-corpus.mjs` produces no further diff.
- Verified end-to-end on the motivating sentence: `…and shot them in the head.` → `…and shot them in the`+NBSP+`head.`, while `Prof.`+NBSP+`Wilson arrived` and `on`+NBSP+`p.`+NBSP+`42` are unchanged.


---
_Generated by [Claude Code](https://claude.ai/code/session_019rKNz88qEEv3ZsEC42k8Be)_