### PR TITLE
fix(release): repoint repository URLs to the publishing owner for npm provenance

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,7 +2,7 @@
 
 ## Reporting a vulnerability
 
-Please report vulnerabilities privately via [GitHub Security Advisories](https://github.com/alexander-turner/punctilio/security/advisories/new) on `alexander-turner/punctilio`. **Do not open a public issue** for security reports.
+Please report vulnerabilities privately via [GitHub Security Advisories](https://github.com/AlexanderMattTurner/punctilio/security/advisories/new) on `AlexanderMattTurner/punctilio`. **Do not open a public issue** for security reports.
 
 You should receive a response within a few days. Please include a minimal reproduction where possible—for this library, that usually means an input string and the options that trigger the problem (e.g. a ReDoS-suspect pattern).
 

--- a/package.json
+++ b/package.json
@@ -81,12 +81,12 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/alexander-turner/punctilio.git"
+    "url": "git+https://github.com/AlexanderMattTurner/punctilio.git"
   },
   "bugs": {
-    "url": "https://github.com/alexander-turner/punctilio/issues"
+    "url": "https://github.com/AlexanderMattTurner/punctilio/issues"
   },
-  "homepage": "https://github.com/alexander-turner/punctilio#readme",
+  "homepage": "https://github.com/AlexanderMattTurner/punctilio#readme",
   "engines": {
     "node": ">=20.0.0"
   },


### PR DESCRIPTION
## Problem

Every release since the GitHub account was renamed `alexander-turner` → `AlexanderMattTurner` fails at `pnpm publish --provenance` with:

```
npm error 422 ... Error verifying sigstore provenance bundle: Failed to validate repository information:
package.json: "repository.url" is "git+https://github.com/alexander-turner/punctilio.git",
expected to match "https://github.com/AlexanderMattTurner/punctilio" from provenance
```

npm mints the provenance attestation from `GITHUB_REPOSITORY` (now `AlexanderMattTurner/punctilio`) and does an **exact-string** match against `package.json`'s `repository.url`. Because that field still names the old owner, the registry rejects the upload. The package is stuck: npm `latest` is `5.0.10` while the `5.1.0` publish keeps failing.

## Fix

Repoint the three self-referential GitHub URLs in `package.json` to the publishing owner:

- `repository.url` → `git+https://github.com/AlexanderMattTurner/punctilio.git` (the provenance-checked one)
- `bugs.url` → `https://github.com/AlexanderMattTurner/punctilio/issues`
- `homepage` → `https://github.com/AlexanderMattTurner/punctilio#readme`

Also update `SECURITY.md`'s advisory link and the `alexander-turner/punctilio` mention to `AlexanderMattTurner/punctilio`, so security reports land on the live repo.

This unblocks `pnpm publish --provenance` — `repository.url` will now match the provenance-minted owner and the E422 clears.

## Scope

Minimal and provenance-focused. README badges and any cosmetic `alexander-turner` references are left alone — GitHub redirects the old owner, so those still resolve; only npm provenance does an exact-string comparison. No test or runtime constant asserts these `package.json` fields (the `pin-readme-rev` tests use their own README fixture; `ISSUES_URL` in `src/constants.ts` is not compared against `package.json`), so nothing else needed updating and CI stays green.


---
_Generated by [Claude Code](https://claude.ai/code/session_01AGE731B9SzBXvHC59CnGEk)_