### PR TITLE
Fix the five deferred follow-ups from #249: opaque gaps, block-child merging, Swiss thousands, idempotency edges, CLI robustness

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2,7 +2,7 @@
 
 import { createHash } from "node:crypto"
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs"
-import { readFile, writeFile } from "node:fs/promises"
+import { readFile, rename, writeFile } from "node:fs/promises"
 import { dirname, extname, isAbsolute, join, relative, resolve } from "node:path"
 import { fileURLToPath } from "node:url"
 import { parseArgs } from "node:util"
@@ -261,31 +261,45 @@ function loadIgnore(cwd: string, ignorePath: string | undefined): Ignore {
   return ig
 }
 
-function isGlobPattern(pattern: string): boolean {
+function hasGlobMetacharacters(pattern: string): boolean {
   return /[*?[\]{}]/.test(pattern)
 }
 
-// Non-glob positionals pass through as literal paths so they error loudly if missing.
+// A positional is a literal path when it has no glob metacharacters, or when a
+// file with that exact name exists on disk (so a real file named `note[1].md`
+// is not mistaken for a glob).
+function isLiteralPath(pattern: string, cwd: string): boolean {
+  return !hasGlobMetacharacters(pattern) || existsSync(resolve(cwd, pattern))
+}
+
+// Literal positionals pass through untouched so they error loudly if missing and
+// bypass ignore rules (naming a file explicitly is an intent to format it).
+// Ignore rules and the zero-match warning apply only to glob-expanded paths.
 async function discoverFiles(
   patterns: string[],
   cwd: string,
   ig: Ignore,
+  stderr: NodeJS.WritableStream,
 ): Promise<string[]> {
-  const literals = patterns.filter((p) => !isGlobPattern(p))
-  const globs = patterns.filter(isGlobPattern)
+  const literals = patterns.filter((p) => isLiteralPath(p, cwd))
+  const globs = patterns.filter((p) => !isLiteralPath(p, cwd))
   const expanded = globs.length > 0
     ? await glob(globs, { cwd, absolute: true, onlyFiles: true })
     : []
-  const all = [...new Set([...literals.map((p) => resolve(cwd, p)), ...expanded])]
-  return all.filter((file) => {
+  const kept = expanded.filter((file) => {
     const rel = relative(cwd, file)
     return rel.startsWith("..") || !ig.ignores(rel)
   })
+  if (globs.length > 0 && kept.length === 0) {
+    stderr.write(`Warning: no files matched: ${globs.join(" ")}\n`)
+  }
+  return [...new Set([...literals.map((p) => resolve(cwd, p)), ...kept])]
 }
 
 interface CacheEntry {
   contentHash: string
   optionsHash: string
+  type: FileType
   version: string
 }
 
@@ -328,6 +342,14 @@ function loadCache(location: string, stderr: NodeJS.WritableStream): Cache {
 function saveCache(location: string, cache: Cache): void {
   mkdirSync(dirname(location), { recursive: true })
   writeFileSync(location, JSON.stringify(cache))
+}
+
+// Replace a file's contents atomically: write a sibling temp file, then rename
+// it over the target so an interrupted run can never leave a half-written file.
+async function atomicWriteFile(path: string, contents: string): Promise<void> {
+  const tmpPath = `${path}.${process.pid}.tmp`
+  await writeFile(tmpPath, contents)
+  await rename(tmpPath, path)
 }
 
 // cwd-relative so the cache survives directory moves and cross-machine syncs.
@@ -473,7 +495,7 @@ async function runValidated(
   }
 
   const ig = loadIgnore(cwd, flags.ignorePath)
-  const files = await discoverFiles(positionals, cwd, ig)
+  const files = await discoverFiles(positionals, cwd, ig, io.stderr)
 
   // In stdout mode every file's content must be produced, so a cache hit
   // could never skip work; only --write and --check use the cache.
@@ -494,6 +516,7 @@ async function runValidated(
         entry !== undefined &&
         entry.contentHash === hashString(original) &&
         entry.optionsHash === optionsHash &&
+        entry.type === type &&
         entry.version === version
       ) continue
     }
@@ -509,12 +532,12 @@ async function runValidated(
       if (check) {
         io.stderr.write(`Would reformat: ${path}\n`)
       } else {
-        await writeFile(path, formatted)
+        await atomicWriteFile(path, formatted)
         io.stdout.write(`Reformatted: ${path}\n`)
       }
     }
     if (cache && (unchanged || !check)) {
-      cache.files[key] = { contentHash: hashString(formatted), optionsHash, version }
+      cache.files[key] = { contentHash: hashString(formatted), optionsHash, type, version }
     }
   }
 

--- a/src/prose-view.ts
+++ b/src/prose-view.ts
@@ -206,6 +206,28 @@ export function buildProseView(nodes: ProseNode[]): ProseView {
   return new ProseViewImpl(nodes)
 }
 
+/**
+ * Partitions `items` into contiguous groups, breaking before every index in
+ * `breakBefore` (indices 1..n-1). With no break indices the whole list is one
+ * group; an empty list yields no groups. Used to isolate opaque-delimited
+ * segments so a pass never sees text as adjacent across removed content.
+ */
+export function splitAtIndices<T>(items: readonly T[], breakBefore: ReadonlySet<number>): T[][] {
+  if (breakBefore.size === 0) {
+    return items.length > 0 ? [items.slice()] : []
+  }
+  const groups: T[][] = []
+  let start = 0
+  for (let i = 1; i < items.length; i++) {
+    if (breakBefore.has(i)) {
+      groups.push(items.slice(start, i))
+      start = i
+    }
+  }
+  groups.push(items.slice(start))
+  return groups
+}
+
 export interface ReplaceAllOptions {
   /** Opt-in: allow a match that contains an interior node boundary. Default: such matches are skipped. */
   allowBoundaries?: (match: RegExpExecArray, view: ProseView) => boolean

--- a/src/quote-classifier.ts
+++ b/src/quote-classifier.ts
@@ -93,13 +93,16 @@ interface Item {
   /** Set when punctuation placement relocates this item. */
   moved: boolean
   /**
-   * Set on a CLOSE_SINGLE that has no matching opener and sits directly after
-   * a letter — a word-final quote that reads as elision ("keep on truckin'")
-   * at least as plausibly as quotation. It keeps its closer role (glyph
-   * U+2019 either way) but punctuation placement must not move around it:
-   * pulling the period into "truckin'." corrupts the word to "truckin.'".
+   * Set on a CLOSE_SINGLE that has no matching opener, so punctuation
+   * placement must not move around it. Two cases qualify: a word-final quote
+   * directly after a letter, which reads as elision ("keep on truckin'") at
+   * least as plausibly as quotation — pulling the period into "truckin'."
+   * corrupts the word to "truckin.'" — and, in German, any orphan closer,
+   * because German re-derives its rendered glyph (U+2018) back to a straight
+   * quote by position on the next run, so relocating punctuation around it
+   * changes that re-derived shape and breaks the fixed point ("'06,'").
    */
-  unmatchedAfterLetter?: boolean
+  frozenCloser?: boolean
   /** Insertion anchor (clean-text offset and bind side) once moved. */
   anchorOffset: number
   anchorBind: "left" | "right"
@@ -530,12 +533,13 @@ function classifyOpeningSingles(items: Item[]): void {
 
 /**
  * Unmatched CLOSE_SINGLE after s/S → APOSTROPHE (plural possessives), via the
- * advisory open/close balance scan. An unmatched closer after any other
- * letter keeps its closer role but is flagged {@link Item.unmatchedAfterLetter}
- * so punctuation placement leaves it alone. Boundaries are fully transparent
- * here.
+ * advisory open/close balance scan. An unmatched closer keeps its closer role
+ * but is flagged {@link Item.frozenCloser} so punctuation placement leaves it
+ * alone: after any other letter in every style, and after any character in
+ * German (which re-derives the rendered glyph by position on re-run).
+ * Boundaries are fully transparent here.
  */
-function classifyPluralPossessives(items: Item[]): void {
+function classifyPluralPossessives(items: Item[], style: ActiveQuoteStyle): void {
   let balance = 0
   for (let i = 0; i < items.length; i++) {
     const item = items[i]
@@ -553,8 +557,8 @@ function classifyPluralPossessives(items: Item[]): void {
     while (j >= 0 && items[j].boundary) j--
     if (j >= 0 && (items[j].ch === "s" || items[j].ch === "S")) {
       item.ch = MODIFIER_LETTER_APOSTROPHE
-    } else if (j >= 0 && isLetterItem(items, j)) {
-      item.unmatchedAfterLetter = true
+    } else if (j >= 0 && (isLetterItem(items, j) || style === "german")) {
+      item.frozenCloser = true
     }
   }
 }
@@ -576,7 +580,7 @@ function classifySingles(items: Item[], style: ActiveQuoteStyle): void {
   if (style !== "german") {
     while (classifyPossessivesAndClosers(items)) { /* to fixpoint */ }
   }
-  classifyPluralPossessives(items)
+  classifyPluralPossessives(items, style)
 }
 
 // ---------------------------------------------------------------------------
@@ -873,7 +877,7 @@ function closingRunMemberAt(items: Item[], index: number, closingSet: ReadonlySe
   if (index >= items.length || items[index].boundary || !closingSet.has(items[index].ch)) return false
   // A word-final closer with no opener behind it reads as elision; moving
   // punctuation around it corrupts the word ("truckin'." → "truckin.'").
-  if (items[index].unmatchedAfterLetter) return false
+  if (items[index].frozenCloser) return false
   if (items[index].ch !== MODIFIER_LETTER_APOSTROPHE) return true
   const prev = prevIndex(items, index, 1)
   return !isCharItem(items, prev, "s") && !isCharItem(items, prev, "S")

--- a/src/quote-classifier.ts
+++ b/src/quote-classifier.ts
@@ -1436,7 +1436,7 @@ function quotePassClosesCandidate(items: Item[], index: number, quote: string): 
  * a prime only when the running quote balance is open-free; contractions are
  * skipped and trailing apostrophes consume balance without converting.
  */
-function convertPrimes(items: Item[]): void {
+function convertPrimes(items: Item[], swissSeparators: ReadonlySet<number>): void {
   const passes: [string, string][] = [
     ["'", PRIME],
     ['"', DOUBLE_PRIME],
@@ -1446,6 +1446,12 @@ function convertPrimes(items: Item[]): void {
     for (let i = 0; i < items.length; i++) {
       const item = items[i]
       if (item.boundary || item.ch !== quote) continue
+      // A Swiss/Liechtenstein digit-group separator (5'000) is an apostrophe,
+      // not a foot/minute prime; curl it and leave the quote balance untouched.
+      if (quote === "'" && swissSeparators.has(item.start)) {
+        item.ch = RIGHT_SINGLE_QUOTE
+        continue
+      }
       const digitIndex = prevIndex(items, i, 1)
       if (isDigitItem(items, digitIndex) && !isLetterItem(items, i + 1)) {
         // Prime candidate. The after-context check is boundary-blind: a
@@ -1489,12 +1495,30 @@ function convertPrimes(items: Item[]): void {
  */
 const PRIME_CANDIDATE_RE = /\d['"]/
 
+// Swiss/Liechtenstein thousands grouping: 5'000, 1'000'000, 5'000.50. Leading
+// group of 1-3 digits, then one or more apostrophe-separated groups of exactly
+// three, not embedded in a longer digit run. Groups of exactly three rule out
+// feet-inches (5'10", 6'2"), whose inch value is one or two digits.
+const SWISS_THOUSANDS_RE = /(?<![\d'])\d{1,3}(?:'\d{3})+(?!\d)/g
+
+/** Offsets of the apostrophes that separate Swiss thousands groups in `text`. */
+function swissThousandsSeparators(text: string): ReadonlySet<number> {
+  const offsets = new Set<number>()
+  if (!text.includes("'")) return offsets
+  for (const match of text.matchAll(SWISS_THOUSANDS_RE)) {
+    for (let i = 0; i < match[0].length; i++) {
+      if (match[0][i] === "'") offsets.add(match.index + i)
+    }
+  }
+  return offsets
+}
+
 /** primeMarks engine: converts `5'10"` to `5′10″` with quote-balance guards. Commits its edits. */
 export function convertPrimeMarks(view: ProseView): void {
   const text = view.text
   if (!PRIME_CANDIDATE_RE.test(text)) return
   const items = buildItems(view, "american")
-  convertPrimes(items)
+  convertPrimes(items, swissThousandsSeparators(text))
   for (const item of items) {
     if (!item.boundary && item.ch !== text[item.start]) {
       view.replace(item.start, item.end, item.ch)

--- a/src/rehype.ts
+++ b/src/rehype.ts
@@ -7,7 +7,7 @@ import { transformView } from "./index.js"
 import { TRANSFORM_OPTION_KEYS, type TransformOptions } from "./transform-options.js"
 import { MAX_RECURSION_DEPTH } from "./constants.js"
 import { assertKnownOptionKeys, formatErrorString } from "./utils.js"
-import { buildProseView, type ProsePass, type ProseView } from "./prose-view.js"
+import { buildProseView, type ProsePass, type ProseView, splitAtIndices } from "./prose-view.js"
 
 export type ElementPredicate = (node: Element) => boolean
 
@@ -80,53 +80,100 @@ export const REHYPE_ONLY_OPTION_KEYS: readonly string[] = ["skipTags", "skipClas
 /** Runtime list of valid `rehypePunctilio` option keys. */
 export const REHYPE_OPTION_KEYS: readonly string[] = [...TRANSFORM_OPTION_KEYS, ...REHYPE_ONLY_OPTION_KEYS]
 
-export function flattenTextNodes(
-  node: Element | ElementContent,
-  shouldSkip: ElementPredicate,
-  options?: ElementTransformOptions
-): Text[] {
-  const shouldSkipText = options?.shouldSkipText
-  // Only track ancestors when shouldSkipText needs them, to avoid the
-  // O(n²) allocation cost of copying the ancestor chain at every level.
-  const ancestors: Element[] | null = shouldSkipText ? [] : null
-  return flattenTextNodesImpl(node, shouldSkip, shouldSkipText, ancestors, 0)
+// Void/replaced inline elements that render atomic content (or a hard break)
+// and carry no transformable text. When one sits between two text nodes it is a
+// real visual separator, so the flattener records an opaque gap there.
+const OPAQUE_VOID_TAGS = new Set([
+  "img", "br", "wbr", "input", "hr", "embed",
+  "area", "source", "track", "col", "param", "keygen",
+])
+
+/** Flattened text nodes plus the opaque gaps that fell between adjacent ones. */
+export interface FlattenedProse {
+  nodes: Text[]
+  /** Indices into `nodes` (1..n-1) with removed opaque content immediately before them. */
+  opaqueBefore: Set<number>
 }
 
-function flattenTextNodesImpl(
-  node: Element | ElementContent,
-  shouldSkip: ElementPredicate,
-  shouldSkipText: TextNodeSkipPredicate | undefined,
-  ancestors: Element[] | null,
-  depth: number
-): Text[] {
+interface ProseCollector {
+  nodes: Text[]
+  opaqueBefore: Set<number>
+  shouldSkip: ElementPredicate
+  shouldSkipText: TextNodeSkipPredicate | undefined
+  ancestors: Element[] | null
+  // An opaque element was dropped since the last emitted text node; the next
+  // emitted node records an opaque gap before it.
+  pendingOpaque: boolean
+}
+
+function collectProse(node: Element | ElementContent, depth: number, c: ProseCollector): void {
   if (depth > MAX_RECURSION_DEPTH) {
-    return []
+    return
   }
 
-  if (node.type === "element" && shouldSkip(node)) {
-    return []
+  if (node.type === "element") {
+    if (c.shouldSkip(node)) {
+      // A skipped element with content is a visual separator; an empty one
+      // renders nothing and leaves its neighbors genuinely adjacent.
+      if (node.children.length > 0) c.pendingOpaque = true
+      return
+    }
+    if (OPAQUE_VOID_TAGS.has(node.tagName)) {
+      c.pendingOpaque = true
+      return
+    }
+    if (c.ancestors) c.ancestors.push(node)
+    for (const child of node.children) collectProse(child, depth + 1, c)
+    if (c.ancestors) c.ancestors.pop()
+    return
   }
 
   if (node.type === "text") {
     // Snapshot ancestors at the callback boundary — the walker mutates the
     // shared array as it recurses, so handing it out directly would let a
     // caller observe a stale view if they captured the reference.
-    if (shouldSkipText && ancestors && shouldSkipText(node, ancestors.slice())) {
-      return []
+    if (c.shouldSkipText && c.ancestors && c.shouldSkipText(node, c.ancestors.slice())) {
+      // Preserved-but-untransformed text is a separator between its neighbors.
+      c.pendingOpaque = true
+      return
     }
-    return [node]
+    if (c.pendingOpaque && c.nodes.length > 0) c.opaqueBefore.add(c.nodes.length)
+    c.pendingOpaque = false
+    c.nodes.push(node)
   }
+}
 
-  if (node.type === "element") {
-    if (ancestors) ancestors.push(node)
-    const result = node.children.flatMap((child) =>
-      flattenTextNodesImpl(child, shouldSkip, shouldSkipText, ancestors, depth + 1)
-    )
-    if (ancestors) ancestors.pop()
-    return result
+function newCollector(shouldSkip: ElementPredicate, options?: ElementTransformOptions): ProseCollector {
+  const shouldSkipText = options?.shouldSkipText
+  return {
+    nodes: [],
+    opaqueBefore: new Set(),
+    shouldSkip,
+    shouldSkipText,
+    // Only track ancestors when shouldSkipText needs them, to avoid the
+    // O(n²) allocation cost of copying the ancestor chain at every level.
+    ancestors: shouldSkipText ? [] : null,
+    pendingOpaque: false,
   }
+}
 
-  return []
+/** Flattens an element's transformable text nodes, tracking opaque gaps. */
+export function flattenProse(
+  node: Element | ElementContent,
+  shouldSkip: ElementPredicate,
+  options?: ElementTransformOptions
+): FlattenedProse {
+  const c = newCollector(shouldSkip, options)
+  collectProse(node, 0, c)
+  return { nodes: c.nodes, opaqueBefore: c.opaqueBefore }
+}
+
+export function flattenTextNodes(
+  node: Element | ElementContent,
+  shouldSkip: ElementPredicate,
+  options?: ElementTransformOptions
+): Text[] {
+  return flattenProse(node, shouldSkip, options).nodes
 }
 
 export function getTextContent(
@@ -191,9 +238,11 @@ export interface ProseViewOfOptions extends ElementTransformOptions {
 }
 
 /**
- * Builds a ProseView over the element's transformable text nodes, honoring
- * the element-level `shouldSkip` and per-text-node `shouldSkipText`
- * predicates. Returns null when the element holds no transformable text.
+ * Builds a single ProseView over the element's transformable text nodes,
+ * honoring the element-level `shouldSkip` and per-text-node `shouldSkipText`
+ * predicates. Returns null when the element holds no transformable text. This
+ * view spans opaque gaps; the transform pipeline uses {@link proseViewsOf},
+ * which splits on them so no pass rewrites across removed atomic content.
  */
 export function proseViewOf(element: Element, options: ProseViewOfOptions = {}): ProseView | null {
   /* istanbul ignore if -- defensive: elements should always have children array */
@@ -208,6 +257,22 @@ export function proseViewOf(element: Element, options: ProseViewOfOptions = {}):
   }
 
   return buildProseView(textNodes)
+}
+
+/**
+ * Builds one ProseView per opaque-delimited segment of the element's text.
+ * Splitting at opaque gaps (removed skipped elements, images, and other atomic
+ * inline content) keeps their surrounding text in separate views, so a pass can
+ * never treat text as adjacent across content that visually separates it.
+ */
+export function proseViewsOf(element: Element, options: ProseViewOfOptions = {}): ProseView[] {
+  /* istanbul ignore if -- defensive: elements should always have children array */
+  if (!element?.children) {
+    return []
+  }
+  const shouldSkip = options.shouldSkip ?? (() => false)
+  const { nodes, opaqueBefore } = flattenProse(element, shouldSkip, options)
+  return splitAtIndices(nodes, opaqueBefore).map((group) => buildProseView(group))
 }
 
 /**
@@ -255,7 +320,7 @@ export function applyPasses(
   passes: readonly PassEntry[],
   options: ProseViewOfOptions = {},
 ): void {
-  let currentView: ProseView | null = null
+  let currentViews: ProseView[] = []
   let currentPredicates: Pick<ResolvedPassEntry, "shouldSkip" | "shouldSkipText"> | null = null
 
   for (const entry of passes) {
@@ -266,20 +331,18 @@ export function applyPasses(
       currentPredicates.shouldSkip === shouldSkip &&
       currentPredicates.shouldSkipText === shouldSkipText
     if (!samePredicates) {
-      currentView = proseViewOf(element, {
+      currentViews = proseViewsOf(element, {
         shouldSkip: mergePredicates(options.shouldSkip, shouldSkip),
         shouldSkipText: mergePredicates(options.shouldSkipText, shouldSkipText),
       })
       currentPredicates = { shouldSkip, shouldSkipText }
     }
 
-    // No transformable text under this entry's predicates; later entries may
-    // still see text (their skip sets differ), so keep going.
-    if (currentView === null) {
-      continue
+    // Each opaque-delimited segment is transformed independently; an entry with
+    // no transformable text simply has no views to run over.
+    for (const view of currentViews) {
+      pass(view)
     }
-
-    pass(currentView)
   }
 }
 
@@ -534,20 +597,19 @@ function collectProseUnitsImpl(
   return units
 }
 
-// Flatten a run's inline siblings to their text nodes, seeding the ancestor
-// chain with `container` so `shouldSkipText` sees the same ancestors it would
-// when the whole element is flattened as a leaf.
-function flattenRunTextNodes(
+// Flatten a run's inline siblings to their text nodes (with opaque gaps),
+// seeding the ancestor chain with `container` so `shouldSkipText` sees the same
+// ancestors it would when the whole element is flattened as a leaf.
+function flattenRunProse(
   container: Element,
   children: readonly ElementContent[],
   shouldSkip: ElementPredicate,
   options: ProseViewOfOptions
-): Text[] {
-  const shouldSkipText = options.shouldSkipText
-  const ancestors: Element[] | null = shouldSkipText ? [container] : null
-  return children.flatMap((child) =>
-    flattenTextNodesImpl(child, shouldSkip, shouldSkipText, ancestors, 1)
-  )
+): FlattenedProse {
+  const c = newCollector(shouldSkip, options)
+  if (c.ancestors) c.ancestors.push(container)
+  for (const child of children) collectProse(child, 1, c)
+  return { nodes: c.nodes, opaqueBefore: c.opaqueBefore }
 }
 
 function markDescendants(node: Element, set: Set<Element>, depth: number = 0): void {
@@ -605,8 +667,7 @@ export function rehypePunctilio(
       for (const unit of units) {
         if (unit.kind === "element") {
           if (!transformed.has(unit.element)) {
-            const view = proseViewOf(unit.element, viewOptions)
-            if (view !== null) {
+            for (const view of proseViewsOf(unit.element, viewOptions)) {
               transformView(view, transformOptions)
             }
             transformed.add(unit.element)
@@ -614,9 +675,9 @@ export function rehypePunctilio(
             markDescendants(unit.element, transformed)
           }
         } else {
-          const textNodes = flattenRunTextNodes(unit.container, unit.children, shouldSkip, viewOptions)
-          if (textNodes.length > 0) {
-            transformView(buildProseView(textNodes), transformOptions)
+          const { nodes, opaqueBefore } = flattenRunProse(unit.container, unit.children, shouldSkip, viewOptions)
+          for (const group of splitAtIndices(nodes, opaqueBefore)) {
+            transformView(buildProseView(group), transformOptions)
           }
           // Mark the container so a later visit doesn't re-collect its runs,
           // and mark the run's inline-element members' subtrees.

--- a/src/rehype.ts
+++ b/src/rehype.ts
@@ -433,30 +433,46 @@ function resolveCollectOptions(options: CollectProseBlocksOptions): ResolvedColl
   }
 }
 
+// A prose unit is either a whole transformable element (an inline-only leaf) or
+// a "run" of consecutive inline siblings that sit alongside block-level
+// children. Runs let a container's loose inline text transform independently of
+// its block children instead of merging across the block boundary.
+type ProseUnit =
+  | { kind: "element"; element: Element }
+  | { kind: "run"; container: Element; children: ElementContent[] }
+
 /**
- * Collects the elements under `root` (inclusive) whose text should be
+ * Collects the leaf elements under `root` (inclusive) whose text should be
  * transformed as one prose block: transformable elements with direct text or
  * inline-only text descendants. Elements with block-level children recurse so
- * each block transforms independently.
+ * each block transforms independently. Loose inline text mixed among block
+ * children is handled by the plugin as its own run and is not represented here.
  */
 export function collectProseBlocks(root: Element, options: CollectProseBlocksOptions = {}): Element[] {
   const { shouldSkip, isTransformable } = resolveCollectOptions(options)
-  return collectProseBlocksImpl(root, shouldSkip, 0, undefined, isTransformable)
+  return collectProseUnitsImpl(root, shouldSkip, 0, undefined, isTransformable)
+    .flatMap((unit) => (unit.kind === "element" ? [unit.element] : []))
 }
 
-function collectProseBlocksImpl(
+function runHasProse(children: readonly ElementContent[], shouldSkip: ElementPredicate): boolean {
+  return children.some(
+    (child) =>
+      (child.type === "text" && child.value.trim() !== "") ||
+      (child.type === "element" && hasTextDescendant(child, shouldSkip))
+  )
+}
+
+function collectProseUnitsImpl(
   node: Element,
   shouldSkip: ElementPredicate,
   depth: number,
   alreadyTransformed: ReadonlySet<Element> | undefined,
   isTransformable: (tagName: string) => boolean
-): Element[] {
+): ProseUnit[] {
   /* istanbul ignore if -- defensive: prevents stack overflow from malicious HTML */
   if (depth > MAX_RECURSION_DEPTH) {
     return []
   }
-
-  const results: Element[] = []
 
   if (shouldSkip(node) || alreadyTransformed?.has(node)) {
     return []
@@ -470,31 +486,68 @@ function collectProseBlocksImpl(
   const hasDirectText = node.children.some(
     (child) => child.type === "text" && child.value.trim() !== ""
   )
-  // Only check for block children and text descendants when there's no direct text
-  // (short-circuit avoids unnecessary tree traversal)
-  const hasBlockChildren = !hasDirectText && node.children.some(
+  const hasBlockChildren = node.children.some(
     (child) => child.type === "element" && BLOCK_ELEMENTS.has(child.tagName)
   )
-  const hasTextDescendants = !hasDirectText && !hasBlockChildren &&
-    hasTextDescendant(node, shouldSkip)
 
+  // Inline-only transformable node: a single leaf unit. `hasTextDescendant` is
+  // only walked when there's no direct text (short-circuit avoids the traversal).
   if (
     isTransformable(node.tagName) &&
-    (hasDirectText || hasTextDescendants)
+    !hasBlockChildren &&
+    (hasDirectText || hasTextDescendant(node, shouldSkip))
   ) {
-    results.push(node)
+    return [{ kind: "element", element: node }]
+  }
+
+  const units: ProseUnit[] = []
+  if (isTransformable(node.tagName) && hasBlockChildren) {
+    // Mixed content: split each maximal run of inline siblings from the block
+    // children so loose text transforms on its own, then recurse per block.
+    let run: ElementContent[] = []
+    const flushRun = () => {
+      if (runHasProse(run, shouldSkip)) units.push({ kind: "run", container: node, children: run })
+      run = []
+    }
+    for (const child of node.children) {
+      if (child.type === "element" && BLOCK_ELEMENTS.has(child.tagName)) {
+        flushRun()
+        for (const u of collectProseUnitsImpl(child, shouldSkip, depth + 1, alreadyTransformed, isTransformable)) {
+          units.push(u)
+        }
+      } else {
+        run.push(child)
+      }
+    }
+    flushRun()
   } else {
-    // Recurse into children: either the node isn't transformable, has block
-    // children that should be independent, or has no text to transform.
+    // Non-transformable, or transformable but textless: recurse into elements.
     for (const child of node.children) {
       if (child.type === "element") {
-        const childResults = collectProseBlocksImpl(child, shouldSkip, depth + 1, alreadyTransformed, isTransformable)
-        for (const r of childResults) results.push(r)
+        for (const u of collectProseUnitsImpl(child, shouldSkip, depth + 1, alreadyTransformed, isTransformable)) {
+          units.push(u)
+        }
       }
     }
   }
 
-  return results
+  return units
+}
+
+// Flatten a run's inline siblings to their text nodes, seeding the ancestor
+// chain with `container` so `shouldSkipText` sees the same ancestors it would
+// when the whole element is flattened as a leaf.
+function flattenRunTextNodes(
+  container: Element,
+  children: readonly ElementContent[],
+  shouldSkip: ElementPredicate,
+  options: ProseViewOfOptions
+): Text[] {
+  const shouldSkipText = options.shouldSkipText
+  const ancestors: Element[] | null = shouldSkipText ? [container] : null
+  return children.flatMap((child) =>
+    flattenTextNodesImpl(child, shouldSkip, shouldSkipText, ancestors, 1)
+  )
 }
 
 function markDescendants(node: Element, set: Set<Element>, depth: number = 0): void {
@@ -547,17 +600,33 @@ export function rehypePunctilio(
         return SKIP
       }
 
-      // Collect and transform elements with text content
-      const elementsToTransform = collectProseBlocksImpl(node, shouldSkip, 0, transformed, isTransformable)
-      for (const elt of elementsToTransform) {
-        if (!transformed.has(elt)) {
-          const view = proseViewOf(elt, viewOptions)
-          if (view !== null) {
-            transformView(view, transformOptions)
+      // Collect and transform every prose unit in this subtree.
+      const units = collectProseUnitsImpl(node, shouldSkip, 0, transformed, isTransformable)
+      for (const unit of units) {
+        if (unit.kind === "element") {
+          if (!transformed.has(unit.element)) {
+            const view = proseViewOf(unit.element, viewOptions)
+            if (view !== null) {
+              transformView(view, transformOptions)
+            }
+            transformed.add(unit.element)
+            // Mark all descendants as processed since their text was included
+            markDescendants(unit.element, transformed)
           }
-          transformed.add(elt)
-          // Mark all descendants as processed since their text was included
-          markDescendants(elt, transformed)
+        } else {
+          const textNodes = flattenRunTextNodes(unit.container, unit.children, shouldSkip, viewOptions)
+          if (textNodes.length > 0) {
+            transformView(buildProseView(textNodes), transformOptions)
+          }
+          // Mark the container so a later visit doesn't re-collect its runs,
+          // and mark the run's inline-element members' subtrees.
+          transformed.add(unit.container)
+          for (const child of unit.children) {
+            if (child.type === "element") {
+              transformed.add(child)
+              markDescendants(child, transformed)
+            }
+          }
         }
       }
     })

--- a/src/remark.ts
+++ b/src/remark.ts
@@ -6,7 +6,7 @@ import { visitParents } from "unist-util-visit-parents"
 import { transformView } from "./index.js"
 import { TRANSFORM_OPTION_KEYS, type TransformOptions } from "./transform-options.js"
 import { MAX_RECURSION_DEPTH } from "./constants.js"
-import { buildProseView } from "./prose-view.js"
+import { buildProseView, splitAtIndices } from "./prose-view.js"
 import { assertKnownOptionKeys } from "./utils.js"
 
 /**
@@ -20,30 +20,48 @@ const PHRASING_CONTAINERS = new Set(["paragraph", "heading", "tableCell"])
 
 const SKIP_TYPES = new Set(["inlineCode", "html"])
 
-function flattenTextNodes(
-  node: PhrasingContent,
-  depth: number = 0
-): Text[] {
+// Leaf phrasing nodes that render atomic content and carry no transformable
+// text. Between two text nodes, one is a real visual separator, so the
+// flattener records an opaque gap there (mirroring skipped `inlineCode`/`html`).
+const OPAQUE_LEAF_TYPES = new Set([
+  "image", "imageReference", "break", "footnoteReference", "inlineMath",
+])
+
+interface ProseCollector {
+  nodes: Text[]
+  opaqueBefore: Set<number>
+  // An opaque node was dropped since the last emitted text node; the next
+  // emitted node records an opaque gap before it.
+  pendingOpaque: boolean
+}
+
+function collectProse(node: PhrasingContent, depth: number, c: ProseCollector): void {
   /* istanbul ignore if -- defensive: prevents stack overflow from malicious nesting */
   if (depth > MAX_RECURSION_DEPTH) {
-    return []
+    return
   }
 
-  if (SKIP_TYPES.has(node.type)) {
-    return []
+  if (SKIP_TYPES.has(node.type) || OPAQUE_LEAF_TYPES.has(node.type)) {
+    c.pendingOpaque = true
+    return
   }
 
   if (node.type === "text") {
-    return [node]
+    if (c.pendingOpaque && c.nodes.length > 0) c.opaqueBefore.add(c.nodes.length)
+    c.pendingOpaque = false
+    c.nodes.push(node)
+    return
   }
 
   if ("children" in node) {
-    return (node.children as PhrasingContent[]).flatMap((child) =>
-      flattenTextNodes(child, depth + 1)
-    )
+    for (const child of node.children as PhrasingContent[]) collectProse(child, depth + 1, c)
   }
+}
 
-  return []
+function flattenProse(children: readonly PhrasingContent[]): { nodes: Text[]; opaqueBefore: Set<number> } {
+  const c: ProseCollector = { nodes: [], opaqueBefore: new Set(), pendingOpaque: false }
+  for (const child of children) collectProse(child, 0, c)
+  return { nodes: c.nodes, opaqueBefore: c.opaqueBefore }
 }
 
 export function remarkPunctilio(
@@ -75,15 +93,13 @@ export function remarkPunctilio(
         return
       }
 
-      const textNodes = (node.children as PhrasingContent[]).flatMap((child) =>
-        flattenTextNodes(child)
-      )
+      const { nodes, opaqueBefore } = flattenProse(node.children as PhrasingContent[])
 
-      if (textNodes.length === 0) {
-        return
+      // Split at opaque gaps (inline code, images, breaks) so no pass rewrites
+      // text as adjacent across content that visually separates it.
+      for (const group of splitAtIndices(nodes, opaqueBefore)) {
+        transformView(buildProseView(group), pluginOptions)
       }
-
-      transformView(buildProseView(textNodes), pluginOptions)
     })
   }
 }

--- a/src/symbols.ts
+++ b/src/symbols.ts
@@ -102,6 +102,20 @@ function ellipsisFoldDots(view: ProseView): void {
 /** Convert "5x5" to "5×5". Skips hex (0x5F). */
 export const multiplication = makeProsePass(multiplicationOverView)
 
+// A curly single-quote glyph directly after a trailing multiplier means the
+// quotes pass (which runs earlier in the pipeline) already read the `x` as a
+// letter — a word-final elision keyed on the letter. Were this pass to rewrite
+// that `x` to `×`, a re-run would re-read the quote as a closing quote after a
+// symbol and relocate a trailing comma/period, so the transform would never
+// reach a fixed point. Leave such an `x` alone. A straight `'` is not blocked:
+// it only reaches this pass on a standalone `multiplication()` call, where no
+// later quote pass can flip its classification.
+const CURLY_APOSTROPHE_FOLLOWERS = new Set<string>([
+  UNICODE_SYMBOLS.RIGHT_SINGLE_QUOTE,
+  UNICODE_SYMBOLS.LEFT_SINGLE_QUOTE,
+  UNICODE_SYMBOLS.MODIFIER_LETTER_APOSTROPHE,
+])
+
 // After a digit run, either a prime mark (10′) or a length/size unit may
 // attach before the multiplication operator. Allowing both lets dimensions
 // like "5m × 5m", "210mm × 297mm", or "1920px × 1080px" convert, matching
@@ -390,6 +404,7 @@ function multiplicationOverView(view: ProseView): void {
     if (op === "X") continue
     const afterOp = operatorOffset + 1
     const followChar = trailingText[afterOp]
+    if (followChar !== undefined && CURLY_APOSTROPHE_FOLLOWERS.has(followChar)) continue
     if (boundaryCountAt(view, afterOp) <= MAX_BOUNDARY_SEPARATORS && followChar !== undefined && WORD_RE.test(followChar)) continue
     view.replace(operatorOffset, afterOp, MULTIPLICATION)
   }

--- a/src/tests/cli.test.ts
+++ b/src/tests/cli.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs"
+import { existsSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { Readable, Writable } from "node:stream"
@@ -740,6 +740,80 @@ describe("runCli", () => {
     const htmlOut = readFileSync(html, "utf8")
     expect(htmlOut).toContain(`${LDQ}a${RDQ}`)
     expect(htmlOut).toContain('"b"')
+  })
+
+  it("treats a positional with glob metacharacters as a literal when the file exists", async () => {
+    await withTempCwd("punctilio-literal-glob-", async (dir) => {
+      writeFileSync(join(dir, "note[1].md"), '"x"\n')
+      const cap = captureIO()
+      expect(await runCli(["--write", "note[1].md", "--no-nbsp"], cap.io)).toBe(0)
+      expect(readFileSync(join(dir, "note[1].md"), "utf8")).toContain(`${LDQ}x${RDQ}`)
+      expect(cap.stderr()).toBe("")
+    })
+  })
+
+  it("formats an explicitly named file even when .punctilioignore lists it", async () => {
+    await withTempCwd("punctilio-explicit-ignored-", async (dir) => {
+      writeFileSync(join(dir, "b.md"), '"b"\n')
+      writeFileSync(join(dir, ".punctilioignore"), "b.md\n")
+      const cap = captureIO()
+      expect(await runCli(["--write", "b.md", "--no-nbsp"], cap.io)).toBe(0)
+      expect(readFileSync(join(dir, "b.md"), "utf8")).toContain(`${LDQ}b${RDQ}`)
+    })
+  })
+
+  it("warns to stderr when a glob matches no files", async () => {
+    await withTempCwd("punctilio-glob-empty-", async (dir) => {
+      writeFileSync(join(dir, "a.md"), '"a"\n')
+      const cap = captureIO()
+      expect(await runCli(["--write", "*.html", "--no-nbsp"], cap.io)).toBe(0)
+      expect(cap.stderr()).toContain("no files matched: *.html")
+    })
+  })
+
+  it("warns when a glob matches only ignored files", async () => {
+    await withTempCwd("punctilio-glob-all-ignored-", async (dir) => {
+      writeFileSync(join(dir, "a.md"), '"a"\n')
+      writeFileSync(join(dir, ".punctilioignore"), "*.md\n")
+      const cap = captureIO()
+      expect(await runCli(["--write", "*.md", "--no-nbsp"], cap.io)).toBe(0)
+      expect(cap.stderr()).toContain("no files matched")
+      expect(readFileSync(join(dir, "a.md"), "utf8")).toBe('"a"\n')
+    })
+  })
+
+  it("cache invalidates when the resolved file type changes across runs", async () => {
+    await withTempCwd("punctilio-cache-type-", async (dir) => {
+      writeFileSync(join(dir, "file.txt"), '"x"\n')
+      const cacheLocation = join(dir, "cache.json")
+      const readType = () =>
+        (JSON.parse(readFileSync(cacheLocation, "utf8")) as {
+          files: Record<string, { type: string }>
+        }).files["file.txt"].type
+
+      expect(await runCli(
+        ["--write", "file.txt", "--type", "md", "--cache-location", cacheLocation, "--no-nbsp"],
+        captureIO().io,
+      )).toBe(0)
+      expect(readType()).toBe("md")
+
+      // Same content and options, only --type differs: a type-agnostic cache
+      // key would stale-hit and never re-record the entry as html.
+      expect(await runCli(
+        ["--write", "file.txt", "--type", "html", "--cache-location", cacheLocation, "--no-nbsp"],
+        captureIO().io,
+      )).toBe(0)
+      expect(readType()).toBe("html")
+    })
+  })
+
+  it("--write leaves no leftover temp file behind", async () => {
+    await withTempCwd("punctilio-atomic-", async (dir) => {
+      writeFileSync(join(dir, "doc.md"), '"Hello."\n')
+      expect(await runCli(["--write", "doc.md", "--no-nbsp"], captureIO().io)).toBe(0)
+      expect(readFileSync(join(dir, "doc.md"), "utf8")).toContain(`${LDQ}Hello.${RDQ}`)
+      expect(readdirSync(dir).some((name) => name.includes(".tmp"))).toBe(false)
+    })
   })
 
   it("--no-config skips config-file loading", async () => {

--- a/src/tests/html-corpus/corpus.json
+++ b/src/tests/html-corpus/corpus.json
@@ -135,10 +135,10 @@
     {
       "input": "<blockquote><p>\"Outer quote with <blockquote><p>\"inner quote\"</p></blockquote> embedded.\"</p></blockquote>",
       "outputs": {
-        "american": "<blockquote><p>“Outer quote with </p><blockquote><p>“inner quote”</p></blockquote> embedded.”<p></p></blockquote>",
-        "british": "<blockquote><p>“Outer quote with </p><blockquote><p>“inner quote”</p></blockquote> embedded”.<p></p></blockquote>",
-        "german": "<blockquote><p>„Outer quote with </p><blockquote><p>„inner quote“</p></blockquote> embedded“.<p></p></blockquote>",
-        "french": "<blockquote><p>« Outer quote with </p><blockquote><p>« inner quote »</p></blockquote> embedded ».<p></p></blockquote>"
+        "american": "<blockquote><p>“Outer quote with </p><blockquote><p>“inner quote”</p></blockquote> embedded.”<p></p></blockquote>",
+        "british": "<blockquote><p>“Outer quote with </p><blockquote><p>“inner quote”</p></blockquote> embedded”.<p></p></blockquote>",
+        "german": "<blockquote><p>„Outer quote with </p><blockquote><p>„inner quote“</p></blockquote> embedded“.<p></p></blockquote>",
+        "french": "<blockquote><p>« Outer quote with </p><blockquote><p>« inner quote »</p></blockquote> embedded ».<p></p></blockquote>"
       }
     },
     {

--- a/src/tests/quote-classifier.test.ts
+++ b/src/tests/quote-classifier.test.ts
@@ -240,6 +240,10 @@ describe("classifier quirks carried over from v4", () => {
       [`-."`, "german", `-.${LEFT_DOUBLE_QUOTE}`],
       [`x${MODIFIER_LETTER_APOSTROPHE}y`, "german", `x${RIGHT_SINGLE_QUOTE}y`],
       [`"3${MULTIPLICATION}''`, "german", `${DOUBLE_LOW_9_QUOTE}3${MULTIPLICATION}'${RIGHT_SINGLE_QUOTE}`],
+      // An orphan single closer freezes punctuation placement in German:
+      // moving the comma outward would let a re-run read the pair as a quoted
+      // number (`'06,'` → opener) and oscillate, so the comma stays inside.
+      [`'06,'`, "german", `${RIGHT_SINGLE_QUOTE}06,${LEFT_SINGLE_QUOTE}`],
       // French NNBSP padding: adjacent NBSPs absorb into the guillemet
       // render instead of oscillating with collapseSpaces, a space after a
       // classified opener reads as the opener, and the outside mover sees
@@ -300,6 +304,26 @@ describe("fuzz: transform is a fixed point on mixed content", () => {
         )
       }
     }
+  })
+})
+
+describe("transform idempotency edges (heavy-fuzz regressions)", () => {
+  // A trailing multiplier before a curly apostrophe the quotes pass already
+  // produced: rewriting the `x` to `×` would flip the following `${RIGHT_SINGLE_QUOTE}` from an
+  // elision to a closer on re-run and relocate the trailing comma, so the
+  // multiplication pass leaves the letter alone.
+  it("american trailing multiplier before an elided apostrophe: 21707x',,", () => {
+    const first = transform("21707x',,", { punctuationStyle: "american" })
+    expect(first).toBe(`21707x${RIGHT_SINGLE_QUOTE},,`)
+    expect(transform(first, { punctuationStyle: "american" })).toBe(first)
+  })
+
+  // An orphan German single closer keeps the comma inside so the pair is not
+  // re-read as a quoted number (opener + closer) on the next run.
+  it("german decade with a trailing orphan closer: —'06,'", () => {
+    const first = transform(`${EM_DASH}'06,'`, { punctuationStyle: "german" })
+    expect(first).toBe(`${EM_DASH}${RIGHT_SINGLE_QUOTE}06,${LEFT_SINGLE_QUOTE}`)
+    expect(transform(first, { punctuationStyle: "german" })).toBe(first)
   })
 })
 

--- a/src/tests/quote-classifier.test.ts
+++ b/src/tests/quote-classifier.test.ts
@@ -63,6 +63,24 @@ describe("quote classifier role-stream regressions", () => {
     expect(transform(first, { nbsp: false })).toBe(first)
   })
 
+  it.each([
+    ["5'000", `5${RIGHT_SINGLE_QUOTE}000`],
+    ["1'000'000", `1${RIGHT_SINGLE_QUOTE}000${RIGHT_SINGLE_QUOTE}000`],
+    ["CHF 5'000.50", `CHF 5${RIGHT_SINGLE_QUOTE}000.50`],
+    // Not a three-digit group, so still a foot/minute prime.
+    ["5'0", `5${PRIME}0`],
+  ])("Swiss thousands separators curl to apostrophes, not primes: %j", (input, expected) => {
+    const first = transform(input, { nbsp: false })
+    expect(first).toBe(expected)
+    expect(transform(first, { nbsp: false })).toBe(first)
+  })
+
+  it("keeps feet-inches as primes even next to a thousands-grouped number", () => {
+    expect(transform(`5'000 at 6'2" tall`, { nbsp: false })).toBe(
+      `5${RIGHT_SINGLE_QUOTE}000 at 6${PRIME}2${DOUBLE_PRIME} tall`,
+    )
+  })
+
   it("niceQuotes converts prime candidates by default and leaves them with primes: false", () => {
     expect(niceQuotes('5\'10" tall')).toBe(`5${PRIME}10${DOUBLE_PRIME} tall`)
     expect(niceQuotes('5\'10" tall', { primes: false })).toBe(`5'10${RIGHT_DOUBLE_QUOTE} tall`)

--- a/src/tests/rehype.test.ts
+++ b/src/tests/rehype.test.ts
@@ -10,6 +10,7 @@ import {
   getFirstTextNode,
   getTextContent,
   proseViewOf,
+  proseViewsOf,
   rehypePunctilio,
   type RehypePunctilioOptions,
 } from "../rehype.js"
@@ -196,6 +197,32 @@ describe("rehypePunctilio", () => {
           shouldSkipText: skipInSpan,
         }),
       ).toEqual(`<div><span>only"x"</span><p>${LDQ}para${RDQ}</p></div>`)
+    })
+  })
+
+  describe("opaque inline content is an impassable gap", () => {
+    // Content removed from the flattened text (a skipped element with content,
+    // an image, or other atomic inline node) visually separates its neighbors,
+    // so passes must not treat the surrounding text as adjacent.
+    it.each([
+      ["skipped element blocks multiplication", "<p>5<code>c</code>x 3</p>", "<p>5<code>c</code>x 3</p>"],
+      ["image blocks multiplication", '<p>5<img src="a">x 3</p>', '<p>5<img src="a">x 3</p>'],
+      ["skipped element blocks a numeric range", "<p>1<code>c</code>-5</p>", `<p>1<code>c</code>${UNICODE_SYMBOLS.MINUS}5</p>`],
+      ["two gaps keep three independent segments", '<p>1<img src="a">5<code>c</code>x 3</p>', '<p>1<img src="a">5<code>c</code>x 3</p>'],
+      // An empty skipped element renders nothing, so its neighbors stay adjacent.
+      ["empty skipped element does not block", "<p>5<code></code>x5</p>", `<p>5<code></code>${MULTIPLICATION}5</p>`],
+      // Leading opaque content has no left neighbor, so it never splits.
+      ["leading opaque content does not split", '<p><img src="a">5x5</p>', `<p><img src="a">5${MULTIPLICATION}5</p>`],
+    ])("%s", async (_name, html, expected) => {
+      expect(await processHtml(html, { nbsp: false })).toEqual(expected)
+    })
+
+    it("skipped-text nodes act as an opaque gap between their neighbors", async () => {
+      // The skipped "MID" text separates "5" from "x5", so no × forms across it.
+      const skipMid = (t: Text) => t.value === "MID"
+      expect(
+        await processHtml("<p>5<span>MID</span>x5</p>", { nbsp: false, shouldSkipText: skipMid }),
+      ).toEqual("<p>5<span>MID</span>x5</p>")
     })
   })
 
@@ -400,6 +427,25 @@ describe("rehypePunctilio", () => {
         let deep: Element = h("span", "deep") as Element
         for (let i = 0; i < 1005; i++) deep = h("div", [deep]) as Element
         expect(flattenTextNodes(deep, ignoreNone)).toHaveLength(0)
+      })
+    })
+
+    describe("proseViewsOf", () => {
+      it("returns one view spanning the element when there is no opaque content", () => {
+        const element = h("p", ["hello ", h("em", "world")]) as Element
+        const views = proseViewsOf(element)
+        expect(views).toHaveLength(1)
+        expect(views[0].text).toBe("hello world")
+      })
+
+      it("splits into one view per opaque-delimited segment", () => {
+        const element = h("p", ["1", h("code", "c"), "-5"]) as Element
+        const views = proseViewsOf(element, { shouldSkip: ignoreCode })
+        expect(views.map((v) => v.text)).toEqual(["1", "-5"])
+      })
+
+      it("returns no views for an element with no text", () => {
+        expect(proseViewsOf(h("div", []) as Element)).toEqual([])
       })
     })
 

--- a/src/tests/rehype.test.ts
+++ b/src/tests/rehype.test.ts
@@ -151,6 +151,54 @@ describe("rehypePunctilio", () => {
     })
   })
 
+  describe("loose inline text among block children", () => {
+    // A container with both direct/inline text and block-level children must
+    // transform each maximal inline run independently of the blocks, never
+    // merging the loose text with a block child's text across the boundary.
+    it.each([
+      // Regression: the div's "5" must not pair with the paragraph's "x 3".
+      ["digit not merged with block child", "<div>5<p>x 3</p></div>", "<div>5<p>x 3</p></div>"],
+      // Regression: quotes open/close within their own block, not across it.
+      [
+        "quotes stay within their block",
+        '<div>He said "hi<p>there" she said.</p></div>',
+        `<div>He said ${LDQ}hi<p>there${RDQ} she said.</p></div>`,
+      ],
+      // The loose run spans an inline element; the range dash still converts.
+      [
+        "inline element inside a loose run",
+        "<div>a <em>1</em>-5 done<ul><li>item</li></ul></div>",
+        `<div>a <em>1</em>${EN_DASH}5 done<ul><li>item</li></ul></div>`,
+      ],
+    ])("%s", async (_name, html, expected) => {
+      expect(await processHtml(html, { nbsp: false })).toEqual(expected)
+    })
+
+    it("applies shouldSkipText within a loose run, honoring the container ancestor", async () => {
+      const skipInSpan = (_t: Text, ancestors: readonly Element[]) =>
+        ancestors.some((a) => a.tagName === "span")
+      // The loose text transforms (ancestors = [div]); the span's text is
+      // skipped (ancestors = [div, span]).
+      expect(
+        await processHtml('<div>loose "text" <span>keep"x"</span><p>"para"</p></div>', {
+          nbsp: false,
+          shouldSkipText: skipInSpan,
+        }),
+      ).toEqual(`<div>loose ${LDQ}text${RDQ} <span>keep"x"</span><p>${LDQ}para${RDQ}</p></div>`)
+    })
+
+    it("leaves a loose run untouched when shouldSkipText excludes all its text", async () => {
+      const skipInSpan = (_t: Text, ancestors: readonly Element[]) =>
+        ancestors.some((a) => a.tagName === "span")
+      expect(
+        await processHtml('<div><span>only"x"</span><p>"para"</p></div>', {
+          nbsp: false,
+          shouldSkipText: skipInSpan,
+        }),
+      ).toEqual(`<div><span>only"x"</span><p>${LDQ}para${RDQ}</p></div>`)
+    })
+  })
+
   describe("dashes across element boundaries", () => {
     it.each([
       ["multi-segment number preserved", "<p>1-<em>2</em>-3</p>", "<p>1-<em>2</em>-3</p>"],
@@ -641,6 +689,23 @@ describe("rehypePunctilio", () => {
         const result = collectProseBlocks(tree)
         expect(result).toHaveLength(2)
         expect(result.map((b) => b.tagName)).toEqual(["p", "p"])
+      })
+
+      it("returns only the block children, not loose inline text, for mixed content", () => {
+        // <div>loose<p>Hello</p></div> — the loose "loose" text is a run unit
+        // handled by the plugin, so collectProseBlocks lists only the <p>.
+        const tree: Element = {
+          type: "element",
+          tagName: "div",
+          properties: {},
+          children: [
+            { type: "text", value: "loose" },
+            h("p", "Hello") as ElementContent,
+          ],
+        }
+        const result = collectProseBlocks(tree)
+        expect(result).toHaveLength(1)
+        expect(result[0].tagName).toBe("p")
       })
 
       it("collects inline-only div as single unit", () => {

--- a/src/tests/remark.test.ts
+++ b/src/tests/remark.test.ts
@@ -13,6 +13,7 @@ const {
   EN_DASH,
   ELLIPSIS,
   MULTIPLICATION,
+  MINUS,
   NOT_EQUAL,
   COPYRIGHT,
   NBSP,
@@ -113,6 +114,19 @@ describe("remarkPunctilio", () => {
     it("transforms text alongside inline code", async () => {
       expect(await processMarkdown('`code` "Hello"', { nbsp: false }))
         .toEqual(`\`code\` ${LDQ}Hello${RDQ}`)
+    })
+  })
+
+  describe("opaque inline content is an impassable gap", () => {
+    // Inline code and images visually separate their neighbors, so a pass must
+    // not treat the surrounding text as adjacent across them.
+    it.each([
+      ["inline code blocks multiplication", "5`c`x 3", "5`c`x 3"],
+      ["inline code blocks a numeric range", "1`c`-5", `1\`c\`${MINUS}5`],
+      ["inline code blocks an attached multiplier", "5`c`x5", "5`c`x5"],
+      ["image blocks a numeric range", "1![x](y)-5", `1![x](y)${MINUS}5`],
+    ])("%s", async (_name, input, expected) => {
+      expect(await processMarkdown(input, { nbsp: false })).toEqual(expected)
     })
   })
 

--- a/src/tests/symbols.test.ts
+++ b/src/tests/symbols.test.ts
@@ -75,6 +75,10 @@ describe("multiplication", () => {
     // Test trailing multiplier before punctuation (word boundary cases)
     ['2x"', `2${UNICODE_SYMBOLS.MULTIPLICATION}"`],
     ["2x'", `2${UNICODE_SYMBOLS.MULTIPLICATION}'`],
+    // A curly apostrophe already produced by the quotes pass means that pass
+    // read the `x` as a word-final elision; converting it here would let a
+    // re-run relocate a trailing comma, so leave the `x` alone.
+    [`2x${UNICODE_SYMBOLS.RIGHT_SINGLE_QUOTE}`, `2x${UNICODE_SYMBOLS.RIGHT_SINGLE_QUOTE}`],
     ["2x.", `2${UNICODE_SYMBOLS.MULTIPLICATION}.`],
     ["2x,", `2${UNICODE_SYMBOLS.MULTIPLICATION},`],
     ["2x!", `2${UNICODE_SYMBOLS.MULTIPLICATION}!`],


### PR DESCRIPTION
This is the focused follow-up PR promised in #249, which deferred five findings as "real but needing their own design/PR." Each is reproduced against the built library before and after the fix; the full suite (2484 tests, 100% branch coverage) is green, `eslint` is clean, and heavy fuzzing at the CI seed (`FUZZ_SEED=0 FUZZ_RUNS=25000`) passes. One commit per finding.

## 1. Opaque inline content breaks adjacency (highest severity)

When dropped inline content — inline `code`/`inlineCode`, an image/`<br>`, or a skipped element with content — sits *between* two text nodes, the flatten layer removed it and the survivors became falsely adjacent across a single soft boundary the multiplication/dash guards tolerate: `5<code>c</code>x 3` → `5<code>c</code> × 3`, and `1<img>-5` → `1<img>–5`.

Fix: the flattener now records an `opaqueBefore` set marking each text node that follows removed opaque content, and the transform **splits the node list into independent views at those gaps** (`splitAtIndices`) so no pass ever sees text as adjacent across a visual separator. Transparent inline elements (`em`, `span`) still share one view, so genuine adjacency (`5<em>x</em>3` → `5×3`) is preserved. Applied symmetrically in `rehype.ts` (void/replaced tags + skipped elements) and `remark.ts` (`image`, `break`, `footnoteReference`, `inlineMath`, …).

## 2. Element with both direct text and block children merges across the block boundary

`collectProseBlocks` paired an element's own loose text with its block children's text: `<div>5<p>x 3</p></div>` produced `5 × 3` across the `<div>`/`<p>` boundary. The collector now splits an element's inline run from its block children into separate `ProseUnit`s, so the loose `5` is transformed as its own block-adjacent run and never merges into the paragraph.

*Corpus:* one nested-blockquote entry in `html-corpus/corpus.json` was regenerated. The visible text is unchanged; the only difference is an invisible widow NBSP the inner block now receives on its own — the correct consequence of treating the inner block independently.

## 3. Swiss-German thousands separator

`5'000` primed to `5′000`. A digit-grouped apostrophe (`\d{1,3}('\d{3})+`) is now curled to `’` instead, so `5'000` → `5’000` and `1'000'000` → `1’000’000`, while feet-inches (`5'10"`) and non-grouped numbers (`5'0`) still take primes. The `’` form is already an idempotent fixed point, so re-runs are stable.

## 4. Pre-existing idempotency edges under heavy fuzzing

Two edges that oscillated only under `FUZZ_RUNS=25000` (present on `main` before #249):

- **American `21707x',,`** — the multiplication pass rewrote the trailing `x` to `×` *after* the quotes pass had classified the following `’` as an elision keyed on the letter; the re-run then re-read `’` as a closer after a symbol and relocated the comma. The multiplication pass now leaves an `x` before a curly apostrophe alone (straight `'` is still converted, since it only reaches the pass on standalone `multiplication()` calls where nothing can reclassify it later).
- **German `)—'06,'`** — German re-derives its rendered single-quote glyphs back to straight quotes by position each run, so placement moving the comma outside the orphan closer let a re-run read `'06'` as a quoted number and reopen the leading quote. The existing "unmatched-after-letter" placement freeze (renamed `frozenCloser`) now covers **any** orphan closer in German, keeping the comma inside so the pair round-trips.

Both are pinned by transform-level regression tests. Note: heavier fuzzing at other seeds/run counts still surfaces a **separate, pre-existing** oscillation class — the dashes pass and the multiplication pass disagree about `Nx` before vs. after `x`→`×` (e.g. `;3-1-29x`), confirmed identical on the pre-#249 base. That is a distinct dash/symbol ordering issue outside these five findings and is left for its own change.

## 5. CLI robustness

- Literal filenames containing glob metacharacters are treated as literal paths when they exist (no longer silently globbed).
- Explicitly-named files bypass `.punctilioignore`; only glob-expanded files are filtered.
- A zero-match glob now warns on stderr instead of exiting 0 silently.
- `--type` is part of the cache key, so a hit can't cross file types.
- In-place `--write` is atomic (temp file + rename).

## Verification

- `pnpm build`, `pnpm lint`, and the full suite (2484 tests, 100% branch coverage) pass.
- `FUZZ_SEED=0 FUZZ_RUNS=25000` fuzz is green; each finding has direct before/after checks and regression tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016fapkP23hoxymPyrqWrSB4

---
_Generated by [Claude Code](https://claude.ai/code/session_016fapkP23hoxymPyrqWrSB4)_