### PR TITLE
Fix quote/dash correctness bugs, a quadratic boundary scan, CRLF handling, and stale docs

### DIFF
--- a/.github/prompts/security-vulnerability-scan.md
+++ b/.github/prompts/security-vulnerability-scan.md
@@ -14,7 +14,7 @@ You are a security analyst triaging vulnerability alerts from GitHub’s securit
 
 For each alert, assess:
 
-1. **Exploitability**: Is this dependency/code reachable in production? A vulnerability in a dev-only tool is lower priority than one in a runtime dependency. Note: punctilio has only 2 runtime dependencies (`escape-string-regexp`, `unist-util-visit-parents`); all others are dev-only.
+1. **Exploitability**: Is this dependency/code reachable in production? A vulnerability in a dev-only tool is lower priority than one in a runtime dependency. Note: punctilio's runtime `dependencies` (see `package.json`) are `cosmiconfig`, `ignore`, `quick-lru`, `tinyglobby`, and `unist-util-visit-parents`; the unified/remark/rehype packages are optional peer dependencies used only by the CLI and Markdown/HTML sinks, and everything else is dev-only.
 2. **Severity context**: Does the CVSS score match the actual risk for this project? A "critical" SQL injection in a library used only for testing may be effectively low risk.
 3. **Actionability**: Is there a fix available (patched version, workaround)?
 4. **Duplicates**: Group related alerts (e.g., multiple CVEs in the same package that would all be fixed by one upgrade).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 ## Unreleased
 
+### Fixed
+
+- A single-quoted term before a colon now curls both quotes (e.g. `'love':` → `‘love’:`). The colon was missing from the single-quote ending contexts, so the closer stayed straight and the opener was then mis-labelled as an apostrophe, mangling both marks.
+- A closing double quote before `]` now curls (e.g. `["foo"]` → `[“foo”]`), matching the opener that already curls after `[`.
+- The month-range en dash now recognizes the common four-letter abbreviation `Sept` (e.g. `Sept-Nov` → `Sept–Nov`), alongside `Sep`.
+- The CLI preserves a file's CRLF line endings instead of rewriting the final line to LF. CRLF files previously gained mixed endings, which made `--check` report a change on every run and `--write` churn indefinitely.
+
+### Performance
+
+- Node-boundary checks in the dash, symbol, and non-breaking-space passes now binary-search only the boundaries inside each match span instead of scanning the entire boundary list per match, removing an O(matches × nodes) cost on inline-element-heavy HTML/Markdown views.
+
+### Changed
+
+- Dropped the unused `escape-string-regexp` runtime dependency.
+
 ## [5.0.10] - 2026-06-27
 
 ### Changed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,10 +14,10 @@ pnpm install
 
 ```bash
 pnpm test        # Jest test suite
-pnpm lint        # ESLint over src/
+pnpm lint        # ESLint over src/ and scripts/
 pnpm benchmark   # build, then run benchmark.mjs against competitor libraries
 pnpm build       # tsc
-pnpm mutation    # Stryker mutation testing (slow; CI runs it weekly)
+pnpm mutation    # Stryker mutation testing (slow; CI runs it on every PR)
 pnpm mutation:changed   # Stryker over only the files changed on this branch
 ```
 

--- a/README.md
+++ b/README.md
@@ -35,14 +35,14 @@ I tested `punctilio` against [`smartypants`](https://www.npmjs.com/package/smart
 
 My [`benchmark.mjs`](https://github.com/alexander-turner/punctilio/blob/main/benchmark.mjs) measures how well libraries handle a [wide range of scenarios](https://github.com/alexander-turner/punctilio/blob/main/benchmark_cases.json). The benchmark normalizes stylistic differences (e.g. non-breaking vs regular space, British vs American dash spacing) for fair comparison. 
 
-|              Package | Passed (of 152) |
+|              Package | Passed (of 160) |
 | -------------------: | :-------------- |
-|          `punctilio` | 150 (99%)       |
-|          `tipograph` | 89 (59%)        |
-|        `smartquotes` | 77 (51%)        |
-|        `smartypants` | 72 (47%)        |
-| `retext-smartypants` | 69 (45%)        |
-|           `typograf` | 64 (42%)        |
+|          `punctilio` | 158 (99%)       |
+|          `tipograph` | 94 (59%)        |
+|        `smartquotes` | 82 (51%)        |
+|        `smartypants` | 76 (48%)        |
+| `retext-smartypants` | 74 (46%)        |
+|           `typograf` | 69 (43%)        |
 
 _Note on benchmark construction: I assembled the initial cases myself. I then sought out cases where `punctilio` failed and competitors succeeded, and improved `punctilio` to succeed there as well. The benchmark may nonetheless remain biased towards `punctilio`._
 

--- a/package.json
+++ b/package.json
@@ -161,7 +161,6 @@
   },
   "dependencies": {
     "cosmiconfig": "9.0.1",
-    "escape-string-regexp": "5.0.0",
     "ignore": "7.0.5",
     "quick-lru": "7.3.0",
     "tinyglobby": "0.2.16",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,9 +11,6 @@ importers:
       cosmiconfig:
         specifier: 9.0.1
         version: 9.0.1(typescript@5.9.3)
-      escape-string-regexp:
-        specifier: 5.0.0
-        version: 5.0.0
       ignore:
         specifier: 7.0.5
         version: 7.0.5

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -366,13 +366,18 @@ async function transformContent(input: string, type: FileType, opts: CliOptions)
     : transformHtml(input, omitKeys(opts, MARKDOWN_ONLY_OPTION_KEYS) as HtmlOptions)
 }
 
-// Unified pipelines unconditionally append a trailing newline; undo if original lacked one.
-function matchTrailingNewline(original: string, formatted: string): string {
-  const originalHas = original.endsWith("\n")
-  const formattedHas = formatted.endsWith("\n")
-  if (originalHas === formattedHas) return formatted
-  if (originalHas) return formatted + "\n"
-  return formatted.replace(/\n$/, "")
+// The unified pipelines emit LF-only output and unconditionally append a
+// trailing newline. Restore the source's line-ending style and trailing-newline
+// presence so a CRLF file doesn't gain mixed endings (which would make --check
+// report a change forever and --write churn on every run).
+function matchLineEndings(original: string, formatted: string): string {
+  // Normalize the LF output back to CRLF when the source used it.
+  let out = original.includes("\r\n")
+    ? formatted.replace(/\r\n/g, "\n").replace(/\n/g, "\r\n")
+    : formatted
+  // Drop the appended trailing newline if the original had none.
+  if (!/\n$/.test(original)) out = out.replace(/\r?\n$/, "")
+  return out
 }
 
 async function readStdin(stdin: AsyncIterable<string | Buffer>): Promise<string> {
@@ -456,7 +461,7 @@ async function runValidated(
       throw new UsageError("Reading from stdin requires --type md|html or --stdin-filepath <path>.")
     }
     const input = await readStdin(io.stdin)
-    const output = matchTrailingNewline(input, await transformContent(input, type, opts))
+    const output = matchLineEndings(input, await transformContent(input, type, opts))
     if (check) return input === output ? 0 : 1
     io.stdout.write(output)
     return 0
@@ -493,7 +498,7 @@ async function runValidated(
       ) continue
     }
 
-    const formatted = matchTrailingNewline(original, await transformContent(original, type, opts))
+    const formatted = matchLineEndings(original, await transformContent(original, type, opts))
     if (!write && !check) {
       io.stdout.write(formatted)
       continue

--- a/src/dashes.ts
+++ b/src/dashes.ts
@@ -1,5 +1,5 @@
 import { cachedRegExp, FOLDED_WORD_CHARS, isWordLike, LATIN_LETTER_RE, LATIN_LETTERS, MAX_BOUNDARY_SEPARATORS, NBSP_CHARS, SPACE_CHAR_RE, UNICODE_SYMBOLS } from "./constants.js"
-import { boundaryCountAt, exceedsSingleBoundary, firstInteriorBoundary, makeProsePass, overInput, type ProseView, replaceAllInView, type ReplaceAllOptions } from "./prose-view.js"
+import { boundaryCountAt, exceedsSingleBoundary, firstInteriorBoundary, lastBoundaryBefore, makeProsePass, overInput, type ProseView, replaceAllInView, type ReplaceAllOptions } from "./prose-view.js"
 
 export const DASH_STYLES = ["american", "british", "none"] as const
 export type DashStyle = (typeof DASH_STYLES)[number]
@@ -27,7 +27,7 @@ const months: readonly string[] = [
   "July", "August", "September", "October", "November", "December",
   // Abbreviated "May" omitted — the full name is already 3 letters
   "Jan", "Feb", "Mar", "Apr", "Jun",
-  "Jul", "Aug", "Sep", "Oct", "Nov", "Dec",
+  "Jul", "Aug", "Sept", "Sep", "Oct", "Nov", "Dec",
 ]
 
 const monthPattern = months.join("|")
@@ -903,10 +903,10 @@ function convertSpacedDashes(view: ProseView, rendered: string): void {
       // consumed span is also a floor: leading spaces it already consumed are not
       // re-used.
       let matchStart = Math.max(match.index, consumedThrough)
-      for (const b of view.boundaries) {
-        if (b > matchStart && b <= firstDash - 1) matchStart = b
-        else if (b > firstDash) break
-      }
+      // The greatest boundary strictly left of the dash restarts the match just
+      // after it (binary search, not a per-match scan of every boundary).
+      const boundaryBeforeDash = lastBoundaryBefore(view, firstDash)
+      if (boundaryBeforeDash > matchStart) matchStart = boundaryBeforeDash
       /* istanbul ignore if -- defensive: the previous match's trailing `(?=\S|$)`
          stops at this dash, so `consumedThrough` never reaches past `firstDash`. */
       if (matchStart >= firstDash + 1) return null
@@ -1276,8 +1276,10 @@ const { WORD_JOINER } = UNICODE_SYMBOLS
 /**
  * Insert a word joiner (U+2060) immediately before each unspaced em or en
  * dash that has preceding content, preventing the dash from appearing as the
- * first glyph on a wrapped line. Both dashes share Unicode line-break class
- * B2, which permits a break before them. Does not insert before line-leading
+ * first glyph on a wrapped line. The em dash (U+2014) is Unicode line-break
+ * class B2, which permits a break on either side; the en dash (U+2013) is
+ * class BA (break after). The word joiner glues either dash to the preceding
+ * word so it cannot start a wrapped line. Does not insert before line-leading
  * dashes (preceded by whitespace or start-of-string) or dashes already glued
  * with a word joiner — including British-style spaced en dashes ("word – word"),
  * which are already protected by the surrounding spaces.

--- a/src/nbsp.ts
+++ b/src/nbsp.ts
@@ -1,5 +1,5 @@
 import { cachedRegExp, LATIN_LETTER_RE, LATIN_LETTERS, NBSP_CHARS, SPACE_CHARS, UNICODE_SYMBOLS } from "./constants.js"
-import { boundaryCountAt, exceedsSingleBoundary, makeProsePass, overInput, type ProseView, replaceAllInView } from "./prose-view.js"
+import { boundaryCountAt, exceedsSingleBoundary, interiorBoundariesWithin, makeProsePass, overInput, type ProseView, replaceAllInView } from "./prose-view.js"
 
 const {
   NBSP,
@@ -105,10 +105,7 @@ const COPYRIGHT_SYMBOLS = `[${COPYRIGHT}${REGISTERED}${TRADEMARK}]`
  * allowed slot offsets.
  */
 function boundariesOnlyAtSlots(view: ProseView, start: number, end: number, slots: number[]): boolean {
-  for (const boundary of view.boundaries) {
-    if (boundary <= start || boundary >= end) continue
-    if (!slots.includes(boundary)) return false
-  }
+  if (!interiorBoundariesWithin(view, start, end, slots)) return false
   for (const slot of slots) {
     if (exceedsSingleBoundary(view, slot)) return false
   }

--- a/src/prose-view.ts
+++ b/src/prose-view.ts
@@ -241,6 +241,32 @@ export function firstInteriorBoundary(view: ProseView, start: number, end: numbe
   return first < boundaries.length && boundaries[first] < end ? boundaries[first] : -1
 }
 
+/** Largest node boundary strictly less than `offset`, or -1 when none. O(log n). */
+export function lastBoundaryBefore(view: ProseView, offset: number): number {
+  const boundaries = view.boundaries
+  const first = lowerBound(boundaries, offset)
+  return first > 0 ? boundaries[first - 1] : -1
+}
+
+/**
+ * True when every node boundary strictly inside (start, end) is one of
+ * `allowedSlots`. Seeks to the span with binary search, so it scans only the
+ * boundaries in range rather than the whole array on every call — the linear
+ * alternative is O(matches × nodes) on inline-element-heavy views.
+ */
+export function interiorBoundariesWithin(
+  view: ProseView,
+  start: number,
+  end: number,
+  allowedSlots: readonly number[],
+): boolean {
+  const boundaries = view.boundaries
+  for (let i = lowerBound(boundaries, start + 1); i < boundaries.length && boundaries[i] < end; i++) {
+    if (!allowedSlots.includes(boundaries[i])) return false
+  }
+  return true
+}
+
 /** Count of node boundaries that fall at exactly `offset` (empty nodes stack). */
 export function boundaryCountAt(view: ProseView, offset: number): number {
   const boundaries = view.boundaries

--- a/src/quote-classifier.ts
+++ b/src/quote-classifier.ts
@@ -134,7 +134,7 @@ const SINGLE_QUOTE_FAMILY = new Set<string>(["'", LEFT_SINGLE_QUOTE, RIGHT_SINGL
 /** Ending-context chars for single quotes (plus any \s char). The curly
  * doubles accompany the straight one: `"` curls into one of them in this same
  * pass, and an ending decision must survive the curl. */
-const SINGLE_ENDING_SET = new Set<string>([".", "!", "?", ";", ",", ")", EM_DASH, "-", "]", '"', LEFT_DOUBLE_QUOTE, RIGHT_DOUBLE_QUOTE, ELLIPSIS, ...FOLDED_TERMINALS])
+const SINGLE_ENDING_SET = new Set<string>([".", "!", "?", ";", ":", ",", ")", EM_DASH, "-", "]", '"', LEFT_DOUBLE_QUOTE, RIGHT_DOUBLE_QUOTE, ELLIPSIS, ...FOLDED_TERMINALS])
 
 /** Boundary chars before an opening single quote (plus any \s char). A
  * straight double quote belongs with the curly pair: whichever way it curls
@@ -160,7 +160,7 @@ const DOUBLE_EMPTY_BEFORE_SET = new Set<string>(["(", "[", "{"])
 const DOUBLE_EMPTY_AFTER_SET = new Set<string>([")", "]", "}", ".", "!", "?", ",", ";", ":", "/", "-", "s", EM_DASH, ELLIPSIS, ...FOLDED_TERMINALS])
 
 /** Ending-context chars after a closing double quote (plus any \s char). */
-const DOUBLE_CLOSE_AFTER_SET = new Set<string>(["/", ")", ".", ",", ";", EM_DASH, ":", "-", "}", "!", "?", "s", ELLIPSIS, ...FOLDED_TERMINALS])
+const DOUBLE_CLOSE_AFTER_SET = new Set<string>(["/", ")", "]", ".", ",", ";", EM_DASH, ":", "-", "}", "!", "?", "s", ELLIPSIS, ...FOLDED_TERMINALS])
 
 /** Builds an `(items, index)` predicate: in range, non-boundary, and `test(ch)`. */
 function makeItemTester(test: (ch: string) => boolean): (items: Item[], index: number) => boolean {

--- a/src/symbols.ts
+++ b/src/symbols.ts
@@ -1,5 +1,5 @@
 import { cachedRegExp, LATIN_LETTER_RE, LATIN_LETTERS, MAX_BOUNDARY_SEPARATORS, SPACE_CHAR_RE, UNICODE_SYMBOLS, WORD_RE } from "./constants.js"
-import { boundaryCountAt, exceedsSingleBoundary, firstInteriorBoundary, makeProsePass, overInput, type ProseView, replaceAllInView } from "./prose-view.js"
+import { boundaryCountAt, exceedsSingleBoundary, firstInteriorBoundary, interiorBoundariesWithin, makeProsePass, overInput, type ProseView, replaceAllInView } from "./prose-view.js"
 import { convertPrimeMarks } from "./quote-classifier.js"
 
 export interface SymbolOptions {
@@ -173,9 +173,7 @@ function chainSegments(chainStart: number, firstNum: string, rest: string): Chai
  */
 function operatorSlotClean(view: ProseView, slotStart: number, slotEnd: number): boolean {
   // No boundary strictly inside the spacing-plus-operator slot.
-  for (const boundary of view.boundaries) {
-    if (boundary > slotStart && boundary < slotEnd) return false
-  }
+  if (firstInteriorBoundary(view, slotStart, slotEnd) >= 0) return false
   // At most one boundary hugging each outer edge (duplicates at an offset come
   // from empty nodes and each counts as one boundary).
   return boundaryCountAt(view, slotStart) <= 1 && boundaryCountAt(view, slotEnd) <= 1
@@ -457,9 +455,7 @@ function mathLookaheadBlocks(text: string, view: ProseView, end: number, forbidd
  */
 function mathOperatorAllowBoundary(match: RegExpExecArray, view: ProseView): boolean {
   const junction = match.index + match[0].length - 1
-  for (const boundary of view.boundaries) {
-    if (boundary > match.index && boundary < match.index + match[0].length && boundary !== junction) return false
-  }
+  if (!interiorBoundariesWithin(view, match.index, match.index + match[0].length, [junction])) return false
   return boundaryCountAt(view, junction) <= 1
 }
 
@@ -744,11 +740,9 @@ function degreeUnitFollowOk(text: string, view: ProseView, unitEnd: number): boo
 function digitSuffixBoundaryOk(match: RegExpExecArray, view: ProseView): boolean {
   const digitEnd = match.index + 1
   const matchEnd = match.index + match[0].length
-  for (const boundary of view.boundaries) {
-    // Reject any interior boundary that is not the single tolerated slot after
-    // the leading digit.
-    if (boundary > match.index && boundary < matchEnd && boundary !== digitEnd) return false
-  }
+  // Reject any interior boundary that is not the single tolerated slot after
+  // the leading digit.
+  if (!interiorBoundariesWithin(view, match.index, matchEnd, [digitEnd])) return false
   return boundaryCountAt(view, digitEnd) <= 1
 }
 

--- a/src/tests/cli.test.ts
+++ b/src/tests/cli.test.ts
@@ -160,6 +160,31 @@ describe("runCli", () => {
     expect(code).toBe(0)
   })
 
+  it("--write preserves CRLF line endings instead of producing mixed endings", async () => {
+    const path = tmpFile('"Hello" -- world.\r\nSecond line.\r\n', "doc.md")
+    const cap = captureIO()
+    const code = await runCli(["--write", path, "--no-nbsp"], cap.io)
+    expect(code).toBe(0)
+    const written = readFileSync(path, "utf8")
+    expect(written).toBe(`${LDQ}Hello${RDQ}${EM_DASH}world.\r\nSecond line.\r\n`)
+    expect(written).not.toMatch(/[^\r]\n/) // no lone LF
+  })
+
+  it("--check is stable on an already-formatted CRLF file (no perpetual churn)", async () => {
+    const path = tmpFile(`${LDQ}Hi${RDQ}${EM_DASH}there.\r\nDone.\r\n`, "doc.md")
+    const cap = captureIO()
+    const code = await runCli(["--check", path, "--no-nbsp"], cap.io)
+    expect(code).toBe(0)
+  })
+
+  it("--write preserves CRLF for HTML files", async () => {
+    const path = tmpFile('<p>"Hello"</p>\r\n', "page.html")
+    const cap = captureIO()
+    const code = await runCli(["--write", path, "--no-nbsp"], cap.io)
+    expect(code).toBe(0)
+    expect(readFileSync(path, "utf8")).toBe(`<p>${LDQ}Hello${RDQ}</p>\r\n`)
+  })
+
   it("handles HTML files via .html extension", async () => {
     const path = tmpFile('<p>"Hello"</p>\n', "page.html")
     const cap = captureIO()

--- a/src/tests/dashes.test.ts
+++ b/src/tests/dashes.test.ts
@@ -148,6 +148,9 @@ describe("hyphenReplace", () => {
       ["October 2012 - December 2014", `October 2012${EN_DASH}December 2014`],
       ["Jan 2000 - Feb", `Jan 2000${EN_DASH}Feb`],
       ["March - April 2025", `March${EN_DASH}April 2025`],
+      // "Sept" is a common four-letter abbreviation for September, alongside "Sep".
+      ["Sept-Nov", `Sept${EN_DASH}Nov`],
+      ["Sept - Dec", `Sept${EN_DASH}Dec`],
     ])('converts "%s"', (input, expected) => {
       expect(hyphenReplace(input)).toBe(expected)
     })

--- a/src/tests/quotes.test.ts
+++ b/src/tests/quotes.test.ts
@@ -471,6 +471,23 @@ describe("niceQuotes", () => {
     })
   })
 
+  describe("quotes closing before a colon or bracket", () => {
+    // A single-quoted term before a colon must curl both marks; the colon is a
+    // closing context just like the semicolon beside it. Regression: a missing
+    // colon left the closer straight, which then relabelled the opener too.
+    it.each([
+      ["the word 'love': a definition", `the word ${LEFT_SINGLE_QUOTE}love${RIGHT_SINGLE_QUOTE}: a definition`],
+      ["She said 'yes': the answer", `She said ${LEFT_SINGLE_QUOTE}yes${RIGHT_SINGLE_QUOTE}: the answer`],
+      ['the word "love": a definition', `the word ${LEFT_DOUBLE_QUOTE}love${RIGHT_DOUBLE_QUOTE}: a definition`],
+      // A closing double quote before `]` curls, mirroring the opener after `[`.
+      ['x ["foo"] y', `x [${LEFT_DOUBLE_QUOTE}foo${RIGHT_DOUBLE_QUOTE}] y`],
+      ['a ["quoted"] item', `a [${LEFT_DOUBLE_QUOTE}quoted${RIGHT_DOUBLE_QUOTE}] item`],
+    ])('curls quotes before a closing colon/bracket: "%s"', (input, expected) => {
+      expect(niceQuotes(input)).toBe(expected)
+      expect(niceQuotes(niceQuotes(input))).toBe(expected)
+    })
+  })
+
   describe("consecutive contractions", () => {
     it.each([
       ["I'd've", `I${MODIFIER_LETTER_APOSTROPHE}d${MODIFIER_LETTER_APOSTROPHE}ve`],


### PR DESCRIPTION
This started as a thorough audit of the whole library (correctness, coverage, efficiency, docs, and packaging). Each finding below was reproduced against the built library before fixing, and the whole suite (2449 tests, 100% branch coverage) plus repeated fresh-seed fuzz runs stay green. Fixes are grouped into focused commits; more speculative findings are listed at the bottom as follow-ups rather than crammed in here.

## Correctness

**Single-quoted term before a colon mangled both quotes.** `:` was missing from the single-quote ending contexts (`SINGLE_ENDING_SET`), while its neighbour `;` was present. As a result:

```
the word 'love': a definition   →  the word ’love': a definition   (both marks wrong)
```

The closer stayed straight, and the leading-apostrophe pass then relabelled the *opener* as an apostrophe. The double-quote path already handled this (`"love":` → `“love”:`). Fixed by adding `:` to `SINGLE_ENDING_SET`. Now: `the word ‘love’: a definition`.

**Closing double quote before `]` not curled.** `]` was in the opener set (`[` opens) but missing from `DOUBLE_CLOSE_AFTER_SET`, so:

```
x ["foo"] y   →   x [“foo"] y   (opener curls, closer doesn't)
```

Added `]` to `DOUBLE_CLOSE_AFTER_SET`. Now: `x [“foo”] y`.

> Note: I deliberately did **not** widen the single-quote sets further (e.g. `}`, `/`, `[`). Existing tests pin that narrowness — because `'` doubles as an apostrophe, treating `'}`/`{'` as quote boundaries would misclassify apostrophes. The colon was the one genuine gap.

**`Sept` month abbreviation not recognized.** The date-range en dash matched `Sep` but not the equally common `Sept`:

```
Sep-Nov  → Sep–Nov      Sept-Nov → Sept-Nov   (unchanged, before)
```

Added `Sept` to the month list. Now `Sept-Nov → Sept–Nov`.

**CLI rewrote CRLF files' final line to LF.** The unified pipelines emit LF and append a trailing newline, so a CRLF file came back with a lone LF on its last line — mixed endings. That made `--check` report a change on *every* run (permanent CI churn) and `--write` rewrite the file every time. Replaced `matchTrailingNewline` with `matchLineEndings`, which restores the source's ending style (CRLF vs LF) across the whole output and matches the original trailing-newline presence. Covers both Markdown and HTML sinks.

## Performance

**Quadratic node-boundary scans.** Several boundary guards scanned the *entire* `view.boundaries` array on every match to detect interior boundaries — O(matches × nodes) on inline-element-heavy HTML/Markdown, exactly the cost the ProseView binary-search helpers exist to avoid. `convertSpacedDashes` was the measured hot spot (`<span>w</span> - <span>w</span> …` repeated): time roughly tripled per input doubling.

Added two O(log n) helpers to `prose-view.ts` (`lastBoundaryBefore`, `interiorBoundariesWithin`) and routed `convertSpacedDashes`, `operatorSlotClean`, `mathOperatorAllowBoundary`, `digitSuffixBoundaryOk`, and `boundariesOnlyAtSlots` through them. Behaviour is unchanged (verified by the full suite); scaling is now near-linear (measured: 16k nodes 338 ms → 39 ms).

## Docs & packaging

- **Benchmark table** used a stale total of 152; the suite now has **160** cases (CI floor 158). Regenerated every row from a fresh run (`punctilio 158/160`, and updated competitor counts).
- Removed the **unused `escape-string-regexp`** runtime dependency (nothing in `src/` imports it; only a transitive copy is used). Lockfile updated; frozen install verified.
- `CONTRIBUTING.md`: `pnpm lint` covers `src/` *and* `scripts/`, and mutation testing runs on every PR (the file also claimed "weekly").
- Corrected the `dashWordJoiner` comment that wrongly claimed the em and en dash share Unicode line-break class B2 (the en dash is class BA).

## Follow-ups identified but intentionally out of scope

These are real but need their own focused design/PR — folding them in here would make the change unreviewable or risky:

1. **Opaque inline content breaks adjacency (higher severity).** When inline `code`/`inlineCode`, an image, or a skipped element sits *between* two text nodes, the flatten layer drops it and the survivors become falsely adjacent across a single soft boundary that the multiplication/dash guards tolerate. E.g. `5<code>c</code>x 3` → `5<code>c</code> × 3`, and `5<a href="/u">x</a> 3` rewrites the link's own label to `×`. The fix needs the flatten/boundary model to mark removed opaque content as an impassable gap.
2. **Element with both direct text and block children merges across the block boundary** (`collectProseBlocks`): `<div>5<p>x 3</p></div>` pairs the div's `5` with the paragraph's `x 3`.
3. **Pre-existing idempotency edges** surfaced only under heavy fuzzing (`FUZZ_RUNS=25000`), not at CI intensity, and present on `main` before this PR — e.g. `[21707x',,` (American comma placement oscillates across `,,`) and an exotic German multi-node decade case. Reproducible with the seeds/paths from a heavy fuzz run.
4. **Swiss-German thousands separator** `5'000` becomes a prime `5′000`; distinguishing it from feet-inches `5'10"` is genuinely ambiguous, so it needs a deliberate heuristic.
5. **CLI robustness** (each real, lower priority): literal filenames containing glob metacharacters are treated as globs; explicitly-named files are still subject to `.punctilioignore`; a zero-match glob exits 0 silently; `--type` isn't part of the cache key (stale hit across types); in-place writes aren't atomic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016fapkP23hoxymPyrqWrSB4

---
_Generated by [Claude Code](https://claude.ai/code/session_016fapkP23hoxymPyrqWrSB4)_