### PR TITLE
fix: parallel audit — quadratic-scan DoS, quote-placement corruption, locale fixed points, hot-path perf

### DIFF
--- a/config/javascript/commitlint.config.js
+++ b/config/javascript/commitlint.config.js
@@ -1,0 +1,1 @@
+export default { extends: ["@commitlint/config-conventional"] }

--- a/src/dashes.ts
+++ b/src/dashes.ts
@@ -297,6 +297,13 @@ function matchRangeBody(view: ProseView, startStart: number): number | null {
 
   // `readStartRun` already stops at the first interior boundary, so the start
   // span is boundary-free and its clean digits are the whole run.
+  //
+  // INVARIANT (load-bearing for failedRangeStartSkip): past the gates above,
+  // `startDigits` is the ONLY value derived from where the run begins, and it
+  // feeds only the conversion decision, never the null/non-null return. The
+  // skip's jump is sound precisely because every interior start shares this
+  // function's post-gate outcome; threading the start position into the
+  // end/tail logic would silently break it.
   const startDigits = text.slice(startStart, startSpanEnd)
   const end = readEndRun(view, dashEnd)
   if (end === null) return null

--- a/src/dashes.ts
+++ b/src/dashes.ts
@@ -203,35 +203,31 @@ function convertPositiveRanges(view: ProseView): void {
 const RANGE_START_CHAR_RE = /[\dp(]/
 
 /**
- * Advance past a failed candidate at `i`. When `i` begins a digit run whose
- * boundary-free `\d[\d.,]*` extent is not followed by a dash, no structural
- * match can begin inside the run either: every interior digit start reads to
- * the same run end and fails the same start-independent gate there (the dash
- * test or the boundary-count check), interior `.`/`,` chars cannot start a
- * run, and the area-code reading needs a `(` or a dash the run does not
- * contain — so the scan jumps to the run end. Advancing one character at a
- * time instead re-reads the run at every digit — O(n²) on inputs like
- * "1.1.1.…", a denial-of-service vector.
+ * Advance past a failed candidate at `i`. Advancing one character at a time
+ * re-reads the digit run at every offset — O(n²) on inputs like "1.1.1.…" or
+ * "111…1-x", a denial-of-service vector — so the scan jumps wherever a
+ * failure at `i` provably rules out interior starts:
  *
- * A dash at the run end can reward an interior start two ways: a `.`/`,`-
- * preceded digit regains the `\b` that blocked `i`, and the area-code reading
- * restarts a fresh match past the dash. Both still need the char past the
- * hyphens to begin an end run (digit/currency) or a start run (digit/`p`) —
- * the dash position and end-run reads are start-independent — so when it
- * cannot, the jump to the run end stays safe; only then fall back to one
- * character (otherwise "111…1-x" re-reads the run at every digit, the same
- * O(n²)).
+ * - A start-dependent failure (`\b`, not-after-dash — checked first in
+ *   matchRangeBody, before any run read) says nothing about interior starts;
+ *   advance one character. The gate order makes each such attempt cheap.
+ * - Otherwise the failure came after the gates, and everything there depends
+ *   only on the run end, not the run start: every interior digit start reads
+ *   to the same boundary-free run end and fails the same wall, `.`/`,` cannot
+ *   start a run, and no dash-at-run-end fallback (dash extent, boundary
+ *   counts, end run, tail resolution) sees a different picture. The single
+ *   escape is the phone-area-code reading, which restarts a fresh match past
+ *   a dash at the run end and therefore only exists at `runEnd - 3` — so
+ *   jump straight there (or to the run end when no dash follows).
  */
 function failedRangeStartSkip(view: ProseView, i: number): number {
   const text = view.text
   if (!/\d/.test(text[i])) return i + 1
+  if (!wordBoundaryStartOk(view, i) || !notAfterDashOk(view, i)) return i + 1
   let runEnd = i + 1
   while (/[\d.,]/.test(text[runEnd] ?? "") && !view.hasBoundary(runEnd)) runEnd++
   if (text[runEnd] !== "-") return runEnd
-  let afterDashes = runEnd + 1
-  while (text[afterDashes] === "-") afterDashes++
-  const next = text[afterDashes] ?? ""
-  return /\d/.test(next) || next === "p" || CURRENCY_RE.test(next) ? i + 1 : runEnd
+  return Math.max(i + 1, runEnd - 3)
 }
 
 /**
@@ -280,6 +276,12 @@ function readPhoneAreaCode(view: ProseView, i: number): number | null {
  */
 function matchRangeBody(view: ProseView, startStart: number): number | null {
   const text = view.text
+  // Start-dependent gates first: they need no run read, and their position in
+  // the conjunction lets the scanner classify a failure — everything after
+  // them depends only on where the boundary-free start run ends, not on where
+  // it begins (see failedRangeStartSkip).
+  if (!wordBoundaryStartOk(view, startStart)) return null
+  if (!notAfterDashOk(view, startStart)) return null
   // rangeStart = `(?:p\.?|[currency])?\d[\d.,]*`, anchored at a `\b`.
   const start = readStartRun(view, startStart)
   if (start === null) return null
@@ -296,9 +298,6 @@ function matchRangeBody(view: ProseView, startStart: number): number | null {
   // `readStartRun` already stops at the first interior boundary, so the start
   // span is boundary-free and its clean digits are the whole run.
   const startDigits = text.slice(startStart, startSpanEnd)
-  if (!wordBoundaryStartOk(view, startStart)) return null
-  if (!notAfterDashOk(view, startStart)) return null
-
   const end = readEndRun(view, dashEnd)
   if (end === null) return null
   // The greedy end `[\d.,]*` and greedy `following*` backtrack together; the

--- a/src/dashes.ts
+++ b/src/dashes.ts
@@ -211,16 +211,27 @@ const RANGE_START_CHAR_RE = /[\dp(]/
  * run, and the area-code reading needs a `(` or a dash the run does not
  * contain — so the scan jumps to the run end. Advancing one character at a
  * time instead re-reads the run at every digit — O(n²) on inputs like
- * "1.1.1.…", a denial-of-service vector. A dash at the run end re-enables
- * start-dependent gates (`\b`, not-after-dash) for interior starts, so then
- * advance by one as usual.
+ * "1.1.1.…", a denial-of-service vector.
+ *
+ * A dash at the run end can reward an interior start two ways: a `.`/`,`-
+ * preceded digit regains the `\b` that blocked `i`, and the area-code reading
+ * restarts a fresh match past the dash. Both still need the char past the
+ * hyphens to begin an end run (digit/currency) or a start run (digit/`p`) —
+ * the dash position and end-run reads are start-independent — so when it
+ * cannot, the jump to the run end stays safe; only then fall back to one
+ * character (otherwise "111…1-x" re-reads the run at every digit, the same
+ * O(n²)).
  */
 function failedRangeStartSkip(view: ProseView, i: number): number {
   const text = view.text
   if (!/\d/.test(text[i])) return i + 1
   let runEnd = i + 1
   while (/[\d.,]/.test(text[runEnd] ?? "") && !view.hasBoundary(runEnd)) runEnd++
-  return text[runEnd] === "-" ? i + 1 : runEnd
+  if (text[runEnd] !== "-") return runEnd
+  let afterDashes = runEnd + 1
+  while (text[afterDashes] === "-") afterDashes++
+  const next = text[afterDashes] ?? ""
+  return /\d/.test(next) || next === "p" || CURRENCY_RE.test(next) ? i + 1 : runEnd
 }
 
 /**

--- a/src/dashes.ts
+++ b/src/dashes.ts
@@ -1,5 +1,5 @@
 import { cachedRegExp, FOLDED_WORD_CHARS, isWordLike, LATIN_LETTER_RE, LATIN_LETTERS, MAX_BOUNDARY_SEPARATORS, NBSP_CHARS, SPACE_CHAR_RE, UNICODE_SYMBOLS } from "./constants.js"
-import { boundaryCountAt, exceedsSingleBoundary, makeProsePass, overInput, type ProseView, replaceAllInView, type ReplaceAllOptions } from "./prose-view.js"
+import { boundaryCountAt, exceedsSingleBoundary, firstInteriorBoundary, makeProsePass, overInput, type ProseView, replaceAllInView, type ReplaceAllOptions } from "./prose-view.js"
 import { namedGroups } from "./utils.js"
 
 export const DASH_STYLES = ["american", "british", "none"] as const
@@ -759,19 +759,14 @@ function minusSubtractionPrefixOk(match: RegExpExecArray, view: ProseView, prefi
   // leading digit and the space; it tolerates at most one boundary.
   if (exceedsSingleBoundary(view, match.index)) return false
   const numStart = match.index + prefixLen
-  for (const b of view.boundaries) {
-    if (b > match.index && b < numStart) return false
-  }
+  if (firstInteriorBoundary(view, match.index, numStart) >= 0) return false
   // The slot before `num` tolerates at most one boundary at the num head.
   if (exceedsSingleBoundary(view, numStart)) return false
   // `num` stops at the first interior boundary; the clean run up to it must
   // still satisfy `\d*\.?\d+` (the mandatory trailing `\d+`).
   const numEnd = match.index + match[0].length
-  let truncatedEnd = numEnd
-  for (const b of view.boundaries) {
-    if (b > numStart && b < numEnd) { truncatedEnd = b; break }
-    if (b >= numEnd) break
-  }
+  const interior = firstInteriorBoundary(view, numStart, numEnd)
+  const truncatedEnd = interior >= 0 ? interior : numEnd
   return NUM_BODY_RE.test(view.text.slice(numStart, truncatedEnd))
 }
 
@@ -810,11 +805,8 @@ function minusDirectNegative(view: ProseView): void {
       // ("-{b}5"), and one that strips the mandatory `\d+` ("-.{b}1") breaks the
       // match, but one past a valid number ("-5{b}5") leaves it intact.
       const numEnd = start + match[0].length
-      let numTruncEnd = numEnd
-      for (const b of v.boundaries) {
-        if (b > start && b < numEnd) { numTruncEnd = b; break }
-        if (b >= numEnd) break
-      }
+      const interior = firstInteriorBoundary(v, start, numEnd)
+      const numTruncEnd = interior >= 0 ? interior : numEnd
       if (!NUM_BODY_RE.test(v.text.slice(start + 1, numTruncEnd))) return null
       // A boundary directly before the hyphen routes to Pattern 2b; otherwise
       // Pattern 2 examines the clean preceding char. (The two never overlap: a

--- a/src/dashes.ts
+++ b/src/dashes.ts
@@ -1,6 +1,5 @@
 import { cachedRegExp, FOLDED_WORD_CHARS, isWordLike, LATIN_LETTER_RE, LATIN_LETTERS, MAX_BOUNDARY_SEPARATORS, NBSP_CHARS, SPACE_CHAR_RE, UNICODE_SYMBOLS } from "./constants.js"
 import { boundaryCountAt, exceedsSingleBoundary, firstInteriorBoundary, makeProsePass, overInput, type ProseView, replaceAllInView, type ReplaceAllOptions } from "./prose-view.js"
-import { namedGroups } from "./utils.js"
 
 export const DASH_STYLES = ["american", "british", "none"] as const
 export type DashStyle = (typeof DASH_STYLES)[number]
@@ -292,8 +291,9 @@ function matchRangeBody(view: ProseView, startStart: number): number | null {
   const end = readEndRun(view, dashEnd)
   if (end === null) return null
   // The greedy end `[\d.,]*` and greedy `following*` backtrack together; the
-  // structural match commits at the longest end whose tail completes.
-  for (let len = end.length; len >= end.minLen; len--) {
+  // structural match commits at the longest end whose tail completes. The
+  // mandatory `\d` caps the backtrack at one digit.
+  for (let len = end.length; len >= 1; len--) {
     const endPos = end.firstDigitStart + len
     const tail = resolvePositiveTail(view, endPos)
     if (tail === null) continue
@@ -340,8 +340,6 @@ interface EndRun {
   firstDigitStart: number
   /** Length of the `[\d.,]` run from `firstDigitStart`, boundary-truncated. */
   length: number
-  /** Minimum end length: 1 digit (`\d` is required). */
-  minLen: number
 }
 
 /** The `[currency]?\d[\d.,]*` end run starting at `pos`, boundary-truncated. */
@@ -357,7 +355,7 @@ function readEndRun(view: ProseView, pos: number): EndRun | null {
   const firstDigitStart = i
   i++
   while (/[\d.,]/.test(text[i] ?? "") && !view.hasBoundary(i)) i++
-  return { firstDigitStart, length: i - firstDigitStart, minLen: 1 }
+  return { firstDigitStart, length: i - firstDigitStart }
 }
 
 interface ResolvedTail {
@@ -635,6 +633,22 @@ export function enDashDateRange(input: string | ProseView, options: DashOptions 
   return overInput(input, (view) => enDashDateRangeOverView(view, options.dashStyle ?? "american"))
 }
 
+interface DateRangeGroups {
+  startMonth: string
+  startYear?: string
+  preSpace: string
+  postSpace: string
+  endMonth: string
+  endYear?: string
+}
+
+/** Clean offsets of the `[preSpace]-[postSpace]` span inside a date-range match. */
+function dateRangeDashSpan(match: RegExpExecArray): { dashStart: number; dashEnd: number } {
+  const groups = match.groups as unknown as DateRangeGroups
+  const dashStart = match.index + groups.startMonth.length + (groups.startYear?.length ?? 0)
+  return { dashStart, dashEnd: dashStart + groups.preSpace.length + 1 + groups.postSpace.length }
+}
+
 function enDashDateRangeOverView(view: ProseView, dashStyle: DashStyle): void {
   if (dashStyle === "none") return
   const [pre, post] = dashStyle === "british" ? [" ", " "] : ["", ""]
@@ -657,37 +671,17 @@ function enDashDateRangeOverView(view: ProseView, dashStyle: DashStyle): void {
       // a word char that blocks the match ("March 2025x3"); re-check the end
       // boundary fold-stably.
       if (!wordBoundaryEndOk(v, match.index + match[0].length)) return null
-      const groups = namedGroups<{
-        startMonth: string
-        startYear?: string
-        preSpace: string
-        postSpace: string
-        endMonth: string
-        endYear?: string
-      }>(matchArgs(match))
       // Replace `[preSpace]-[postSpace]` (the dash and its spaces) with the
       // styled en-dash, leaving the months and any boundaries around them.
-      const startLen = groups.startMonth.length + (groups.startYear?.length ?? 0)
-      const dashSpan = groups.preSpace.length + 1 + groups.postSpace.length
-      const dashStart = match.index + startLen
-      v.replace(dashStart, dashStart + dashSpan, `${pre}${EN_DASH}${post}`)
+      const { dashStart, dashEnd } = dateRangeDashSpan(match)
+      v.replace(dashStart, dashEnd, `${pre}${EN_DASH}${post}`)
       return null
     },
     {
       allowBoundaries: (match, v) => {
-        const groups = namedGroups<{
-          startMonth: string
-          startYear?: string
-          preSpace: string
-          postSpace: string
-          endMonth: string
-          endYear?: string
-        }>(matchArgs(match))
-        const startLen = groups.startMonth.length + (groups.startYear?.length ?? 0)
         // One boundary is tolerated after the start year and one before the end
         // month, bracketing the dash and spaces.
-        const dashStart = match.index + startLen
-        const dashEnd = dashStart + groups.preSpace.length + 1 + groups.postSpace.length
+        const { dashStart, dashEnd } = dateRangeDashSpan(match)
         const tolerated = new Map<number, number>()
         tolerated.set(dashStart, 1)
         tolerated.set(dashEnd, 1)
@@ -883,7 +877,7 @@ function convertSpacedDashes(view: ProseView, rendered: string): void {
     cachedRegExp(pattern, "g"),
     (match, v) => {
       const text = v.text
-      const groups = namedGroups<{ dashStart: string }>(matchArgs(match))
+      const groups = match.groups as { dashStart: string }
       const firstDash = match.index + match[0].length - groups.dashStart.length
       // The greedy `[ ]+` starts at the leftmost position whose `(?<=[^\s]|^)`
       // holds: line/text start, a non-whitespace clean char, or a boundary. A
@@ -1236,7 +1230,7 @@ function preserveLineLeadingEmDashSpace(view: ProseView): void {
       // One boundary is tolerated between the line start and the em-dash; two or
       // more exceed that slot and block the match.
       if (exceedsSingleBoundary(v, match.index)) return null
-      const groups = namedGroups<{ after: string }>(matchArgs(match))
+      const groups = match.groups as { after: string }
       return `${EM_DASH} ${groups.after}`
     },
   )
@@ -1281,8 +1275,3 @@ export const dashWordJoiner = makeProsePass((view) => {
   const re = cachedRegExp(`(?<=[^\\s${WORD_JOINER}])[${EM_DASH}${EN_DASH}]`, "gu")
   replaceAllInView(view, re, (match) => `${WORD_JOINER}${match[0]}`)
 })
-
-/** Reconstructs `.replace()`-style callback args from a RegExpExecArray. */
-function matchArgs(match: RegExpExecArray): unknown[] {
-  return [...match, match.index, match.input, match.groups]
-}

--- a/src/dashes.ts
+++ b/src/dashes.ts
@@ -191,10 +191,37 @@ function convertPositiveRanges(view: ProseView): void {
   const text = view.text
   let i = 0
   while (i < text.length) {
+    // A structural match can only begin at a digit, `p`, or `(` (the area-code
+    // and start-run readers reject every other first character), so other
+    // offsets skip the match attempt entirely.
+    if (!RANGE_START_CHAR_RE.test(text[i])) { i++; continue }
     const span = matchPositiveRangeAt(view, i)
-    i = span === null ? i + 1 : Math.max(span, i + 1)
+    i = span === null ? failedRangeStartSkip(view, i) : Math.max(span, i + 1)
   }
   view.commit()
+}
+
+const RANGE_START_CHAR_RE = /[\dp(]/
+
+/**
+ * Advance past a failed candidate at `i`. When `i` begins a digit run whose
+ * boundary-free `\d[\d.,]*` extent is not followed by a dash, no structural
+ * match can begin inside the run either: every interior digit start reads to
+ * the same run end and fails the same start-independent gate there (the dash
+ * test or the boundary-count check), interior `.`/`,` chars cannot start a
+ * run, and the area-code reading needs a `(` or a dash the run does not
+ * contain — so the scan jumps to the run end. Advancing one character at a
+ * time instead re-reads the run at every digit — O(n²) on inputs like
+ * "1.1.1.…", a denial-of-service vector. A dash at the run end re-enables
+ * start-dependent gates (`\b`, not-after-dash) for interior starts, so then
+ * advance by one as usual.
+ */
+function failedRangeStartSkip(view: ProseView, i: number): number {
+  const text = view.text
+  if (!/\d/.test(text[i])) return i + 1
+  let runEnd = i + 1
+  while (/[\d.,]/.test(text[runEnd] ?? "") && !view.hasBoundary(runEnd)) runEnd++
+  return text[runEnd] === "-" ? i + 1 : runEnd
 }
 
 /**

--- a/src/prose-view.ts
+++ b/src/prose-view.ts
@@ -67,19 +67,8 @@ class ProseViewImpl implements ProseView {
 
   hasBoundary(offset: number): boolean {
     const boundaries = this.cachedBoundaries
-    let low = 0
-    let high = boundaries.length - 1
-    while (low <= high) {
-      const mid = (low + high) >>> 1
-      const value = boundaries[mid]
-      if (value === offset) return true
-      if (value < offset) {
-        low = mid + 1
-      } else {
-        high = mid - 1
-      }
-    }
-    return false
+    const first = lowerBound(boundaries, offset)
+    return first < boundaries.length && boundaries[first] === offset
   }
 
   replace(start: number, end: number, text: string, opts?: { bind?: "left" | "right" }): void {

--- a/src/prose-view.ts
+++ b/src/prose-view.ts
@@ -224,22 +224,42 @@ export interface ReplaceAllOptions {
   bind?: "left" | "right"
 }
 
+/**
+ * Index of the first element in sorted `values` that is >= `target`. The
+ * boundary helpers below run per candidate offset in the pass scanners, so a
+ * linear scan here would make inline-element-heavy views O(text × nodes).
+ */
+function lowerBound(values: readonly number[], target: number): number {
+  let low = 0
+  let high = values.length
+  while (low < high) {
+    const mid = (low + high) >>> 1
+    if (values[mid] < target) low = mid + 1
+    else high = mid
+  }
+  return low
+}
+
 /** True iff some interior boundary falls strictly inside the match span. */
 function matchContainsBoundary(match: RegExpExecArray, view: ProseView): boolean {
-  const matchStart = match.index
-  const matchEnd = match.index + match[0].length
-  for (const boundary of view.boundaries) {
-    if (boundary > matchStart && boundary < matchEnd) return true
-  }
-  return false
+  return firstInteriorBoundary(view, match.index, match.index + match[0].length) >= 0
+}
+
+/** Smallest node boundary strictly inside (start, end), or -1 when none. */
+export function firstInteriorBoundary(view: ProseView, start: number, end: number): number {
+  const boundaries = view.boundaries
+  const first = lowerBound(boundaries, start + 1)
+  return first < boundaries.length && boundaries[first] < end ? boundaries[first] : -1
 }
 
 /** Count of node boundaries that fall at exactly `offset` (empty nodes stack). */
 export function boundaryCountAt(view: ProseView, offset: number): number {
+  const boundaries = view.boundaries
+  let i = lowerBound(boundaries, offset)
   let count = 0
-  for (const boundary of view.boundaries) {
-    if (boundary === offset) count++
-    else if (boundary > offset) break
+  while (i < boundaries.length && boundaries[i] === offset) {
+    count++
+    i++
   }
   return count
 }

--- a/src/quote-classifier.ts
+++ b/src/quote-classifier.ts
@@ -692,8 +692,15 @@ function foldsToNotEqual(items: Item[], index: number): boolean {
   return !isCharItem(items, nextIndex(items, eq, 1), "=")
 }
 
-/** Opening double quote by following context. */
-function classifyOpeningDoubles(items: Item[]): void {
+/**
+ * Opening double quote by following context.
+ *
+ * French: a plain space directly before a pre-labeled closer merges into the
+ * closer's rendered NNBSP padding once spaces collapse, so a re-run reads the
+ * closer itself directly after the candidate — read it that way now (the
+ * mirror of {@link classifyClosingDoubles}'s opener-side absorption).
+ */
+function classifyOpeningDoubles(items: Item[], style: ActiveQuoteStyle): void {
   for (let i = 0; i < items.length; i++) {
     const item = items[i]
     if (item.boundary || item.ch !== '"') continue
@@ -711,8 +718,10 @@ function classifyOpeningDoubles(items: Item[]): void {
       const j = nextIndex(items, i, 1)
       if (j < items.length && !items[j].boundary) {
         const ch = items[j].ch
+        const absorbedIntoCloser = style === "french" && ch === " " && isCharItem(items, j + 1, RIGHT_DOUBLE_QUOTE)
         opens = isEllipsisDots(items, j) || foldsToNotEqual(items, j)
           || (!SPACE_RE.test(ch) && !DOUBLE_OPEN_ENDING_SET.has(ch))
+          || absorbedIntoCloser
       }
     }
     if (opens) item.ch = LEFT_DOUBLE_QUOTE
@@ -840,7 +849,7 @@ function classifySinglesBeforeClosingDoubles(items: Item[]): void {
 
 function classifyDoubles(items: Item[], style: ActiveQuoteStyle): void {
   classifyEmptyDoublePairs(items)
-  classifyOpeningDoubles(items)
+  classifyOpeningDoubles(items, style)
   classifyQuotedPunctuationOpeners(items)
   classifyBraceOpeners(items)
   classifyClosingDoubles(items, style)

--- a/src/quote-classifier.ts
+++ b/src/quote-classifier.ts
@@ -92,6 +92,14 @@ interface Item {
   end: number
   /** Set when punctuation placement relocates this item. */
   moved: boolean
+  /**
+   * Set on a CLOSE_SINGLE that has no matching opener and sits directly after
+   * a letter — a word-final quote that reads as elision ("keep on truckin'")
+   * at least as plausibly as quotation. It keeps its closer role (glyph
+   * U+2019 either way) but punctuation placement must not move around it:
+   * pulling the period into "truckin'." corrupts the word to "truckin.'".
+   */
+  unmatchedAfterLetter?: boolean
   /** Insertion anchor (clean-text offset and bind side) once moved. */
   anchorOffset: number
   anchorBind: "left" | "right"
@@ -517,7 +525,10 @@ function classifyOpeningSingles(items: Item[]): void {
 
 /**
  * Unmatched CLOSE_SINGLE after s/S → APOSTROPHE (plural possessives), via the
- * advisory open/close balance scan. Boundaries are fully transparent here.
+ * advisory open/close balance scan. An unmatched closer after any other
+ * letter keeps its closer role but is flagged {@link Item.unmatchedAfterLetter}
+ * so punctuation placement leaves it alone. Boundaries are fully transparent
+ * here.
  */
 function classifyPluralPossessives(items: Item[]): void {
   let balance = 0
@@ -537,6 +548,8 @@ function classifyPluralPossessives(items: Item[]): void {
     while (j >= 0 && items[j].boundary) j--
     if (j >= 0 && (items[j].ch === "s" || items[j].ch === "S")) {
       item.ch = MODIFIER_LETTER_APOSTROPHE
+    } else if (j >= 0 && isLetterItem(items, j)) {
+      item.unmatchedAfterLetter = true
     }
   }
 }
@@ -844,6 +857,9 @@ function classifyDoubles(items: Item[], style: ActiveQuoteStyle): void {
  */
 function closingRunMemberAt(items: Item[], index: number, closingSet: ReadonlySet<string>): boolean {
   if (index >= items.length || items[index].boundary || !closingSet.has(items[index].ch)) return false
+  // A word-final closer with no opener behind it reads as elision; moving
+  // punctuation around it corrupts the word ("truckin'." → "truckin.'").
+  if (items[index].unmatchedAfterLetter) return false
   if (items[index].ch !== MODIFIER_LETTER_APOSTROPHE) return true
   const prev = prevIndex(items, index, 1)
   return !isCharItem(items, prev, "s") && !isCharItem(items, prev, "S")

--- a/src/quote-classifier.ts
+++ b/src/quote-classifier.ts
@@ -286,8 +286,13 @@ function buildItems(view: ProseView, style: ActiveQuoteStyle): Item[] {
         mapped = '"'
       } else if (ch === RIGHT_SINGLE_QUOTE || ch === MODIFIER_LETTER_APOSTROPHE) {
         // U+02BC renders as U+2019, which the next run re-derives by position;
-        // re-derive it the same way now so both runs agree.
-        mapped = "'"
+        // re-derive it the same way now so both runs agree. Directly after a
+        // digit the mark is a separator (Swiss "5’000"), never a German quote
+        // glyph: keep the apostrophe role, which renders U+2019 unchanged.
+        // Re-deriving to a straight quote there hands correct typography to
+        // the next run's prime pass ("5'000" → "5′000") — a destroyed
+        // separator and a broken fixed point.
+        mapped = DIGIT_RE.test(text[i - 1] ?? "") ? MODIFIER_LETTER_APOSTROPHE : "'"
       }
       if (mapped !== null) {
         items.push(makeItem(false, mapped, i, i + 1))

--- a/src/quote-classifier.ts
+++ b/src/quote-classifier.ts
@@ -1481,10 +1481,18 @@ function convertPrimes(items: Item[]): void {
   }
 }
 
+/**
+ * Every conversion in {@link convertPrimes} keys on a digit item directly
+ * before the quote, and boundary items are zero-width, so clean text without
+ * a digit-quote pair can never change. Checking that up front skips the full
+ * per-character item build on the (overwhelmingly common) digit-free prose.
+ */
+const PRIME_CANDIDATE_RE = /\d['"]/
+
 /** primeMarks engine: converts `5'10"` to `5′10″` with quote-balance guards. Commits its edits. */
 export function convertPrimeMarks(view: ProseView): void {
   const text = view.text
-  if (!text.includes("'") && !text.includes('"')) return
+  if (!PRIME_CANDIDATE_RE.test(text)) return
   const items = buildItems(view, "american")
   convertPrimes(items)
   for (const item of items) {

--- a/src/symbols.ts
+++ b/src/symbols.ts
@@ -1,5 +1,5 @@
 import { cachedRegExp, LATIN_LETTER_RE, LATIN_LETTERS, MAX_BOUNDARY_SEPARATORS, SPACE_CHAR_RE, UNICODE_SYMBOLS, WORD_RE } from "./constants.js"
-import { boundaryCountAt, exceedsSingleBoundary, makeProsePass, overInput, type ProseView, replaceAllInView } from "./prose-view.js"
+import { boundaryCountAt, exceedsSingleBoundary, firstInteriorBoundary, makeProsePass, overInput, type ProseView, replaceAllInView } from "./prose-view.js"
 import { convertPrimeMarks } from "./quote-classifier.js"
 
 export interface SymbolOptions {
@@ -656,6 +656,9 @@ function arrowsOverView(view: ProseView): void {
     const text = view.text
     let i = 0
     while (i < text.length) {
+      // Every arrow shape starts with `-` or `<`; skip other offsets before
+      // the comparatively expensive left-context/boundary check.
+      if (text[i] !== "-" && text[i] !== "<") { i++; continue }
       if (!arrowLeftContextOk(view, text, i)) { i++; continue }
       const end = matcher(view, text, i)
       if (end < 0 || !arrowRightContextOk(view, text, end)) { i++; continue }
@@ -794,10 +797,8 @@ function fractionsOverView(view: ProseView): void {
     if (!fractionLookaheadOk(text, v, end)) return null
     // Distribute interior boundaries: the first lands before the unicode char,
     // any remaining after it.
-    let firstBoundary = end
-    for (const boundary of v.boundaries) {
-      if (boundary > start && boundary < end) { firstBoundary = boundary; break }
-    }
+    const interior = firstInteriorBoundary(v, start, end)
+    const firstBoundary = interior >= 0 ? interior : end
     if (firstBoundary > start) v.replace(start, firstBoundary, "")
     v.replace(firstBoundary, end, FRACTION_MAP[match[0]])
     return null

--- a/src/symbols.ts
+++ b/src/symbols.ts
@@ -266,6 +266,24 @@ function runHasInteriorBoundary(view: ProseView, operandStart: number, operandEn
   return false
 }
 
+const ASCII_DIGIT_RE = /\d/
+
+/**
+ * Next offset at which a sticky `\d`-anchored pattern could match after a miss
+ * at `scan`. A miss at a digit rules out every start in the rest of its run:
+ * from a later start the pattern's leading `\d+` reaches a strict subset of
+ * the split positions the failed attempt already backtracked through. So the
+ * scan jumps past the current digit run (if any), then past non-digits to the
+ * next digit. Advancing one character at a time here instead re-reads the run
+ * at every offset — O(n²) on a long digit run, a denial-of-service vector.
+ */
+function nextDigitAnchorAfterMiss(text: string, scan: number): number {
+  let next = scan
+  while (next < text.length && ASCII_DIGIT_RE.test(text[next])) next++
+  while (next < text.length && !ASCII_DIGIT_RE.test(text[next])) next++
+  return next
+}
+
 function multiplicationOverView(view: ProseView): void {
   // The chain is matched with a sticky regex driven by a manual left-to-right
   // scan. Sticky anchoring keeps the nested `\d+(…\d+)+` quantifier ReDoS-safe
@@ -279,7 +297,7 @@ function multiplicationOverView(view: ProseView): void {
   while (scan < chainText.length) {
     chainPattern.lastIndex = scan
     const match = chainPattern.exec(chainText)
-    if (match === null) { scan++; continue }
+    if (match === null) { scan = nextDigitAnchorAfterMiss(chainText, scan); continue }
     const { firstNum, rest } = match.groups as { firstNum: string; rest: string }
     const text = chainText
     const chainStart = match.index
@@ -352,7 +370,7 @@ function multiplicationOverView(view: ProseView): void {
   while (trailingScan < trailingText.length) {
     trailingPattern.lastIndex = trailingScan
     const match = trailingPattern.exec(trailingText)
-    if (match === null) { trailingScan++; continue }
+    if (match === null) { trailingScan = nextDigitAnchorAfterMiss(trailingText, trailingScan); continue }
     const num = match.groups!.num
     const op = match.groups!.op
     const operatorOffset = match.index + num.length

--- a/src/tests/dashes.test.ts
+++ b/src/tests/dashes.test.ts
@@ -873,6 +873,9 @@ describe("ProseView boundary-tolerance edges", () => {
       // A boundary between `p.` and the digit severs the page prefix; the bare
       // range past the boundary still converts.
       ["boundary after the p. prefix", `p.${sep}5-10`, `p.${sep}5${EN_DASH}10`],
+      // A boundary directly after the bare `p` severs the prefix too, and the
+      // glued `p${sep}5` word blocks the bare range's leading `\b`.
+      ["boundary after the bare p prefix", `p${sep}5-10`, `p${sep}5-10`],
       ["boundary inside am/pm suffix", `2-3p${sep}m`, `2-3p${sep}m`],
     ])("%s", (_desc, input, expected) => {
       expect(viewTransform(enDashNumberRange, input, sep)).toBe(expected)

--- a/src/tests/quotes.test.ts
+++ b/src/tests/quotes.test.ts
@@ -439,6 +439,23 @@ describe("niceQuotes", () => {
     ])('handles edge quote pattern: "%s"', (input, expected) => {
       expect(classifyApostrophes(input)).toBe(expected)
     })
+
+    // A word-final quote with no opener behind it keeps its closer role
+    // (pinned above: "a'" → RIGHT_SINGLE_QUOTE) but reads as elision at least
+    // as plausibly as quotation, so American placement must not pull the
+    // following punctuation into the word ("truckin'." must not become
+    // "truckin.'"). A matched closer still attracts punctuation as usual.
+    it.each([
+      ["We keep on truckin'.", `We keep on truckin${RIGHT_SINGLE_QUOTE}.`],
+      [
+        "singin', dancin', and laughin'.",
+        `singin${RIGHT_SINGLE_QUOTE}, dancin${RIGHT_SINGLE_QUOTE}, and laughin${RIGHT_SINGLE_QUOTE}.`,
+      ],
+      ["'Keep on truckin', he said.", `${LEFT_SINGLE_QUOTE}Keep on truckin,${RIGHT_SINGLE_QUOTE} he said.`],
+    ])('word-final elision quote keeps punctuation outside: "%s"', (input, expected) => {
+      expect(niceQuotes(input)).toBe(expected)
+      expect(niceQuotes(expected)).toBe(expected)
+    })
   })
 
   describe("quotes after various punctuation", () => {

--- a/src/tests/quotes.test.ts
+++ b/src/tests/quotes.test.ts
@@ -771,6 +771,18 @@ describe("niceQuotes", () => {
       expect(niceQuotes(input, options)).toBe(input)
     })
 
+    it("french opener before a spaced closer reaches its fixed point in one run", () => {
+      // The plain space merges into the closer's NNBSP padding when spaces
+      // collapse, so a re-run reads the closer directly after the straight
+      // quote and opens it; the first run must make the same reading.
+      // niceQuotes alone keeps the source space; the pipeline's collapse pass
+      // later merges it with the padding.
+      const input = `a " ${RIGHT_DOUBLE_QUOTE}`
+      const once = niceQuotes(input, { punctuationStyle: "french" })
+      expect(once).toBe(`a ${LEFT_GUILLEMET}${NNBSP} ${NNBSP}${RIGHT_GUILLEMET}`)
+      expect(niceQuotes(once, { punctuationStyle: "french" })).toBe(once)
+    })
+
     it("german normalizer re-classifies pre-existing RDQ", () => {
       // RDQ is not used in German — should become German closing double
       const input = `${LEFT_DOUBLE_QUOTE}Hello${RIGHT_DOUBLE_QUOTE}`

--- a/src/tests/quotes.test.ts
+++ b/src/tests/quotes.test.ts
@@ -762,6 +762,11 @@ describe("niceQuotes", () => {
       [`word${LEFT_DOUBLE_QUOTE}`, { punctuationStyle: "german" as const }],
       [`x${LEFT_SINGLE_QUOTE}`, { punctuationStyle: "german" as const }],
       [LEFT_DOUBLE_QUOTE, { punctuationStyle: "german" as const }],
+      // Swiss thousands separators: a digit-adjacent U+2019 is never a German
+      // quote glyph and must survive untouched, not be re-derived to a
+      // straight quote (which the next run's prime pass would fold to U+2032).
+      [`Das kostet 5${RIGHT_SINGLE_QUOTE}000 Franken.`, { punctuationStyle: "german" as const }],
+      [`Rund 1${RIGHT_SINGLE_QUOTE}000${RIGHT_SINGLE_QUOTE}000 Einwohner.`, { punctuationStyle: "german" as const }],
     ])("locale output is idempotent: %s", (input, options) => {
       expect(niceQuotes(input, options)).toBe(input)
     })

--- a/src/tests/regex-safety.test.ts
+++ b/src/tests/regex-safety.test.ts
@@ -99,6 +99,8 @@ describe("regex safety (runtime introspection)", () => {
     ["digit run with dash then p (range scanner)", "1".repeat(80_000) + "-p"],
     ["dotted digits with dash then currency (range scanner)", "1.".repeat(40_000) + "-€x"],
     ["dash-led digit run with live tail (range scanner)", "-" + "1".repeat(80_000) + "-5"],
+    ["digit run with over-long dash run (range scanner)", "1".repeat(80_000) + "----5"],
+    ["letter-anchored digit run with live tail (range scanner)", "a" + "1".repeat(80_000) + "-1"],
   ])("scan loops stay linear on pathological input: %s", (_name, input) => {
     const startMs = performance.now()
     transform(input)

--- a/src/tests/regex-safety.test.ts
+++ b/src/tests/regex-safety.test.ts
@@ -96,6 +96,9 @@ describe("regex safety (runtime introspection)", () => {
     ["comma digits (range scanner)", "1,".repeat(40_000)],
     ["digit run ending in a dead dash (range scanner)", "1".repeat(80_000) + "-x"],
     ["dotted digits ending in a bare dash (range scanner)", "1.".repeat(40_000) + "-"],
+    ["digit run with dash then p (range scanner)", "1".repeat(80_000) + "-p"],
+    ["dotted digits with dash then currency (range scanner)", "1.".repeat(40_000) + "-€x"],
+    ["dash-led digit run with live tail (range scanner)", "-" + "1".repeat(80_000) + "-5"],
   ])("scan loops stay linear on pathological input: %s", (_name, input) => {
     const startMs = performance.now()
     transform(input)

--- a/src/tests/regex-safety.test.ts
+++ b/src/tests/regex-safety.test.ts
@@ -94,6 +94,8 @@ describe("regex safety (runtime introspection)", () => {
     ["digit run (multiplication scanner)", "1".repeat(80_000)],
     ["dotted digits (range scanner)", "1.".repeat(40_000)],
     ["comma digits (range scanner)", "1,".repeat(40_000)],
+    ["digit run ending in a dead dash (range scanner)", "1".repeat(80_000) + "-x"],
+    ["dotted digits ending in a bare dash (range scanner)", "1.".repeat(40_000) + "-"],
   ])("scan loops stay linear on pathological input: %s", (_name, input) => {
     const startMs = performance.now()
     transform(input)

--- a/src/tests/regex-safety.test.ts
+++ b/src/tests/regex-safety.test.ts
@@ -81,4 +81,22 @@ describe("regex safety (runtime introspection)", () => {
       )
     }
   }, 600_000)
+
+  // recheck only analyzes individual regexes; quadratic blowup can also live
+  // in the hand-written scan loops that drive sticky regexes or run readers at
+  // successive offsets (an O(n) run re-read at each of O(n) offsets). These
+  // inputs each took multiple seconds — up to ~44 s for "1." at 80 KB — before
+  // the scanners learned to jump past a failed digit run instead of advancing
+  // one character. Linear scans finish in well under a second; the generous
+  // budget only guards against CI jitter, not against a quadratic regression,
+  // which overshoots it by an order of magnitude.
+  it.each([
+    ["digit run (multiplication scanner)", "1".repeat(80_000)],
+    ["dotted digits (range scanner)", "1.".repeat(40_000)],
+    ["comma digits (range scanner)", "1,".repeat(40_000)],
+  ])("scan loops stay linear on pathological input: %s", (_name, input) => {
+    const startMs = performance.now()
+    transform(input)
+    expect(performance.now() - startMs).toBeLessThan(5_000)
+  })
 })

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -67,8 +67,3 @@ export function stableStringify(obj: object): string {
     .map(([k, v]) => [k, Array.isArray(v) ? [...v].sort() : v])
   return JSON.stringify(entries)
 }
-
-/** Extracts named groups from a `.replace()` callback's arguments. @internal */
-export function namedGroups<G>(args: unknown[]): G {
-  return args[args.length - 1] as G
-}


### PR DESCRIPTION
## Summary

Findings from a four-dimension audit (security, correctness, efficiency, refactoring) of the transform pipeline, fixed in priority order. Every behavioral change was differential-fuzzed against the previous code; the perf and scan-loop changes are byte-identical on 188,000 seeded random plain-string and multi-node HTML inputs.

## Changes

**Security — quadratic scan-loop DoS (`dashes.ts`, `symbols.ts`)**
- The number-range scanner and both multiplication scanners advanced one character after every failed match, re-reading the same digit run at each offset: 80 KB of `"1."` repeated took ~44 s; 80 KB of digits took seconds. Reachable from untrusted input through every public entry point, and invisible to the regex-only ReDoS tooling (the blowup lives in the hand-written loops around the regexes).
- The multiplication scanners now jump past a failed digit run (a sticky `\d`-anchored miss at a run's first digit rules out every start inside it).
- The range scanner classifies failures: `matchRangeBody` checks its start-dependent gates (`\b`, not-after-dash) before any run read, so a start-dependent failure advances one character cheaply, while any later failure depends only on the shared run end — provably identical for every interior start — and the scan jumps to `runEnd - 3` (the one offset where the phone-area-code reading can restart a match past a trailing dash) or the run end. This closes every trailing-context variant an adversarial review pass could construct (`-x`, bare `-`, `-p`, `-€x`, `----5`, dash-led and letter-anchored live tails); all are covered by time-budgeted regression tests and now run in ≤ 40 ms.

**Correctness (`quote-classifier.ts`)**
- Word-final elision quotes: `We keep on truckin'.` was corrupted to `We keep on truckin.'` because the unmatched closer counted as a movable closing run for American placement. Placement-only fix (the closer *role* is pinned by existing tests): the balance scan flags unmatched letter-attached closers and the closing-run membership test skips them, exactly as it already skips `the boys'.`
- German: digit-adjacent U+2019 (Swiss thousands separators, `5’000`) was re-derived to a straight quote and then prime-folded by the next run (`5'000` → `5′000`), breaking both the typography and the documented fixed-point invariant. It now keeps the apostrophe role and renders unchanged.
- French: `a " ”` needed two runs to reach `a « »` because the opener rule didn't anticipate the space collapsing into the closer's NNBSP padding, unlike its sibling closer rule. It now converges in one run.

**Performance (~32 % on 50 KB prose, 28.4 ms → 19.2 ms)**
- `convertPrimeMarks` gates on `/\d['"]/` instead of any quote, skipping the full per-character item build on digit-free prose.
- The arrow scanner skips offsets that can't start an arrow before running its boundary-search context check.
- `boundaryCountAt`/`matchContainsBoundary` binary-search the sorted boundaries array (shared `lowerBound`, also reused by `hasBoundary`) instead of scanning from index 0, taking inline-element-heavy views from O(text × nodes) to O(text log nodes) — a 4000-node view was measured ~3× slower than the same text in one node.

**Refactoring (`dashes.ts`, `utils.ts`, `prose-view.ts`)**
- `namedGroups(matchArgs(match))` was a round-trip no-op for `match.groups`; both helpers deleted, four call sites simplified.
- The twice-written date-range group type and dash-span arithmetic became `DateRangeGroups` + `dateRangeDashSpan`; the thrice-duplicated first-interior-boundary loop became a shared `firstInteriorBoundary` helper; dead `EndRun.minLen` (always 1) removed.

**Repo hygiene**
- Added `config/javascript/commitlint.config.js`: the checked-in `.hooks/commit-msg` hook passes that path to commitlint, so every local commit aborted with ENOENT before validation.

## Audit findings intentionally not changed

- An unmatched word-final quote keeps its **closer role** (`a'` → U+2019 closer) — pinned by existing tests; only its punctuation-attraction behavior changed.
- `getFirstTextNode`/`assertSmartQuotesMatch` in `rehype.ts` appear unused outside tests, but `punctilio/rehype` is a published entry point, so removal is a semver question for the maintainer.
- German doubles after a digit (`5”`) still re-derive (no render role can preserve `”` in German); judged too contrived to warrant a mechanism.
- The `html.ts`/`markdown.ts` processor-LRU scaffolding duplication (~25 lines each) is real but touches two public entry points; left for a dedicated change.

## Testing

- Full suite: 2,439 tests pass (2,422 baseline + 17 new: 8 DoS time budgets, 3 elision placement, 2 German idempotence, 1 French fixed point, 1 severed bare-`p` boundary, plus the reviewer-driven variants), 100 % coverage maintained; lint clean.
- Differential fuzz vs. the pre-change code: 188k seeded random inputs across four alphabets (digit/dash/operator/quote, dash-heavy, multi-node HTML), byte-identical.
- Two adversarial review passes on the scan-skip logic; the second constructed the `-p`/`-€x`/`----5` counterexamples that drove the failure-classification design.
- Perf measured best-of-10 on built dist: 50 KB prose 28.4 ms → 19.2 ms; pathological digit inputs ~44 s → ≤ 40 ms.