### PR TITLE
test(benchmark): add real-world cases from brendanlong.com

### DIFF
--- a/benchmark_cases.json
+++ b/benchmark_cases.json
@@ -405,6 +405,10 @@
     [
       "Qwen1.5-1.8B",
       "Qwen1.5-1.8B"
+    ],
+    [
+      "with a Ryzen 9 5900X (12 core / 24 thread) processor.",
+      "with a Ryzen 9 5900X (12 core / 24 thread) processor."
     ]
   ],
   "Multi-segment pattern preservation": [
@@ -729,6 +733,42 @@
     [
       "desk 120 cm x 60 cm x 75 cm",
       "desk 120 cm × 60 cm × 75 cm"
+    ]
+  ],
+  "Quoted prefixes ending in hyphen": [
+    [
+      "splitting an \"un-\" or \"non-\" prefix into a separate token",
+      "splitting an “un-” or “non-” prefix into a separate token"
+    ],
+    [
+      "hundreds of individual tokens starting with \"un-\" and \"non-\", or cases",
+      "hundreds of individual tokens starting with “un-” and “non-”, or cases"
+    ]
+  ],
+  "Quoted string with trailing space (known limitation)": [
+    [
+      "the increment for \"New \", the model needs to decide before it sees \"York\".",
+      "the increment for “New ”, the model needs to decide before it sees “York.”"
+    ]
+  ],
+  "Multiplication - realistic prose": [
+    [
+      "each sprite is usually 16x16 pixels, so processing 14x14 patches",
+      "each sprite is usually 16×16 pixels, so processing 14×14 patches"
+    ],
+    [
+      "reduces your effective context length by 4x.",
+      "reduces your effective context length by 4×."
+    ]
+  ],
+  "Identifier and URL-encoding preservation": [
+    [
+      "W3C has a way to generate URNs from the HTML5 spec",
+      "W3C has a way to generate URNs from the HTML5 spec"
+    ],
+    [
+      "#:~:text=In%202020%2C%20the%20U.S.%20Census",
+      "#:~:text=In%202020%2C%20the%20U.S.%20Census"
     ]
   ]
 }


### PR DESCRIPTION
I'm not sure if this is useful, but I had Claude audit punctilio false-positives if I enabled all of the settings, and it found some cases you might want to handle:

- Quoted prefixes ending in hyphen: the closer of "un-"/"non-" currently re-opens via the quoted-punctuation rule when another quote follows in the block (renders as a second opening quote). https://www.brendanlong.com/shorter-tokens-are-more-likely.html
- Quoted string with trailing space (known limitation): "New ", flips its closer into an opener the same way; ideal output keeps an exact-string closer before the comma. https://www.brendanlong.com/how-far-apart-does-a-model-think-its-tokens-are.html
- Model name preservation: "Ryzen 9 5900X" currently converts the SKU suffix to a multiplication sign. https://www.brendanlong.com/cpu-utilization-is-a-lie.html
- Multiplication - realistic prose: "16x16 pixels", "by 4x." from running prose (Claude suggested a passing version to match the failing one). https://www.brendanlong.com/llms-cant-see-pixels-or-characters.html
- Identifier and URL-encoding preservation: "W3C", "%2C" snippets get converted to degrees Celcius (already passing with default options, where degrees is disabled). https://www.brendanlong.com/common-informative-metadata-in-mpeg-dash.html and https://www.brendanlong.com/doing-a-thing-puts-you-in-the-top-10-and-that-sucks.html

The "New " case might be ambiguous but would be better if it was left straight. I think "un-" and "non-" are fixable and may be common in some types of writing (a quote that gets cut off). W3C should be fixable by detecting that the word doesn't start with a digit.

For what it's worth, Claude proposed these fixes (https://github.com/brendanlong/punctilio/commits/fix/quote-and-symbol-false-positives/) but I don't understand the code well enough to review this, so I figured proposing the test cases would be more useful than unreviewed AI-written code. I'm also unsure if you'd want to fix the Ryzen 5900X case or if the false positive here is acceptable.