### PR TITLE
ci: use TEMPLATE_SYNC_ORG variable for template repo owner

### DIFF
--- a/.github/workflows/phone-home.yaml
+++ b/.github/workflows/phone-home.yaml
@@ -9,7 +9,7 @@ on:
     types: [closed]
 
 env:
-  TEMPLATE_REPO: "alexander-turner/claude-automation-template"
+  TEMPLATE_REPO: "${{ vars.TEMPLATE_SYNC_ORG || 'alexander-turner' }}/claude-automation-template"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}

--- a/.github/workflows/template-sync.yaml
+++ b/.github/workflows/template-sync.yaml
@@ -39,7 +39,7 @@ on:
     - cron: "0 9 * * 1"
 
 env:
-  TEMPLATE_REPO: "alexander-turner/claude-automation-template"
+  TEMPLATE_REPO: "${{ vars.TEMPLATE_SYNC_ORG || 'alexander-turner' }}/claude-automation-template"
   # Whole directories of core automation files that are always template-owned.
   # Every file under these paths propagates to downstream consumers; new files
   # added to the template auto-sync without anyone having to edit this list.


### PR DESCRIPTION
Replace the hardcoded `alexander-turner` org in `TEMPLATE_REPO` with `${{ vars.TEMPLATE_SYNC_ORG || 'alexander-turner' }}` in the template-sync and phone-home workflows.

This lets a fork in another org redirect template-sync / phone-home by setting a single `TEMPLATE_SYNC_ORG` repo/org variable, instead of editing every workflow. Behavior is unchanged when the variable is unset (the `|| 'alexander-turner'` fallback preserves the current upstream target).

---
_Generated by [Claude Code](https://claude.ai/code/session_016PEfoYSAEkJjCoa5uU2VSW)_