### PR TITLE
fix: resolve quote, multiplication, and degree false positives from real-world prose (#244)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,7 +43,7 @@ jobs:
           node-version: 22
 
       - name: Run benchmark
-        run: pnpm build && node benchmark.mjs --min-passes 150
+        run: pnpm build && node benchmark.mjs --min-passes 158
 
   all-checks-passed:
     name: All checks passed

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,7 @@ reports/
 *.log
 .DS_Store
 *~
+
+# Local Claude Code settings and Python hook bytecode cache
+.claude/settings.local.json
+.claude/hooks/__pycache__/

--- a/benchmark_cases.json
+++ b/benchmark_cases.json
@@ -405,6 +405,10 @@
     [
       "Qwen1.5-1.8B",
       "Qwen1.5-1.8B"
+    ],
+    [
+      "with a Ryzen 9 5900X (12 core / 24 thread) processor.",
+      "with a Ryzen 9 5900X (12 core / 24 thread) processor."
     ]
   ],
   "Multi-segment pattern preservation": [
@@ -729,6 +733,42 @@
     [
       "desk 120 cm x 60 cm x 75 cm",
       "desk 120 cm × 60 cm × 75 cm"
+    ]
+  ],
+  "Quoted prefixes ending in hyphen": [
+    [
+      "splitting an \"un-\" or \"non-\" prefix into a separate token",
+      "splitting an “un-” or “non-” prefix into a separate token"
+    ],
+    [
+      "hundreds of individual tokens starting with \"un-\" and \"non-\", or cases",
+      "hundreds of individual tokens starting with “un-” and “non-”, or cases"
+    ]
+  ],
+  "Quoted string with trailing space (known limitation)": [
+    [
+      "the increment for \"New \", the model needs to decide before it sees \"York\".",
+      "the increment for “New ”, the model needs to decide before it sees “York.”"
+    ]
+  ],
+  "Multiplication - realistic prose": [
+    [
+      "each sprite is usually 16x16 pixels, so processing 14x14 patches",
+      "each sprite is usually 16×16 pixels, so processing 14×14 patches"
+    ],
+    [
+      "reduces your effective context length by 4x.",
+      "reduces your effective context length by 4×."
+    ]
+  ],
+  "Identifier and URL-encoding preservation": [
+    [
+      "W3C has a way to generate URNs from the HTML5 spec",
+      "W3C has a way to generate URNs from the HTML5 spec"
+    ],
+    [
+      "#:~:text=In%202020%2C%20the%20U.S.%20Census",
+      "#:~:text=In%202020%2C%20the%20U.S.%20Census"
     ]
   ]
 }

--- a/src/quote-classifier.ts
+++ b/src/quote-classifier.ts
@@ -721,19 +721,37 @@ function quotedPunctuationPrefixOk(items: Item[], index: number): boolean {
  * Quoted-punctuation openers like `"?"`: an opener-prefixed straight double
  * quote with a closing straight double quote anywhere ahead (at least one
  * item between them). Decisions use the pass-start set of straight quotes.
+ *
+ * Inside an already-open double quote the same shape is that quote's closer,
+ * not a new opener: in `"un-" or "non-"` the quote after `un-` is
+ * opener-prefixed (a hyphen) with a straight quote ahead, but it closes the
+ * open `“un-`. A running depth of classified doubles — updated as this pass
+ * assigns roles, so each decision sees the ones before it — picks the reading.
  */
 function classifyQuotedPunctuationOpeners(items: Item[]): void {
   const straightIndices: number[] = []
   for (let i = 0; i < items.length; i++) {
     if (isCharItem(items, i, '"')) straightIndices.push(i)
   }
-  for (let k = 0; k < straightIndices.length; k++) {
-    const i = straightIndices[k]
-    if (!quotedPunctuationPrefixOk(items, i)) continue
-    const closer = straightIndices[k + 1]
-    if (closer !== undefined && closer >= i + 2) {
-      items[i].ch = LEFT_DOUBLE_QUOTE
+  let openDepth = 0
+  let k = 0
+  for (let i = 0; i < items.length; i++) {
+    const item = items[i]
+    if (item.boundary) continue
+    if (k < straightIndices.length && straightIndices[k] === i) {
+      // `i` is a pass-start straight quote; after k++, `straightIndices[k]`
+      // is the nearest pass-start straight quote ahead of it.
+      k++
+      const closer = straightIndices[k]
+      if (quotedPunctuationPrefixOk(items, i) && closer !== undefined && closer >= i + 2) {
+        item.ch = openDepth > 0 ? RIGHT_DOUBLE_QUOTE : LEFT_DOUBLE_QUOTE
+      }
     }
+    // Depth over classified doubles, including the role just assigned above.
+    // A still-straight double quote below an open `“` counts as its closer:
+    // the closing rules classify it that way after this pass ends.
+    if (item.ch === LEFT_DOUBLE_QUOTE) openDepth++
+    else if ((item.ch === RIGHT_DOUBLE_QUOTE || item.ch === '"') && openDepth > 0) openDepth--
   }
 }
 
@@ -957,6 +975,13 @@ function movePunctuationInside(order: Item[], isMovable: (items: Item[], index: 
       continue
     }
     if (insideMoveFlipsContext(order, runStart, punctIndex)) {
+      position++
+      continue
+    }
+    // A space directly before the run marks an exact-string quote (`"New ",`):
+    // its content ends in whitespace on purpose, and pulling the punctuation
+    // inside would attach it to that verbatim trailing space.
+    if (beforeIndex >= 0 && !order[beforeIndex].boundary && SPACE_RE.test(order[beforeIndex].ch)) {
       position++
       continue
     }

--- a/src/symbols.ts
+++ b/src/symbols.ts
@@ -368,6 +368,10 @@ function multiplicationOverView(view: ProseView): void {
     // trailing `\b`; otherwise reject when a word character follows the operator
     // through at most three boundaries.
     if (op === "*") continue
+    // An uppercase `X` directly attached to the digits is a model/SKU suffix
+    // (Ryzen 9 5900X), not a multiplier — prose multipliers write a lowercase
+    // x ("by 4x."). Chains ("16X16") convert above regardless of case.
+    if (op === "X") continue
     const afterOp = operatorOffset + 1
     const followChar = trailingText[afterOp]
     if (boundaryCountAt(view, afterOp) <= MAX_BOUNDARY_SEPARATORS && followChar !== undefined && WORD_RE.test(followChar)) continue
@@ -644,6 +648,20 @@ function arrowsOverView(view: ProseView): void {
   }
 }
 
+/**
+ * A temperature's digit run starts a word: a letter directly before the run
+ * makes it an identifier ("W3C", "HTML5C"), and a `%` makes it a URL-encoded
+ * octet ("%2C"). Mirrors {@link chainGuardOk}'s boundary handling — a node
+ * boundary at the run start shadows the prior character and the guard passes.
+ */
+function degreeLeadingGuardOk(text: string, view: ProseView, digitIndex: number): boolean {
+  let start = digitIndex
+  while (start > 0 && /\d/.test(text[start - 1]) && !view.hasBoundary(start)) start--
+  if (view.hasBoundary(start)) return true
+  const prior = text[start - 1]
+  return prior === undefined || (!LATIN_LETTER_RE.test(prior) && prior !== "%")
+}
+
 export const degrees = makeProsePass(degreesOverView)
 
 function degreesOverView(view: ProseView): void {
@@ -657,6 +675,7 @@ function degreesOverView(view: ProseView): void {
   const text = view.text
   replaceAllInView(view, pattern, (match, v) => {
     const unitEnd = match.index + match[0].length
+    if (!degreeLeadingGuardOk(text, v, match.index)) return null
     if (!degreeUnitFollowOk(text, v, unitEnd)) return null
     const { unit } = match.groups!
     // Replace everything after the leading digit (the optional space and the

--- a/src/tests/quotes.test.ts
+++ b/src/tests/quotes.test.ts
@@ -717,6 +717,17 @@ describe("niceQuotes", () => {
       ['"Bonjour," dit-il.', `${LEFT_GUILLEMET}${NNBSP}Bonjour${NNBSP}${RIGHT_GUILLEMET}, dit-il.`, { punctuationStyle: "french" as const }],
       // German leading apostrophe ('Twas)
       ["'Twas the night", `${RIGHT_SINGLE_QUOTE}Twas the night`, { punctuationStyle: "german" as const }],
+      // Hyphen-ended quoted prefixes close (not re-open) in every locale
+      [
+        '"un-" or "non-", done',
+        `${DOUBLE_LOW_9_QUOTE}un-${LEFT_DOUBLE_QUOTE} or ${DOUBLE_LOW_9_QUOTE}non-${LEFT_DOUBLE_QUOTE}, done`,
+        { punctuationStyle: "german" as const },
+      ],
+      [
+        '"un-" or "non-", done',
+        `${LEFT_GUILLEMET}${NNBSP}un-${NNBSP}${RIGHT_GUILLEMET} or ${LEFT_GUILLEMET}${NNBSP}non-${NNBSP}${RIGHT_GUILLEMET}, done`,
+        { punctuationStyle: "french" as const },
+      ],
     ])("locale quotes: %s → %s", (input, expected, options) => {
       it("transforms correctly", () => {
         expect(niceQuotes(input, options)).toBe(expected)

--- a/src/tests/quotes.test.ts
+++ b/src/tests/quotes.test.ts
@@ -50,6 +50,9 @@ describe("niceQuotes", () => {
       ['"Game"/"Life"', `${LEFT_DOUBLE_QUOTE}Game${RIGHT_DOUBLE_QUOTE}/${LEFT_DOUBLE_QUOTE}Life${RIGHT_DOUBLE_QUOTE}`],
       ['"Test:".', `${LEFT_DOUBLE_QUOTE}Test:${RIGHT_DOUBLE_QUOTE}.`],
       ['"Test...".', `${LEFT_DOUBLE_QUOTE}Test...${RIGHT_DOUBLE_QUOTE}.`],
+      // Dots before the closer: the period stays outside either way.
+      ['"Test . . .".', `${LEFT_DOUBLE_QUOTE}Test . . .${RIGHT_DOUBLE_QUOTE}.`],
+      ['"Test .".', `${LEFT_DOUBLE_QUOTE}Test .${RIGHT_DOUBLE_QUOTE}.`],
       [`"To maximize reward${ELLIPSIS}".`, `${LEFT_DOUBLE_QUOTE}To maximize reward${ELLIPSIS}${RIGHT_DOUBLE_QUOTE}.`],
       ['"Test"s', `${LEFT_DOUBLE_QUOTE}Test${RIGHT_DOUBLE_QUOTE}s`],
       // End-of-line quote becomes RIGHT quote
@@ -70,6 +73,32 @@ describe("niceQuotes", () => {
       ['why not "?"', `why not ${LEFT_DOUBLE_QUOTE}?${RIGHT_DOUBLE_QUOTE}`],
       ['She asked "?" and left.', `She asked ${LEFT_DOUBLE_QUOTE}?${RIGHT_DOUBLE_QUOTE} and left.`],
       ['("?")', `(${LEFT_DOUBLE_QUOTE}?${RIGHT_DOUBLE_QUOTE})`],
+      // Inside an open double quote, an opener-prefixed quote in ending
+      // position is that quote's closer, not a quoted-punctuation opener —
+      // even with another straight quote ahead.
+      [
+        'splitting an "un-" or "non-" prefix into a separate token',
+        `splitting an ${LEFT_DOUBLE_QUOTE}un-${RIGHT_DOUBLE_QUOTE} or ${LEFT_DOUBLE_QUOTE}non-${RIGHT_DOUBLE_QUOTE} prefix into a separate token`,
+      ],
+      [
+        'tokens starting with "un-" and "non-", or cases',
+        `tokens starting with ${LEFT_DOUBLE_QUOTE}un-${RIGHT_DOUBLE_QUOTE} and ${LEFT_DOUBLE_QUOTE}non-${RIGHT_DOUBLE_QUOTE}, or cases`,
+      ],
+      // Exact-string quote with a trailing space: the quote closes and the
+      // comma stays outside instead of attaching to the verbatim space.
+      [
+        'the increment for "New ", before it sees "York".',
+        `the increment for ${LEFT_DOUBLE_QUOTE}New ${RIGHT_DOUBLE_QUOTE}, before it sees ${LEFT_DOUBLE_QUOTE}York.${RIGHT_DOUBLE_QUOTE}`,
+      ],
+      // A quoted-punctuation opener after a completed quote still opens: the
+      // completed quote's straight closer consumes the open depth.
+      ['"a" and "?" then', `${LEFT_DOUBLE_QUOTE}a${RIGHT_DOUBLE_QUOTE} and ${LEFT_DOUBLE_QUOTE}?${RIGHT_DOUBLE_QUOTE} then`],
+      ['"?" and "!" marks', `${LEFT_DOUBLE_QUOTE}?${RIGHT_DOUBLE_QUOTE} and ${LEFT_DOUBLE_QUOTE}!${RIGHT_DOUBLE_QUOTE} marks`],
+      // A stray closer before the passage does not push the depth negative.
+      [
+        `plain${RIGHT_DOUBLE_QUOTE} then "un-" or "non-", done`,
+        `plain${RIGHT_DOUBLE_QUOTE} then ${LEFT_DOUBLE_QUOTE}un-${RIGHT_DOUBLE_QUOTE} or ${LEFT_DOUBLE_QUOTE}non-${RIGHT_DOUBLE_QUOTE}, done`,
+      ],
     ])('handles quoted punctuation: "%s"', (input, expected) => {
       expect(classifyApostrophes(input)).toBe(expected)
     })

--- a/src/tests/symbols.test.ts
+++ b/src/tests/symbols.test.ts
@@ -85,6 +85,11 @@ describe("multiplication", () => {
     ["5xword", "5xword"],
     ["10xbox", "10xbox"],
     ["2xLarge", "2xLarge"],
+    // Trailing uppercase X attached to the digits is a model/SKU suffix
+    ["with a Ryzen 9 5900X (12 core / 24 thread) processor.", "with a Ryzen 9 5900X (12 core / 24 thread) processor."],
+    ["faster by 4X", "faster by 4X"],
+    // ...but uppercase chains still convert
+    ["16X16", `16${UNICODE_SYMBOLS.MULTIPLICATION}16`],
     // Dimensions with prime marks already attached (post primeMarks pass)
     [`10′ x 12′`, `10′ ${UNICODE_SYMBOLS.MULTIPLICATION} 12′`],
     [`Room is 10′ x 12′`, `Room is 10′ ${UNICODE_SYMBOLS.MULTIPLICATION} 12′`],
@@ -306,6 +311,12 @@ describe("degrees", () => {
     ["20 C++", "20 C++"],
     ["20 C#", "20 C#"],
     ["100 F#", "100 F#"],
+    // Digit run preceded by a letter is an identifier, not a temperature
+    ["W3C has a spec", "W3C has a spec"],
+    ["the HTML5C variant", "the HTML5C variant"],
+    // Digit run preceded by % is a URL-encoded octet
+    ["%2C", "%2C"],
+    ["#:~:text=In%202020%2C%20the%20U.S.%20Census", "#:~:text=In%202020%2C%20the%20U.S.%20Census"],
   ])('converts "%s" to "%s"', (input, expected) => {
     expect(degrees(input)).toBe(expected)
   })
@@ -326,6 +337,10 @@ describe("degrees", () => {
       ["false boundary before word char", `20C${sep}elsius`, `20C${sep}elsius`], // "20Celsius" - should NOT convert
       ["valid boundary before space", `20C${sep} today`, `20 ${UNICODE_SYMBOLS.DEGREE}C${sep} today`], // should convert
       ["valid boundary before punctuation", `68F${sep}.`, `68 ${UNICODE_SYMBOLS.DEGREE}F${sep}.`], // should convert
+      // A boundary at the digit-run start shadows the leading-guard character
+      // (same semantics as the multiplication chain guard)
+      ["boundary shadows leading letter", `W${sep}3C today`, `W${sep}3 ${UNICODE_SYMBOLS.DEGREE}C today`],
+      ["boundary splits the digit run", `20${sep}5C today`, `20${sep}5 ${UNICODE_SYMBOLS.DEGREE}C today`],
     ])("handles %s", (_desc, input, expected) => {
       expect(viewTransform(degrees, input, sep)).toBe(expected)
     })


### PR DESCRIPTION
## Summary

Confirms and fixes the false positives reported in #244 (thanks @brendanlong), found by running punctilio over brendanlong.com posts with all options enabled. Reproduced under the benchmark harness, four of the reported shapes failed: quoted hyphen-prefixes (`"un-"`/`"non-"`), the trailing-space quote (`"New ",`), the `5900X` SKU suffix, and — with `degrees: true` — identifier/URL-encoded digit runs (`W3C`, `%2C`).

## Changes

- **Quoted prefixes ending in a hyphen**: the quoted-punctuation opener rule now tracks a running double-quote depth; an opener-prefixed straight quote inside an open double quote is classified as that quote's closer instead of re-opening (`“un-“` → `“un-”`). A still-straight quote below an open `“` counts as its future closer so later openers aren't misread.
- **Quoted string with trailing space**: a space directly before a closing-quote run now blocks the American inside-move, keeping the comma outside an exact-string quote (`“New ,”` → `“New ”,`).
- **Model/SKU suffixes**: the trailing-multiplier rule skips an uppercase `X` attached to digits (`Ryzen 9 5900X` preserved); lowercase multipliers (`by 4x.`) and chains (`16X16`) still convert.
- **Degrees leading guard**: the digit run must start its word — a letter before it is an identifier (`W3C`) and `%` is a URL-encoded octet (`%2C`); real temperatures (`25C`, `-40 C`) still convert.
- Incorporates the benchmark cases from #244 and ratchets the CI benchmark floor from 150 to 158 (punctilio now passes 158/160; the two remaining failures are pre-existing "known limitation" categories).

## Testing

- All new benchmark cases pass and re-running the transform on its own output is a fixed point.
- Added parametrized unit tests for each fix, including depth-tracking edge cases (opener after a completed quote, stray closer before the passage) and boundary-shadowing cases for the degrees guard.
- `pnpm test` (2420 tests, 100% statement/branch coverage), `pnpm lint`, and `node benchmark.mjs --min-passes 158` all pass; Stryker run on the two touched files.

## Notes

The trailing-space case is ambiguous (the PR author flagged it as a known limitation); the chosen reading closes the quote and treats its content as verbatim, which matches the expected output in #244. The uppercase-`X` heuristic trades the rare uppercase prose multiplier ("improved 10X") for SKU preservation, consistent with the pass's existing bias against false conversions (`Surface5x3`, `RTX3060x2`).

---
_Generated by [Claude Code](https://claude.ai/code/session_01855ryPKMTuQU5K4EPKNKt1)_