### PR TITLE
test(quotes): add failing cases for closing quote before "]"

### DIFF
--- a/src/tests/quotes.test.ts
+++ b/src/tests/quotes.test.ts
@@ -104,6 +104,31 @@ describe("niceQuotes", () => {
     })
   })
 
+  // Known bug: a straight closing double quote sitting directly before a
+  // closing square bracket "]" is left straight instead of curled. It shows
+  // up in prose that lists quoted string literals, e.g. a tokenizer
+  // vocabulary ["A", "-lice", ..., "-athryn"], where the final entry renders
+  // as `-athryn"` instead of `-athryn`. The same position before ")" or "}"
+  // already curls correctly (see the "double quotes" cases above), so the
+  // classifier just needs to treat "]" like the other closing brackets.
+  //
+  // Written with `it.failing` so CI stays green while the bug is open; once
+  // it is fixed these will start passing and Jest will flag them for
+  // promotion to normal `it` cases.
+  describe("closing quote before a bracket (known bug)", () => {
+    it.failing('curls the closer in \'["B"]\'', () => {
+      expect(classifyApostrophes('["B"]')).toBe(
+        `[${LEFT_DOUBLE_QUOTE}B${RIGHT_DOUBLE_QUOTE}]`,
+      )
+    })
+
+    it.failing('curls the last entry of a quoted vocab list', () => {
+      expect(classifyApostrophes('["A", "-athryn"]')).toBe(
+        `[${LEFT_DOUBLE_QUOTE}A${RIGHT_DOUBLE_QUOTE}, ${LEFT_DOUBLE_QUOTE}-athryn${RIGHT_DOUBLE_QUOTE}]`,
+      )
+    })
+  })
+
   describe("single quotes and apostrophes", () => {
     it.each([
       ["He said, 'Hi'", `He said, ${LEFT_SINGLE_QUOTE}Hi${RIGHT_SINGLE_QUOTE}`],


### PR DESCRIPTION
classifyApostrophes leaves a straight closing double quote straight when it sits directly before a closing square bracket, so a quoted list like ["A", "-athryn"] renders its last entry as `-athryn"` instead of curling it. The same position before ")" or "}" already curls correctly, so this is specific to "]".

Added as `it.failing` so CI stays green while the bug is open; they will flip to failing (and prompt promotion to normal `it`) once it's fixed.

Found while running punctilio over [brendanlong.com posts](https://www.brendanlong.com/shorter-tokens-are-more-likely.html) (follow-up to the false-positive fixes in #246). 