### PR TITLE
fix: permit same-offset pure insertions with opposite bind

### DIFF
--- a/src/prose-view.ts
+++ b/src/prose-view.ts
@@ -1,93 +1,107 @@
 export interface ProseNode {
-  value: string
+  value: string;
 }
 
 export interface ProseView {
   /** Concatenation of the nodes' values. No markers, ever. */
-  readonly text: string
+  readonly text: string;
   /** Offsets in `text` where one source node ends and the next begins (interior boundaries only; length = nodes.length - 1; may contain duplicates when nodes are empty). */
-  readonly boundaries: readonly number[]
+  readonly boundaries: readonly number[];
   /** True iff a node edge falls at exactly this offset. O(log n) binary search. */
-  hasBoundary(offset: number): boolean
+  hasBoundary(offset: number): boolean;
   /** Queue an edit replacing [start, end) with `text`. Edits must not overlap; enforced at commit. */
-  replace(start: number, end: number, text: string, opts?: { bind?: "left" | "right" }): void
+  replace(
+    start: number,
+    end: number,
+    text: string,
+    opts?: { bind?: "left" | "right" },
+  ): void;
   /** Apply queued edits back onto the source nodes (mutating their `value`s), then recompute `text`/`boundaries`. The view supports arbitrarily many queue/commit cycles. */
-  commit(): void
+  commit(): void;
 }
 
 interface QueuedEdit {
-  start: number
-  end: number
-  text: string
-  bind: "left" | "right"
+  start: number;
+  end: number;
+  text: string;
+  bind: "left" | "right";
 }
 
 /** True iff the offset falls between a high surrogate and its low surrogate. */
 function splitsSurrogatePair(text: string, offset: number): boolean {
-  if (offset <= 0 || offset >= text.length) return false
-  const high = text.charCodeAt(offset - 1)
-  const low = text.charCodeAt(offset)
-  return high >= 0xd800 && high <= 0xdbff && low >= 0xdc00 && low <= 0xdfff
+  if (offset <= 0 || offset >= text.length) return false;
+  const high = text.charCodeAt(offset - 1);
+  const low = text.charCodeAt(offset);
+  return high >= 0xd800 && high <= 0xdbff && low >= 0xdc00 && low <= 0xdfff;
 }
 
 class ProseViewImpl implements ProseView {
-  private readonly nodes: ProseNode[]
-  private cachedText: string
-  private cachedBoundaries: number[]
-  private edits: QueuedEdit[] = []
+  private readonly nodes: ProseNode[];
+  private cachedText: string;
+  private cachedBoundaries: number[];
+  private edits: QueuedEdit[] = [];
 
   constructor(nodes: ProseNode[]) {
-    this.nodes = nodes
-    this.cachedText = ""
-    this.cachedBoundaries = []
-    this.refresh()
+    this.nodes = nodes;
+    this.cachedText = "";
+    this.cachedBoundaries = [];
+    this.refresh();
   }
 
   get text(): string {
-    return this.cachedText
+    return this.cachedText;
   }
 
   get boundaries(): readonly number[] {
-    return this.cachedBoundaries
+    return this.cachedBoundaries;
   }
 
   /** Recompute `text` and `boundaries` from the current node values. */
   private refresh(): void {
-    let text = ""
-    const boundaries: number[] = []
+    let text = "";
+    const boundaries: number[] = [];
     this.nodes.forEach((node, index) => {
-      text += node.value
+      text += node.value;
       if (index < this.nodes.length - 1) {
-        boundaries.push(text.length)
+        boundaries.push(text.length);
       }
-    })
-    this.cachedText = text
-    this.cachedBoundaries = boundaries
+    });
+    this.cachedText = text;
+    this.cachedBoundaries = boundaries;
   }
 
   hasBoundary(offset: number): boolean {
-    const boundaries = this.cachedBoundaries
-    const first = lowerBound(boundaries, offset)
-    return first < boundaries.length && boundaries[first] === offset
+    const boundaries = this.cachedBoundaries;
+    const first = lowerBound(boundaries, offset);
+    return first < boundaries.length && boundaries[first] === offset;
   }
 
-  replace(start: number, end: number, text: string, opts?: { bind?: "left" | "right" }): void {
+  replace(
+    start: number,
+    end: number,
+    text: string,
+    opts?: { bind?: "left" | "right" },
+  ): void {
     if (!Number.isInteger(start) || !Number.isInteger(end)) {
-      throw new Error(`replace() offsets must be integers, got start=${start}, end=${end}.`)
+      throw new Error(
+        `replace() offsets must be integers, got start=${start}, end=${end}.`,
+      );
     }
     if (start < 0 || start > end || end > this.cachedText.length) {
       throw new Error(
         `replace() requires 0 <= start <= end <= text.length (${this.cachedText.length}), ` +
-        `got start=${start}, end=${end}.`
-      )
+          `got start=${start}, end=${end}.`,
+      );
     }
     if (splitsSurrogatePair(this.cachedText, start)) {
-      throw new Error(`replace() start=${start} splits a UTF-16 surrogate pair.`)
+      throw new Error(
+        `replace() start=${start} splits a UTF-16 surrogate pair.`,
+      );
     }
     if (splitsSurrogatePair(this.cachedText, end)) {
-      throw new Error(`replace() end=${end} splits a UTF-16 surrogate pair.`)
+      throw new Error(`replace() end=${end} splits a UTF-16 surrogate pair.`);
     }
-    this.edits.push({ start, end, text, bind: opts?.bind ?? "left" })
+    this.edits.push({ start, end, text, bind: opts?.bind ?? "left" });
   }
 
   /**
@@ -95,8 +109,12 @@ class ProseViewImpl implements ProseView {
    * tie-breaking shorter spans first so a zero-length edit sorts before a
    * spanning edit at the same start. A pure insertion may therefore coexist
    * with a replacement starting at the same offset: the insertion's text lands
-   * before the replaced span's text. Overlapping spans (and two pure
-   * insertions at the same offset) are rejected.
+   * before the replaced span's text. Overlapping spans are rejected, as are two
+   * pure insertions at the same offset that share a `bind` — those would land in
+   * the same node with no defined order. Two same-offset insertions with
+   * opposite `bind` are unambiguous: `bind: "left"` routes to the node ending at
+   * the offset and `bind: "right"` to the node starting there, so they occupy
+   * different nodes (left-bound sorted first).
    *
    * All edits are distributed in a single left-to-right pass that rebuilds
    * each node's value once — per-edit string surgery would be quadratic on
@@ -104,73 +122,86 @@ class ProseViewImpl implements ProseView {
    */
   commit(): void {
     if (this.edits.length === 0) {
-      return
+      return;
     }
 
+    const bindRank = (edit: QueuedEdit): number =>
+      edit.bind === "left" ? 0 : 1;
     const sorted = [...this.edits].sort(
-      (a, b) => a.start - b.start || (a.end - a.start) - (b.end - b.start)
-    )
+      (a, b) =>
+        a.start - b.start ||
+        a.end - a.start - (b.end - b.start) ||
+        bindRank(a) - bindRank(b),
+    );
     for (let i = 1; i < sorted.length; i++) {
-      const prev = sorted[i - 1]
-      const curr = sorted[i]
+      const prev = sorted[i - 1];
+      const curr = sorted[i];
       if (prev.end > curr.start) {
         throw new Error(
-          `Overlapping edits: [${prev.start}, ${prev.end}) and [${curr.start}, ${curr.end}).`
-        )
+          `Overlapping edits: [${prev.start}, ${prev.end}) and [${curr.start}, ${curr.end}).`,
+        );
       }
-      if (prev.end === curr.start && prev.start === prev.end && curr.start === curr.end) {
+      if (
+        prev.end === curr.start &&
+        prev.start === prev.end &&
+        curr.start === curr.end &&
+        prev.bind === curr.bind
+      ) {
         throw new Error(
-          `Two pure insertions at the same offset ${curr.start} are ambiguous; combine them.`
-        )
+          `Two pure insertions at the same offset ${curr.start} with bind "${curr.bind}" are ` +
+            `ambiguous; combine them.`,
+        );
       }
     }
 
     // Node spans in `text` via cumulative lengths.
-    const starts: number[] = []
-    const ends: number[] = []
-    let cursor = 0
+    const starts: number[] = [];
+    const ends: number[] = [];
+    let cursor = 0;
     for (const node of this.nodes) {
-      starts.push(cursor)
-      cursor += node.value.length
-      ends.push(cursor)
+      starts.push(cursor);
+      cursor += node.value.length;
+      ends.push(cursor);
     }
 
-    const text = this.cachedText
-    const parts: string[][] = this.nodes.map(() => [])
+    const text = this.cachedText;
+    const parts: string[][] = this.nodes.map(() => []);
 
     // Rolling copy state: kept text in [0, copiedUpTo) has been distributed.
-    let copiedUpTo = 0
-    let copyNode = 0
+    let copiedUpTo = 0;
+    let copyNode = 0;
     const copyUpTo = (target: number): void => {
       while (copiedUpTo < target) {
-        while (copyNode < this.nodes.length - 1 && ends[copyNode] <= copiedUpTo) copyNode++
-        const sliceEnd = Math.min(target, ends[copyNode])
-        parts[copyNode].push(text.slice(copiedUpTo, sliceEnd))
-        copiedUpTo = sliceEnd
+        while (copyNode < this.nodes.length - 1 && ends[copyNode] <= copiedUpTo)
+          copyNode++;
+        const sliceEnd = Math.min(target, ends[copyNode]);
+        parts[copyNode].push(text.slice(copiedUpTo, sliceEnd));
+        copiedUpTo = sliceEnd;
       }
-    }
+    };
 
     for (const edit of sorted) {
-      copyUpTo(edit.start)
+      copyUpTo(edit.start);
       // Deleted spans are simply never copied; replacement/insertion text
       // lands in the target node, whose parts are filled exactly up to
       // `edit.start` at this point.
       if (edit.text.length > 0) {
-        const targetIndex = edit.end > edit.start
-          ? this.nodeContainingChar(edit.start, ends)
-          : this.targetNodeForInsertion(edit, ends)
-        parts[targetIndex].push(edit.text)
+        const targetIndex =
+          edit.end > edit.start
+            ? this.nodeContainingChar(edit.start, ends)
+            : this.targetNodeForInsertion(edit, ends);
+        parts[targetIndex].push(edit.text);
       }
-      if (edit.end > copiedUpTo) copiedUpTo = edit.end
+      if (edit.end > copiedUpTo) copiedUpTo = edit.end;
     }
-    copyUpTo(text.length)
+    copyUpTo(text.length);
 
     this.nodes.forEach((node, index) => {
-      node.value = parts[index].join("")
-    })
+      node.value = parts[index].join("");
+    });
 
-    this.edits = []
-    this.refresh()
+    this.edits = [];
+    this.refresh();
   }
 
   /**
@@ -179,31 +210,31 @@ class ProseViewImpl implements ProseView {
    * the offset are skipped, matching a first-containing-span linear scan).
    */
   private nodeContainingChar(offset: number, ends: number[]): number {
-    let low = 0
-    let high = ends.length - 1
+    let low = 0;
+    let high = ends.length - 1;
     while (low < high) {
-      const mid = (low + high) >>> 1
+      const mid = (low + high) >>> 1;
       if (ends[mid] <= offset) {
-        low = mid + 1
+        low = mid + 1;
       } else {
-        high = mid
+        high = mid;
       }
     }
-    return low
+    return low;
   }
 
   private targetNodeForInsertion(edit: QueuedEdit, ends: number[]): number {
     if (edit.bind === "left") {
-      if (edit.start === 0) return 0
-      return this.nodeContainingChar(edit.start - 1, ends)
+      if (edit.start === 0) return 0;
+      return this.nodeContainingChar(edit.start - 1, ends);
     }
-    if (edit.start === this.cachedText.length) return this.nodes.length - 1
-    return this.nodeContainingChar(edit.start, ends)
+    if (edit.start === this.cachedText.length) return this.nodes.length - 1;
+    return this.nodeContainingChar(edit.start, ends);
   }
 }
 
 export function buildProseView(nodes: ProseNode[]): ProseView {
-  return new ProseViewImpl(nodes)
+  return new ProseViewImpl(nodes);
 }
 
 /**
@@ -212,27 +243,30 @@ export function buildProseView(nodes: ProseNode[]): ProseView {
  * group; an empty list yields no groups. Used to isolate opaque-delimited
  * segments so a pass never sees text as adjacent across removed content.
  */
-export function splitAtIndices<T>(items: readonly T[], breakBefore: ReadonlySet<number>): T[][] {
+export function splitAtIndices<T>(
+  items: readonly T[],
+  breakBefore: ReadonlySet<number>,
+): T[][] {
   if (breakBefore.size === 0) {
-    return items.length > 0 ? [items.slice()] : []
+    return items.length > 0 ? [items.slice()] : [];
   }
-  const groups: T[][] = []
-  let start = 0
+  const groups: T[][] = [];
+  let start = 0;
   for (let i = 1; i < items.length; i++) {
     if (breakBefore.has(i)) {
-      groups.push(items.slice(start, i))
-      start = i
+      groups.push(items.slice(start, i));
+      start = i;
     }
   }
-  groups.push(items.slice(start))
-  return groups
+  groups.push(items.slice(start));
+  return groups;
 }
 
 export interface ReplaceAllOptions {
   /** Opt-in: allow a match that contains an interior node boundary. Default: such matches are skipped. */
-  allowBoundaries?: (match: RegExpExecArray, view: ProseView) => boolean
+  allowBoundaries?: (match: RegExpExecArray, view: ProseView) => boolean;
   /** For pure-insertion edits produced by the replacer (rare), bind side. */
-  bind?: "left" | "right"
+  bind?: "left" | "right";
 }
 
 /**
@@ -241,33 +275,44 @@ export interface ReplaceAllOptions {
  * linear scan here would make inline-element-heavy views O(text × nodes).
  */
 function lowerBound(values: readonly number[], target: number): number {
-  let low = 0
-  let high = values.length
+  let low = 0;
+  let high = values.length;
   while (low < high) {
-    const mid = (low + high) >>> 1
-    if (values[mid] < target) low = mid + 1
-    else high = mid
+    const mid = (low + high) >>> 1;
+    if (values[mid] < target) low = mid + 1;
+    else high = mid;
   }
-  return low
+  return low;
 }
 
 /** True iff some interior boundary falls strictly inside the match span. */
-function matchContainsBoundary(match: RegExpExecArray, view: ProseView): boolean {
-  return firstInteriorBoundary(view, match.index, match.index + match[0].length) >= 0
+function matchContainsBoundary(
+  match: RegExpExecArray,
+  view: ProseView,
+): boolean {
+  return (
+    firstInteriorBoundary(view, match.index, match.index + match[0].length) >= 0
+  );
 }
 
 /** Smallest node boundary strictly inside (start, end), or -1 when none. */
-export function firstInteriorBoundary(view: ProseView, start: number, end: number): number {
-  const boundaries = view.boundaries
-  const first = lowerBound(boundaries, start + 1)
-  return first < boundaries.length && boundaries[first] < end ? boundaries[first] : -1
+export function firstInteriorBoundary(
+  view: ProseView,
+  start: number,
+  end: number,
+): number {
+  const boundaries = view.boundaries;
+  const first = lowerBound(boundaries, start + 1);
+  return first < boundaries.length && boundaries[first] < end
+    ? boundaries[first]
+    : -1;
 }
 
 /** Largest node boundary strictly less than `offset`, or -1 when none. O(log n). */
 export function lastBoundaryBefore(view: ProseView, offset: number): number {
-  const boundaries = view.boundaries
-  const first = lowerBound(boundaries, offset)
-  return first > 0 ? boundaries[first - 1] : -1
+  const boundaries = view.boundaries;
+  const first = lowerBound(boundaries, offset);
+  return first > 0 ? boundaries[first - 1] : -1;
 }
 
 /**
@@ -282,23 +327,27 @@ export function interiorBoundariesWithin(
   end: number,
   allowedSlots: readonly number[],
 ): boolean {
-  const boundaries = view.boundaries
-  for (let i = lowerBound(boundaries, start + 1); i < boundaries.length && boundaries[i] < end; i++) {
-    if (!allowedSlots.includes(boundaries[i])) return false
+  const boundaries = view.boundaries;
+  for (
+    let i = lowerBound(boundaries, start + 1);
+    i < boundaries.length && boundaries[i] < end;
+    i++
+  ) {
+    if (!allowedSlots.includes(boundaries[i])) return false;
   }
-  return true
+  return true;
 }
 
 /** Count of node boundaries that fall at exactly `offset` (empty nodes stack). */
 export function boundaryCountAt(view: ProseView, offset: number): number {
-  const boundaries = view.boundaries
-  let i = lowerBound(boundaries, offset)
-  let count = 0
+  const boundaries = view.boundaries;
+  let i = lowerBound(boundaries, offset);
+  let count = 0;
   while (i < boundaries.length && boundaries[i] === offset) {
-    count++
-    i++
+    count++;
+    i++;
   }
-  return count
+  return count;
 }
 
 /**
@@ -306,8 +355,11 @@ export function boundaryCountAt(view: ProseView, offset: number): number {
  * position exceeds the single-boundary tolerance the passes allow in an
  * editing slot.
  */
-export function exceedsSingleBoundary(view: ProseView, offset: number): boolean {
-  return boundaryCountAt(view, offset) > 1
+export function exceedsSingleBoundary(
+  view: ProseView,
+  offset: number,
+): boolean {
+  return boundaryCountAt(view, offset) > 1;
 }
 
 export function replaceAllInView(
@@ -317,30 +369,37 @@ export function replaceAllInView(
   options?: ReplaceAllOptions,
 ): void {
   if (!regex.global) {
-    throw new Error("replaceAllInView() requires a regex with the global (g) flag.")
+    throw new Error(
+      "replaceAllInView() requires a regex with the global (g) flag.",
+    );
   }
 
-  const allowBoundaries = options?.allowBoundaries
-  const bind = options?.bind
-  const text = view.text
-  regex.lastIndex = 0
+  const allowBoundaries = options?.allowBoundaries;
+  const bind = options?.bind;
+  const text = view.text;
+  regex.lastIndex = 0;
 
-  let match: RegExpExecArray | null
+  let match: RegExpExecArray | null;
   while ((match = regex.exec(text)) !== null) {
     if (match[0].length === 0) {
-      regex.lastIndex += 1
+      regex.lastIndex += 1;
     }
 
     if (matchContainsBoundary(match, view) && !allowBoundaries?.(match, view)) {
-      continue
+      continue;
     }
 
-    const replacement = replacer(match, view)
+    const replacement = replacer(match, view);
     if (replacement === null) {
-      continue
+      continue;
     }
 
-    view.replace(match.index, match.index + match[0].length, replacement, bind ? { bind } : undefined)
+    view.replace(
+      match.index,
+      match.index + match[0].length,
+      replacement,
+      bind ? { bind } : undefined,
+    );
   }
 }
 
@@ -348,12 +407,15 @@ export function replaceAllInView(
  * String↔view bridge: builds a single-node ProseView over `text`, runs `run`
  * against it, commits any queued edits, and returns the resulting text.
  */
-export function withProseView(text: string, run: (view: ProseView) => void): string {
-  const node: ProseNode = { value: text }
-  const view = buildProseView([node])
-  run(view)
-  view.commit()
-  return node.value
+export function withProseView(
+  text: string,
+  run: (view: ProseView) => void,
+): string {
+  const node: ProseNode = { value: text };
+  const view = buildProseView([node]);
+  run(view);
+  view.commit();
+  return node.value;
 }
 
 /**
@@ -362,9 +424,9 @@ export function withProseView(text: string, run: (view: ProseView) => void): str
  * edits committed onto it in place.
  */
 export type ProsePass = {
-  (input: string): string
-  (input: ProseView): void
-}
+  (input: string): string;
+  (input: ProseView): void;
+};
 
 export interface DefinePassOptions {
   /**
@@ -377,64 +439,78 @@ export interface DefinePassOptions {
    * - predicate: forwarded as `allowBoundaries` to {@link replaceAllInView};
    *   return `true` to allow that particular boundary-spanning match.
    */
-  boundaries?: "skip" | "allow" | ((match: RegExpExecArray, view: ProseView) => boolean)
+  boundaries?:
+    | "skip"
+    | "allow"
+    | ((match: RegExpExecArray, view: ProseView) => boolean);
 }
 
 type ReplacementPart =
   | { kind: "literal"; text: string }
   | { kind: "whole" }
-  | { kind: "indexed"; index: number; fallback?: { index: number; literal: string } }
-  | { kind: "named"; name: string }
+  | {
+      kind: "indexed";
+      index: number;
+      fallback?: { index: number; literal: string };
+    }
+  | { kind: "named"; name: string };
 
 function isAsciiDigit(char: string | undefined): char is string {
-  return char !== undefined && char >= "0" && char <= "9"
+  return char !== undefined && char >= "0" && char <= "9";
 }
 
 /** Parses the `$`-token starting at `dollarIndex`; returns the part and the offset past it. */
-function parseDollarToken(template: string, dollarIndex: number): { part: ReplacementPart; next: number } {
+function parseDollarToken(
+  template: string,
+  dollarIndex: number,
+): { part: ReplacementPart; next: number } {
   const unsupported = (): Error =>
     new Error(
       `Unsupported "$" form in replacement template ${JSON.stringify(template)}; ` +
-      `supported forms are $$, $&, $1-$99, and $<name>.`
-    )
+        `supported forms are $$, $&, $1-$99, and $<name>.`,
+    );
 
-  const next = template[dollarIndex + 1]
+  const next = template[dollarIndex + 1];
   if (next === "$") {
-    return { part: { kind: "literal", text: "$" }, next: dollarIndex + 2 }
+    return { part: { kind: "literal", text: "$" }, next: dollarIndex + 2 };
   }
   if (next === "&") {
-    return { part: { kind: "whole" }, next: dollarIndex + 2 }
+    return { part: { kind: "whole" }, next: dollarIndex + 2 };
   }
   if (isAsciiDigit(next)) {
     const digits = isAsciiDigit(template[dollarIndex + 2])
       ? next + template[dollarIndex + 2]
-      : next
-    const index = parseInt(digits, 10)
+      : next;
+    const index = parseInt(digits, 10);
     // `$12` means group 12 when it exists, otherwise group 1 followed by a
     // literal "2" — matching String.replace. `$0`/`$00` reference nothing.
-    const fallbackIndex = parseInt(digits[0], 10)
-    const fallback = digits.length === 2 && fallbackIndex > 0
-      ? { index: fallbackIndex, literal: digits[1] }
-      : undefined
+    const fallbackIndex = parseInt(digits[0], 10);
+    const fallback =
+      digits.length === 2 && fallbackIndex > 0
+        ? { index: fallbackIndex, literal: digits[1] }
+        : undefined;
     if (index === 0 && fallback === undefined) {
       throw new Error(
         `Unsupported group reference $${digits} in replacement template ` +
-        `${JSON.stringify(template)}; numbered groups start at $1.`
-      )
+          `${JSON.stringify(template)}; numbered groups start at $1.`,
+      );
     }
-    return { part: { kind: "indexed", index, fallback }, next: dollarIndex + 1 + digits.length }
+    return {
+      part: { kind: "indexed", index, fallback },
+      next: dollarIndex + 1 + digits.length,
+    };
   }
   if (next === "<") {
-    const close = template.indexOf(">", dollarIndex + 2)
+    const close = template.indexOf(">", dollarIndex + 2);
     if (close === -1 || close === dollarIndex + 2) {
-      throw unsupported()
+      throw unsupported();
     }
     return {
       part: { kind: "named", name: template.slice(dollarIndex + 2, close) },
       next: close + 1,
-    }
+    };
   }
-  throw unsupported()
+  throw unsupported();
 }
 
 /**
@@ -444,29 +520,29 @@ function parseDollarToken(template: string, dollarIndex: number): { part: Replac
  * `$'`, a bare or malformed `$`) throws rather than silently substituting.
  */
 function parseReplacementTemplate(template: string): ReplacementPart[] {
-  const parts: ReplacementPart[] = []
-  let literalStart = 0
-  let i = 0
+  const parts: ReplacementPart[] = [];
+  let literalStart = 0;
+  let i = 0;
 
   while (i < template.length) {
     if (template[i] !== "$") {
-      i++
-      continue
+      i++;
+      continue;
     }
     if (i > literalStart) {
-      parts.push({ kind: "literal", text: template.slice(literalStart, i) })
+      parts.push({ kind: "literal", text: template.slice(literalStart, i) });
     }
-    const { part, next } = parseDollarToken(template, i)
-    parts.push(part)
-    i = next
-    literalStart = next
+    const { part, next } = parseDollarToken(template, i);
+    parts.push(part);
+    i = next;
+    literalStart = next;
   }
 
   if (template.length > literalStart) {
-    parts.push({ kind: "literal", text: template.slice(literalStart) })
+    parts.push({ kind: "literal", text: template.slice(literalStart) });
   }
 
-  return parts
+  return parts;
 }
 
 /** Renders a numbered group reference, applying the `$12` → `$1` + "2" fallback. */
@@ -475,15 +551,15 @@ function renderIndexedPart(
   match: RegExpExecArray,
 ): string {
   if (part.index < match.length) {
-    return match[part.index] ?? ""
+    return match[part.index] ?? "";
   }
   if (part.fallback && part.fallback.index < match.length) {
-    return (match[part.fallback.index] ?? "") + part.fallback.literal
+    return (match[part.fallback.index] ?? "") + part.fallback.literal;
   }
   throw new Error(
     `Replacement references group $${part.index} but the pattern only has ` +
-    `${match.length - 1} capture group(s).`
-  )
+      `${match.length - 1} capture group(s).`,
+  );
 }
 
 /**
@@ -492,31 +568,33 @@ function renderIndexedPart(
  * throws, while a defined group that simply did not participate in the match
  * substitutes the empty string (as with String.replace).
  */
-function compileReplacementTemplate(template: string): (match: RegExpExecArray) => string {
-  const parts = parseReplacementTemplate(template)
+function compileReplacementTemplate(
+  template: string,
+): (match: RegExpExecArray) => string {
+  const parts = parseReplacementTemplate(template);
   return (match) =>
     parts
       .map((part) => {
         switch (part.kind) {
           case "literal":
-            return part.text
+            return part.text;
           case "whole":
-            return match[0]
+            return match[0];
           case "indexed":
-            return renderIndexedPart(part, match)
+            return renderIndexedPart(part, match);
           case "named": {
-            const groups = match.groups
+            const groups = match.groups;
             if (!groups || !(part.name in groups)) {
               throw new Error(
                 `Replacement references group $<${part.name}> but the pattern ` +
-                `has no capture group named "${part.name}".`
-              )
+                  `has no capture group named "${part.name}".`,
+              );
             }
-            return groups[part.name] ?? ""
+            return groups[part.name] ?? "";
           }
         }
       })
-      .join("")
+      .join("");
 }
 
 /**
@@ -535,38 +613,48 @@ function compileReplacementTemplate(template: string): (match: RegExpExecArray) 
  */
 export function definePass(
   pattern: RegExp,
-  replacement: string | ((match: RegExpExecArray, view: ProseView) => string | null),
+  replacement:
+    | string
+    | ((match: RegExpExecArray, view: ProseView) => string | null),
   options: DefinePassOptions = {},
 ): ProsePass {
   if (!pattern.global) {
-    throw new Error("definePass() requires a pattern with the global (g) flag.")
+    throw new Error(
+      "definePass() requires a pattern with the global (g) flag.",
+    );
   }
 
-  const boundaries = options.boundaries ?? "skip"
-  let allowBoundaries: ReplaceAllOptions["allowBoundaries"]
+  const boundaries = options.boundaries ?? "skip";
+  let allowBoundaries: ReplaceAllOptions["allowBoundaries"];
   if (boundaries === "allow") {
-    allowBoundaries = () => true
+    allowBoundaries = () => true;
   } else if (typeof boundaries === "function") {
-    allowBoundaries = boundaries
+    allowBoundaries = boundaries;
   } else if (boundaries !== "skip") {
     throw new Error(
       `Invalid boundaries option: ${JSON.stringify(boundaries)}. ` +
-      `Must be "skip", "allow", or a predicate.`
-    )
+        `Must be "skip", "allow", or a predicate.`,
+    );
   }
 
-  const replacer = typeof replacement === "string"
-    ? compileReplacementTemplate(replacement)
-    : replacement
+  const replacer =
+    typeof replacement === "string"
+      ? compileReplacementTemplate(replacement)
+      : replacement;
 
-  function pass(input: string): string
-  function pass(input: ProseView): void
+  function pass(input: string): string;
+  function pass(input: ProseView): void;
   function pass(input: string | ProseView): string | void {
     return overInput(input, (view) => {
-      replaceAllInView(view, pattern, replacer, allowBoundaries ? { allowBoundaries } : undefined)
-    })
+      replaceAllInView(
+        view,
+        pattern,
+        replacer,
+        allowBoundaries ? { allowBoundaries } : undefined,
+      );
+    });
   }
-  return pass
+  return pass;
 }
 
 /**
@@ -574,15 +662,27 @@ export function definePass(
  * single-node view and returns the transformed string; a ProseView has the
  * pass's edits queued and committed onto it in place (returns nothing).
  */
-export function overInput(input: string, run: (view: ProseView) => void): string
-export function overInput(input: ProseView, run: (view: ProseView) => void): void
-export function overInput(input: string | ProseView, run: (view: ProseView) => void): string | void
-export function overInput(input: string | ProseView, run: (view: ProseView) => void): string | void {
+export function overInput(
+  input: string,
+  run: (view: ProseView) => void,
+): string;
+export function overInput(
+  input: ProseView,
+  run: (view: ProseView) => void,
+): void;
+export function overInput(
+  input: string | ProseView,
+  run: (view: ProseView) => void,
+): string | void;
+export function overInput(
+  input: string | ProseView,
+  run: (view: ProseView) => void,
+): string | void {
   if (typeof input === "string") {
-    return withProseView(input, run)
+    return withProseView(input, run);
   }
-  run(input)
-  input.commit()
+  run(input);
+  input.commit();
 }
 
 /**
@@ -592,10 +692,10 @@ export function overInput(input: string | ProseView, run: (view: ProseView) => v
  * otherwise repeat.
  */
 export function makeProsePass(run: (view: ProseView) => void): ProsePass {
-  function pass(input: string): string
-  function pass(input: ProseView): void
+  function pass(input: string): string;
+  function pass(input: ProseView): void;
   function pass(input: string | ProseView): string | void {
-    return overInput(input, run)
+    return overInput(input, run);
   }
-  return pass
+  return pass;
 }

--- a/src/tests/prose-view.test.ts
+++ b/src/tests/prose-view.test.ts
@@ -6,10 +6,10 @@ import {
   type ProseView,
   replaceAllInView,
   withProseView,
-} from "../prose-view.js"
+} from "../prose-view.js";
 
 function nodes(...values: string[]): ProseNode[] {
-  return values.map((value) => ({ value }))
+  return values.map((value) => ({ value }));
 }
 
 describe("buildProseView: text and boundaries", () => {
@@ -17,18 +17,23 @@ describe("buildProseView: text and boundaries", () => {
     ["multi-node", ["abc", "de", "f"], "abcdef", [3, 5]],
     ["single node", ["hello"], "hello", []],
     ["empty array", [], "", []],
-    ["empty middle node gives duplicate boundary", ["ab", "", "cd"], "abcd", [2, 2]],
+    [
+      "empty middle node gives duplicate boundary",
+      ["ab", "", "cd"],
+      "abcd",
+      [2, 2],
+    ],
     ["leading empty node", ["", "xy"], "xy", [0]],
     ["trailing empty node", ["xy", ""], "xy", [2]],
   ])("%s", (_desc, values, text, boundaries) => {
-    const view = buildProseView(nodes(...values))
-    expect(view.text).toBe(text)
-    expect(view.boundaries).toEqual(boundaries)
-  })
-})
+    const view = buildProseView(nodes(...values));
+    expect(view.text).toBe(text);
+    expect(view.boundaries).toEqual(boundaries);
+  });
+});
 
 describe("hasBoundary", () => {
-  const view = buildProseView(nodes("abc", "de", "f"))
+  const view = buildProseView(nodes("abc", "de", "f"));
   it.each([
     [0, false],
     [3, true],
@@ -36,199 +41,236 @@ describe("hasBoundary", () => {
     [4, false],
     [6, false],
   ])("offset %i -> %s", (offset, expected) => {
-    expect(view.hasBoundary(offset)).toBe(expected)
-  })
+    expect(view.hasBoundary(offset)).toBe(expected);
+  });
 
   it("single-node view has no boundaries", () => {
-    const single = buildProseView(nodes("hello"))
-    expect(single.hasBoundary(0)).toBe(false)
-    expect(single.hasBoundary(5)).toBe(false)
-  })
-})
+    const single = buildProseView(nodes("hello"));
+    expect(single.hasBoundary(0)).toBe(false);
+    expect(single.hasBoundary(5)).toBe(false);
+  });
+});
 
 /** Independently compute the expected text after applying non-overlapping edits. */
 function applyEdits(
   text: string,
   edits: { start: number; end: number; text: string }[],
 ): string {
-  const sorted = [...edits].sort((a, b) => a.start - b.start)
-  let result = ""
-  let cursor = 0
+  const sorted = [...edits].sort((a, b) => a.start - b.start);
+  let result = "";
+  let cursor = 0;
   for (const edit of sorted) {
-    result += text.slice(cursor, edit.start) + edit.text
-    cursor = edit.end
+    result += text.slice(cursor, edit.start) + edit.text;
+    cursor = edit.end;
   }
-  return result + text.slice(cursor)
+  return result + text.slice(cursor);
 }
 
 describe("replace + commit", () => {
   it("single-node edit", () => {
-    const ns = nodes("hello")
-    const view = buildProseView(ns)
-    view.replace(1, 4, "XYZ")
-    view.commit()
-    expect(ns.map((n) => n.value)).toEqual(["hXYZo"])
-    expect(view.text).toBe("hXYZo")
-  })
+    const ns = nodes("hello");
+    const view = buildProseView(ns);
+    view.replace(1, 4, "XYZ");
+    view.commit();
+    expect(ns.map((n) => n.value)).toEqual(["hXYZo"]);
+    expect(view.text).toBe("hXYZo");
+  });
 
   it("deletion spanning a boundary shrinks both covered nodes, count preserved", () => {
-    const ns = nodes("abc", "def")
-    const view = buildProseView(ns)
-    view.replace(2, 4, "")
-    view.commit()
-    expect(ns.map((n) => n.value)).toEqual(["ab", "ef"])
-    expect(ns.length).toBe(2)
-  })
+    const ns = nodes("abc", "def");
+    const view = buildProseView(ns);
+    view.replace(2, 4, "");
+    view.commit();
+    expect(ns.map((n) => n.value)).toEqual(["ab", "ef"]);
+    expect(ns.length).toBe(2);
+  });
 
   it("replacement spanning boundary lands text in node containing start", () => {
-    const ns = nodes("abc", "def")
-    const view = buildProseView(ns)
-    view.replace(2, 4, "XY")
-    view.commit()
-    expect(ns.map((n) => n.value)).toEqual(["abXY", "ef"])
-    expect(view.text).toBe("abXYef")
-  })
+    const ns = nodes("abc", "def");
+    const view = buildProseView(ns);
+    view.replace(2, 4, "XY");
+    view.commit();
+    expect(ns.map((n) => n.value)).toEqual(["abXY", "ef"]);
+    expect(view.text).toBe("abXYef");
+  });
 
   it("deletion that fully empties a covered node keeps node count", () => {
-    const ns = nodes("ab", "cd", "ef")
-    const view = buildProseView(ns)
-    view.replace(1, 5, "")
-    view.commit()
-    expect(ns.map((n) => n.value)).toEqual(["a", "", "f"])
-    expect(ns.length).toBe(3)
-  })
+    const ns = nodes("ab", "cd", "ef");
+    const view = buildProseView(ns);
+    view.replace(1, 5, "");
+    view.commit();
+    expect(ns.map((n) => n.value)).toEqual(["a", "", "f"]);
+    expect(ns.length).toBe(3);
+  });
 
   it.each([
     ["bind left (default)", undefined, ["abcZ", "def"]],
     ["bind right", "right" as const, ["abc", "Zdef"]],
   ])("pure insertion at boundary: %s", (_desc, bind, expected) => {
-    const ns = nodes("abc", "def")
-    const view = buildProseView(ns)
-    view.replace(3, 3, "Z", bind ? { bind } : undefined)
-    view.commit()
-    expect(ns.map((n) => n.value)).toEqual(expected)
-  })
+    const ns = nodes("abc", "def");
+    const view = buildProseView(ns);
+    view.replace(3, 3, "Z", bind ? { bind } : undefined);
+    view.commit();
+    expect(ns.map((n) => n.value)).toEqual(expected);
+  });
 
   it.each([
-    ["insertion at 0, bind left -> first node", 0, "left" as const, ["Zabc", "def"]],
-    ["insertion at 0, bind right -> first node", 0, "right" as const, ["Zabc", "def"]],
-    ["insertion at length, bind left -> last node", 6, "left" as const, ["abc", "defZ"]],
-    ["insertion at length, bind right -> last node", 6, "right" as const, ["abc", "defZ"]],
+    [
+      "insertion at 0, bind left -> first node",
+      0,
+      "left" as const,
+      ["Zabc", "def"],
+    ],
+    [
+      "insertion at 0, bind right -> first node",
+      0,
+      "right" as const,
+      ["Zabc", "def"],
+    ],
+    [
+      "insertion at length, bind left -> last node",
+      6,
+      "left" as const,
+      ["abc", "defZ"],
+    ],
+    [
+      "insertion at length, bind right -> last node",
+      6,
+      "right" as const,
+      ["abc", "defZ"],
+    ],
   ])("%s", (_desc, offset, bind, expected) => {
-    const ns = nodes("abc", "def")
-    const view = buildProseView(ns)
-    view.replace(offset, offset, "Z", { bind })
-    view.commit()
-    expect(ns.map((n) => n.value)).toEqual(expected)
-  })
+    const ns = nodes("abc", "def");
+    const view = buildProseView(ns);
+    view.replace(offset, offset, "Z", { bind });
+    view.commit();
+    expect(ns.map((n) => n.value)).toEqual(expected);
+  });
 
   it("multiple non-adjacent edits in one commit, queue order != position order", () => {
-    const ns = nodes("abcdef", "ghijkl")
-    const view = buildProseView(ns)
+    const ns = nodes("abcdef", "ghijkl");
+    const view = buildProseView(ns);
     // Queue out of position order.
-    view.replace(8, 10, "Y")
-    view.replace(1, 3, "X")
-    view.commit()
+    view.replace(8, 10, "Y");
+    view.replace(1, 3, "X");
+    view.commit();
     const expected = applyEdits("abcdefghijkl", [
       { start: 8, end: 10, text: "Y" },
       { start: 1, end: 3, text: "X" },
-    ])
-    expect(ns.map((n) => n.value).join("")).toBe(expected)
-  })
+    ]);
+    expect(ns.map((n) => n.value).join("")).toBe(expected);
+  });
 
   it("empty-string replacement is a pure deletion", () => {
-    const ns = nodes("hello")
-    const view = buildProseView(ns)
-    view.replace(0, 2, "")
-    view.commit()
-    expect(ns.map((n) => n.value)).toEqual(["llo"])
-  })
+    const ns = nodes("hello");
+    const view = buildProseView(ns);
+    view.replace(0, 2, "");
+    view.commit();
+    expect(ns.map((n) => n.value)).toEqual(["llo"]);
+  });
 
   it("commit with no edits is a no-op", () => {
-    const ns = nodes("abc", "def")
-    const view = buildProseView(ns)
-    view.commit()
-    expect(ns.map((n) => n.value)).toEqual(["abc", "def"])
-    expect(view.text).toBe("abcdef")
-  })
+    const ns = nodes("abc", "def");
+    const view = buildProseView(ns);
+    view.commit();
+    expect(ns.map((n) => n.value)).toEqual(["abc", "def"]);
+    expect(view.text).toBe("abcdef");
+  });
 
   it("repeated queue/commit cycles", () => {
-    const ns = nodes("abc", "def")
-    const view = buildProseView(ns)
-    view.replace(0, 1, "X")
-    view.commit()
-    expect(view.text).toBe("Xbcdef")
-    view.replace(view.text.length, view.text.length, "!")
-    view.commit()
-    expect(view.text).toBe("Xbcdef!")
-    expect(ns.map((n) => n.value)).toEqual(["Xbc", "def!"])
-  })
+    const ns = nodes("abc", "def");
+    const view = buildProseView(ns);
+    view.replace(0, 1, "X");
+    view.commit();
+    expect(view.text).toBe("Xbcdef");
+    view.replace(view.text.length, view.text.length, "!");
+    view.commit();
+    expect(view.text).toBe("Xbcdef!");
+    expect(ns.map((n) => n.value)).toEqual(["Xbc", "def!"]);
+  });
 
   it("invariant: committed concatenation == old text with edits applied", () => {
-    const ns = nodes("The quick ", "brown fox ", "jumps")
-    const view = buildProseView(ns)
-    const oldText = view.text
+    const ns = nodes("The quick ", "brown fox ", "jumps");
+    const view = buildProseView(ns);
+    const oldText = view.text;
     const edits = [
       { start: 0, end: 3, text: "A" },
       { start: 16, end: 21, text: "" },
       { start: 25, end: 25, text: "!" },
-    ]
-    for (const e of edits) view.replace(e.start, e.end, e.text)
-    view.commit()
-    expect(ns.map((n) => n.value).join("")).toBe(applyEdits(oldText, edits))
-  })
-})
+    ];
+    for (const e of edits) view.replace(e.start, e.end, e.text);
+    view.commit();
+    expect(ns.map((n) => n.value).join("")).toBe(applyEdits(oldText, edits));
+  });
+});
 
 describe("replace assertions", () => {
-  let view: ProseView
+  let view: ProseView;
   beforeEach(() => {
-    view = buildProseView(nodes("abc", "def"))
-  })
+    view = buildProseView(nodes("abc", "def"));
+  });
 
   it.each([
     ["negative start", -1, 2],
     ["start > end", 4, 2],
     ["end > length", 0, 7],
   ])("throws on out-of-range: %s", (_desc, start, end) => {
-    expect(() => view.replace(start, end, "x")).toThrow(/0 <= start <= end/)
-  })
+    expect(() => view.replace(start, end, "x")).toThrow(/0 <= start <= end/);
+  });
 
   it.each([
     ["non-integer start", 1.5, 2],
     ["non-integer end", 1, 2.5],
   ])("throws on %s", (_desc, start, end) => {
-    expect(() => view.replace(start, end, "x")).toThrow(/must be integers/)
-  })
+    expect(() => view.replace(start, end, "x")).toThrow(/must be integers/);
+  });
 
   it.each([
     ["start splits surrogate pair", 1, 3],
     ["end splits surrogate pair", 0, 1],
   ])("throws when %s", (_desc, start, end) => {
     // "\u{1F600}" (emoji) occupies offsets 0-1 as a surrogate pair.
-    const emojiView = buildProseView(nodes("\u{1F600}xx"))
-    expect(() => emojiView.replace(start, end, "y")).toThrow(/surrogate pair/)
-  })
+    const emojiView = buildProseView(nodes("\u{1F600}xx"));
+    expect(() => emojiView.replace(start, end, "y")).toThrow(/surrogate pair/);
+  });
 
   it("rejects overlapping edits at commit", () => {
-    view.replace(0, 3, "X")
-    view.replace(2, 4, "Y")
-    expect(() => view.commit()).toThrow(/Overlapping edits/)
-  })
+    view.replace(0, 3, "X");
+    view.replace(2, 4, "Y");
+    expect(() => view.commit()).toThrow(/Overlapping edits/);
+  });
 
   it("rejects two pure insertions at the same offset", () => {
-    view.replace(2, 2, "X")
-    view.replace(2, 2, "Y")
-    expect(() => view.commit()).toThrow(/ambiguous/)
-  })
+    view.replace(2, 2, "X");
+    view.replace(2, 2, "Y");
+    expect(() => view.commit()).toThrow(/ambiguous/);
+  });
+
+  it("rejects two same-offset pure insertions that share an explicit bind", () => {
+    view.replace(2, 2, "X", { bind: "right" });
+    view.replace(2, 2, "Y", { bind: "right" });
+    expect(() => view.commit()).toThrow(/ambiguous/);
+  });
+
+  it("allows two same-offset pure insertions with opposite bind", () => {
+    // At a node boundary, bind "left" routes into the node ending there and
+    // bind "right" into the node starting there, so the two land in different
+    // nodes with a defined order (left-bound first) — not ambiguous.
+    const v = buildProseView(nodes("ab", "cd"));
+    v.replace(2, 2, "X", { bind: "left" });
+    v.replace(2, 2, "Y", { bind: "right" });
+    v.commit();
+    expect(v.text).toBe("abXYcd");
+  });
 
   it("allows an insertion adjacent to a replacement end", () => {
-    const ns = nodes("abcdef")
-    const v = buildProseView(ns)
-    v.replace(0, 2, "X")
-    v.replace(2, 2, "Y")
-    v.commit()
-    expect(ns[0].value).toBe("XYcdef")
-  })
+    const ns = nodes("abcdef");
+    const v = buildProseView(ns);
+    v.replace(0, 2, "X");
+    v.replace(2, 2, "Y");
+    v.commit();
+    expect(ns[0].value).toBe("XYcdef");
+  });
 
   it.each([
     ["insertion queued first", "insertion-first" as const],
@@ -236,139 +278,146 @@ describe("replace assertions", () => {
   ])(
     "coexisting insertion and replacement at the same start: %s (order-independent, insertion before span)",
     (_desc, order) => {
-      const ns = nodes("abcdef")
-      const v = buildProseView(ns)
+      const ns = nodes("abcdef");
+      const v = buildProseView(ns);
       if (order === "insertion-first") {
-        v.replace(2, 2, "I")
-        v.replace(2, 5, "R")
+        v.replace(2, 2, "I");
+        v.replace(2, 5, "R");
       } else {
-        v.replace(2, 5, "R")
-        v.replace(2, 2, "I")
+        v.replace(2, 5, "R");
+        v.replace(2, 2, "I");
       }
-      v.commit()
-      expect(ns[0].value).toBe("abIRf")
-    }
-  )
-})
+      v.commit();
+      expect(ns[0].value).toBe("abIRf");
+    },
+  );
+});
 
 describe("replaceAllInView", () => {
   it("throws when regex lacks global flag", () => {
-    const view = buildProseView(nodes("aaa"))
-    expect(() => replaceAllInView(view, /a/, () => "b")).toThrow(/global/)
-  })
+    const view = buildProseView(nodes("aaa"));
+    expect(() => replaceAllInView(view, /a/, () => "b")).toThrow(/global/);
+  });
 
   it("replaces all matches and commits via caller", () => {
-    const ns = nodes("a-a-a")
-    const view = buildProseView(ns)
-    replaceAllInView(view, /a/g, () => "X")
-    view.commit()
-    expect(view.text).toBe("X-X-X")
-  })
+    const ns = nodes("a-a-a");
+    const view = buildProseView(ns);
+    replaceAllInView(view, /a/g, () => "X");
+    view.commit();
+    expect(view.text).toBe("X-X-X");
+  });
 
   it("does not commit on its own", () => {
-    const ns = nodes("aaa")
-    const view = buildProseView(ns)
-    replaceAllInView(view, /a/g, () => "X")
+    const ns = nodes("aaa");
+    const view = buildProseView(ns);
+    replaceAllInView(view, /a/g, () => "X");
     // Edits queued but not applied.
-    expect(view.text).toBe("aaa")
-    expect(ns[0].value).toBe("aaa")
-  })
+    expect(view.text).toBe("aaa");
+    expect(ns[0].value).toBe("aaa");
+  });
 
   it("skips matches containing an interior boundary by default", () => {
-    const ns = nodes("foo", "bar")
-    const view = buildProseView(ns)
-    replaceAllInView(view, /oob/g, () => "ZZZ")
-    view.commit()
-    expect(view.text).toBe("foobar")
-  })
+    const ns = nodes("foo", "bar");
+    const view = buildProseView(ns);
+    replaceAllInView(view, /oob/g, () => "ZZZ");
+    view.commit();
+    expect(view.text).toBe("foobar");
+  });
 
   it("allowBoundaries opt-in lets a boundary-spanning match through and receives it", () => {
-    const ns = nodes("foo", "bar")
-    const view = buildProseView(ns)
-    const seen: string[] = []
+    const ns = nodes("foo", "bar");
+    const view = buildProseView(ns);
+    const seen: string[] = [];
     replaceAllInView(
       view,
       /oob/g,
       (m) => {
-        seen.push(m[0])
-        return "ZZZ"
+        seen.push(m[0]);
+        return "ZZZ";
       },
       { allowBoundaries: () => true },
-    )
-    view.commit()
-    expect(seen).toEqual(["oob"])
-    expect(view.text).toBe("fZZZar")
-  })
+    );
+    view.commit();
+    expect(seen).toEqual(["oob"]);
+    expect(view.text).toBe("fZZZar");
+  });
 
   it("replacer returning null leaves the match untouched", () => {
-    const ns = nodes("a1b2")
-    const view = buildProseView(ns)
-    replaceAllInView(view, /\d/g, (m) => (m[0] === "1" ? null : "X"))
-    view.commit()
-    expect(view.text).toBe("a1bX")
-  })
+    const ns = nodes("a1b2");
+    const view = buildProseView(ns);
+    replaceAllInView(view, /\d/g, (m) => (m[0] === "1" ? null : "X"));
+    view.commit();
+    expect(view.text).toBe("a1bX");
+  });
 
   it("terminates on zero-length matches", () => {
-    const ns = nodes("abc")
-    const view = buildProseView(ns)
-    const positions: number[] = []
+    const ns = nodes("abc");
+    const view = buildProseView(ns);
+    const positions: number[] = [];
     replaceAllInView(view, /(?=[\s\S])/g, (m) => {
-      positions.push(m.index)
-      return null
-    })
+      positions.push(m.index);
+      return null;
+    });
     // One zero-length lookahead match before each character; terminates.
-    expect(positions).toEqual([0, 1, 2])
-  })
+    expect(positions).toEqual([0, 1, 2]);
+  });
 
   it("passes bind option through for pure-insertion edits", () => {
-    const ns = nodes("ab", "cd")
-    const view = buildProseView(ns)
+    const ns = nodes("ab", "cd");
+    const view = buildProseView(ns);
     // Match the empty string right at the boundary only.
-    replaceAllInView(view, /(?<=b)(?=c)/g, () => "Z", { bind: "right" })
-    view.commit()
-    expect(ns.map((n) => n.value)).toEqual(["ab", "Zcd"])
-  })
-})
+    replaceAllInView(view, /(?<=b)(?=c)/g, () => "Z", { bind: "right" });
+    view.commit();
+    expect(ns.map((n) => n.value)).toEqual(["ab", "Zcd"]);
+  });
+});
 
 describe("withProseView", () => {
   it("runs the pass over a single-node view and returns the result", () => {
-    expect(withProseView("hello", (view) => view.replace(0, 1, "H"))).toBe("Hello")
-  })
+    expect(withProseView("hello", (view) => view.replace(0, 1, "H"))).toBe(
+      "Hello",
+    );
+  });
 
   it("commits edits the pass left queued", () => {
     const result = withProseView("abc", (view) => {
-      view.replace(3, 3, "!")
-    })
-    expect(result).toBe("abc!")
-  })
-})
+      view.replace(3, 3, "!");
+    });
+    expect(result).toBe("abc!");
+  });
+});
 
 describe("overInput", () => {
   it("string input: transforms through a single-node view and returns a string", () => {
-    expect(overInput("abc", (view) => view.replace(0, 3, "xyz"))).toBe("xyz")
-  })
+    expect(overInput("abc", (view) => view.replace(0, 3, "xyz"))).toBe("xyz");
+  });
 
   it("view input: applies and commits edits in place, returns undefined", () => {
-    const ns = nodes("ab", "cd")
-    const view = buildProseView(ns)
-    const result = overInput(view, (v) => v.replace(1, 3, "--"))
-    expect(result).toBeUndefined()
-    expect(ns.map((n) => n.value)).toEqual(["a--", "d"])
-  })
+    const ns = nodes("ab", "cd");
+    const view = buildProseView(ns);
+    const result = overInput(view, (v) => v.replace(1, 3, "--"));
+    expect(result).toBeUndefined();
+    expect(ns.map((n) => n.value)).toEqual(["a--", "d"]);
+  });
 
   it("view input: commits edits the run left queued", () => {
-    const ns = nodes("ab")
-    const view = buildProseView(ns)
+    const ns = nodes("ab");
+    const view = buildProseView(ns);
     overInput(view, (v) => {
-      v.replace(0, 0, ">")
-    })
-    expect(ns[0].value).toBe(">ab")
-  })
-})
+      v.replace(0, 0, ">");
+    });
+    expect(ns[0].value).toBe(">ab");
+  });
+});
 
 describe("boundaryCountAt", () => {
   // "ab" | "" | "cd" | "e": boundaries at 2 (doubled by the empty node) and 4.
-  const view = buildProseView([{ value: "ab" }, { value: "" }, { value: "cd" }, { value: "e" }])
+  const view = buildProseView([
+    { value: "ab" },
+    { value: "" },
+    { value: "cd" },
+    { value: "e" },
+  ]);
 
   it.each([
     [0, 0],
@@ -378,6 +427,6 @@ describe("boundaryCountAt", () => {
     [4, 1],
     [5, 0],
   ])("offset %d has %d boundaries", (offset, expected) => {
-    expect(boundaryCountAt(view, offset)).toBe(expected)
-  })
-})
+    expect(boundaryCountAt(view, offset)).toBe(expected);
+  });
+});


### PR DESCRIPTION
## Summary

`ProseView.commit()` rejected **any** two pure insertions at the same offset as ambiguous ("combine them"), even when their `bind` differed. But `bind` is already load-bearing for routing: `targetNodeForInsertion` sends a `bind: "left"` insertion into the node **ending** at the offset and a `bind: "right"` insertion into the node **starting** there. So two opposite-`bind` insertions at one offset land in **different nodes** — there is no real ambiguity, yet the guard threw and aborted the whole transform.

**Fix:** in `commit()`, sort same-offset pure insertions `left`-before-`right`, and only reject when the two share a `bind` (same node, genuinely undefined order). Behavior for every other case — overlaps, same-`bind` collisions, insertions adjacent to a replacement — is unchanged.

## Why this matters (the real-world crash)

A downstream consumer (turntrout.com's slash-spacing pass) pads both sides of a `/`. When two slashes are separated **only** by an inline-element boundary, the first slash's trailing NBSP (`bind: "left"`) and the next slash's leading NBSP (`bind: "right"`) target the same offset. The old guard threw `Two pure insertions at the same offset N are ambiguous`, which aborted the entire site build. Those two NBSPs route to different nodes, so this is exactly the false-positive the fix removes — hardening the engine for every consumer, not just one caller.

## Tests

- Existing "rejects two pure insertions at the same offset" (both default `bind: "left"`) still throws.
- New: same-offset insertions with **matching explicit** bind still throw.
- New: same-offset insertions with **opposite** bind commit successfully, landing in the correct nodes (`ab|cd` + left`X`/right`Y` → `abXYcd`).

Full suite: 2486 tests pass, 100% coverage on `prose-view.ts`; `tsc`, ESLint, Prettier clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AjQ1rd6bcW6mYjTa7WopbM)_