### PR TITLE
fix(rehype): keep applyPasses on one spanning view so passes cross opaque gaps

### DIFF
--- a/src/rehype.ts
+++ b/src/rehype.ts
@@ -314,13 +314,21 @@ function mergePredicates<Args extends unknown[]>(
  * an entry with different `shouldSkip`/`shouldSkipText` predicates gets a
  * fresh view (built after the previous pass committed) over the text nodes
  * that survive both the base `options` predicates and its own.
+ *
+ * The view is a single {@link proseViewOf} spanning the whole element, with a
+ * boundary recorded at every opaque gap (removed skipped element, image, …).
+ * Caller passes stay boundary-aware via `view.hasBoundary`, so each pass
+ * decides for itself whether to act across a gap — spacing a slash between two
+ * skipped `<code>` runs, gluing a dash after a skipped element — rather than
+ * being blocked wholesale. Passes that must not cross a gap consult the same
+ * boundary marks; use {@link proseViewsOf} directly for hard per-segment views.
  */
 export function applyPasses(
   element: Element,
   passes: readonly PassEntry[],
   options: ProseViewOfOptions = {},
 ): void {
-  let currentViews: ProseView[] = []
+  let currentView: ProseView | null = null
   let currentPredicates: Pick<ResolvedPassEntry, "shouldSkip" | "shouldSkipText"> | null = null
 
   for (const entry of passes) {
@@ -331,18 +339,19 @@ export function applyPasses(
       currentPredicates.shouldSkip === shouldSkip &&
       currentPredicates.shouldSkipText === shouldSkipText
     if (!samePredicates) {
-      currentViews = proseViewsOf(element, {
+      currentView = proseViewOf(element, {
         shouldSkip: mergePredicates(options.shouldSkip, shouldSkip),
         shouldSkipText: mergePredicates(options.shouldSkipText, shouldSkipText),
       })
       currentPredicates = { shouldSkip, shouldSkipText }
     }
 
-    // Each opaque-delimited segment is transformed independently; an entry with
-    // no transformable text simply has no views to run over.
-    for (const view of currentViews) {
-      pass(view)
+    // No transformable text under this entry's predicates; a later entry may
+    // still see text (its skip set differs), so keep going.
+    if (currentView === null) {
+      continue
     }
+    pass(currentView)
   }
 }
 

--- a/src/tests/apply-passes.test.ts
+++ b/src/tests/apply-passes.test.ts
@@ -2,7 +2,7 @@ import type { Element } from "hast"
 import { h } from "hastscript"
 
 import { applyPasses, getTextContent, type PassEntry } from "../rehype.js"
-import { definePass } from "../prose-view.js"
+import { definePass, makeProsePass, type ProseView } from "../prose-view.js"
 import { hyphenReplace } from "../dashes.js"
 import { UNICODE_SYMBOLS } from "../constants.js"
 
@@ -102,5 +102,33 @@ describe("applyPasses", () => {
     const element = h("p")
     expect(() => applyPasses(element, [definePass(/a/g, "b")])).not.toThrow()
     expect(getTextContent(element)).toBe("")
+  })
+
+  // A pass receives one view spanning the whole element, with a boundary
+  // recorded at each opaque gap (a removed skipped element) — not a separate
+  // view per gap-delimited segment. This keeps boundary-aware passes able to
+  // act across an inline-element boundary instead of seeing isolated fragments.
+  const skipCode = (node: Element): boolean => node.tagName === "code"
+
+  it("hands each pass one spanning view with a boundary at an opaque gap", () => {
+    const element = h("p", ["a", h("code", "x"), "/", h("code", "y"), "b"])
+    const seen: Array<{ text: string; boundaryAtSlash: boolean }> = []
+    const capture = makeProsePass((view: ProseView) => {
+      const slash = view.text.indexOf("/")
+      seen.push({ text: view.text, boundaryAtSlash: view.hasBoundary(slash) })
+    })
+    applyPasses(element, [capture], { shouldSkip: skipCode })
+    expect(seen).toEqual([{ text: "a/b", boundaryAtSlash: true }])
+  })
+
+  it("lets a boundary-aware pass act across an opaque gap", () => {
+    const element = h("p", ["a", h("code", "x"), "/", h("code", "y"), "b"])
+    // Pads the slash only when it can see a following character — reachable
+    // only if the code-separated neighbors share one spanning view.
+    const padSlash = definePass(/\//g, (match, view) =>
+      view.text[match.index + 1] !== undefined ? " / " : "/",
+    )
+    applyPasses(element, [padSlash], { shouldSkip: skipCode })
+    expect(getTextContent(element)).toBe("ax / yb")
   })
 })


### PR DESCRIPTION
## Summary

`applyPasses` (the public helper consumers drive to run a pass list over an element) was silently changed in `063a7da` from a **single spanning `proseViewOf`** to **per-gap split `proseViewsOf`** views. That isolates text on each side of an opaque gap (a removed skipped element such as `<code>`/`<pre>`, an image, …), so a boundary-aware pass can no longer see across the gap. Downstream this broke real formatting in a consumer (turntrout.com):

- slash spacing between two skipped `<code>` runs (`<code>A</code>/<code>B</code>` → ` / `) stopped;
- a straight quote isolated at a fragment edge got curled the wrong direction by `niceQuotes`;
- the em-dash word-joiner and link-punctuation passes lost the neighbor context they inspect across the boundary.

The spanning view already records a **boundary mark** at each opaque gap, so passes stay boundary-aware via `view.hasBoundary` and decide for themselves whether to act across a gap — strictly more expressive than a hard split. This restores that contract for `applyPasses`.

The **internal** pipeline (`rehypePunctilio`) still calls `proseViewsOf` directly where a hard per-segment split is wanted (e.g. to stop `5<code>c</code>x 3` → `5×3`); that path is untouched.

## Root cause

`063a7da`'s target was the internal opaque-gap handling; flipping `applyPasses` to split was collateral. It shipped green because `apply-passes.test.ts` had **no test exercising a context-dependent pass across an opaque gap** — the exact consumer scenario. This PR adds that coverage.

## Tests

- `apply-passes.test.ts`: one test asserts a pass receives a **single** spanning view (`"a/b"` with `hasBoundary` true at the gap); one asserts a boundary-aware slash pass spaces across two skipped `<code>` runs (`"ax / yb"`).
- Non-vacuity: both **fail** on the pre-fix split code, **pass** after.
- Full suite: **2488 passed, 100%** statement/branch/function/line coverage. End-to-end, a consumer's formatting suite goes from 8 failures to 1 (the remaining one is an intentional `collectProseBlocks` API change in `4f2f350`, not this).

## Lessons Learned

- **A public view-construction helper (`applyPasses`) must preserve boundary context, not hard-split at opaque gaps** — consumers rely on `hasBoundary` to make per-pass cross-gap decisions. When changing an internal pipeline's view strategy, don't let it flip the public helper too, and pin the public contract with a test that runs a context-dependent pass across a gap. (Template-relevant for any repo exposing a prose-view/pass API.)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AjQ1rd6bcW6mYjTa7WopbM)_