### PR TITLE
feat(quotes): keep list-separator commas outside quoted items in brackets (closes #247)

### DIFF
--- a/src/quote-classifier.ts
+++ b/src/quote-classifier.ts
@@ -949,6 +949,49 @@ function applyRelocations(order: Item[], moves: Relocation[]): Item[] {
   return result
 }
 
+const OPEN_BRACKETS = new Set<string>(["(", "[", "{"])
+const CLOSE_BRACKETS = new Set<string>([")", "]", "}"])
+
+/**
+ * Unmatched open brackets (`(`, `[`, `{`) strictly before each item — a
+ * position is inside a bracket pair when its entry is > 0. Brackets never move
+ * during placement, so the depths hold across the fixpoint's rounds. Boundary
+ * items are transparent; a closer with no opener above it floors the depth at 0.
+ */
+function bracketDepths(order: Item[]): number[] {
+  const depths: number[] = []
+  let depth = 0
+  for (const item of order) {
+    depths.push(depth)
+    if (item.boundary) continue
+    if (OPEN_BRACKETS.has(item.ch)) depth++
+    else if (CLOSE_BRACKETS.has(item.ch) && depth > 0) depth--
+  }
+  return depths
+}
+
+/**
+ * True iff the comma at `punctIndex` delimits two quoted items inside a bracket
+ * pair (`["a", "b"]`, `("a", "b")`, `{"a", "b"}`). Such a comma is a list
+ * separator, not sentence punctuation, so American placement must leave it
+ * outside the closer — pulling it in would corrupt the quoted item's exact text
+ * (`"a,"`). Detected when the run sits inside a bracket (depth > 0; a stray
+ * closer floors the count at 0, so an unbalanced `depth <= 0` reads as outside)
+ * and the next item after the comma opens the following quoted item. Bare
+ * `"a", "b"` in running prose (depth 0) is left to the American rule, where a
+ * comma between quoted words correctly moves inside.
+ */
+function isBracketedListSeparator(order: Item[], runStart: number, punctIndex: number, depths: number[]): boolean {
+  if (order[punctIndex].ch !== "," || depths[runStart] <= 0) return false
+  // The next quoted item always opens after the separator's single space
+  // (`, "b"`): a comma-adjacent quote never satisfies an opener rule, so the
+  // space is invariant.
+  const space = nextIndex(order, punctIndex, 1)
+  if (!isCharItem(order, space, " ")) return false
+  const opener = order[nextIndex(order, space, 1)]
+  return opener?.ch === LEFT_DOUBLE_QUOTE || opener?.ch === LEFT_SINGLE_QUOTE
+}
+
 /**
  * American style: a period or comma directly after a closing-quote run moves
  * to just before the run, unless the character before the run is terminal
@@ -969,6 +1012,7 @@ function movePunctuationInside(order: Item[], isMovable: (items: Item[], index: 
     }
   }
   const movedFrom = new Set<number>()
+  const depths = bracketDepths(order)
   let position = 0
   while (position < order.length) {
     const runStart = order[position].boundary ? position + 1 : position
@@ -1016,6 +1060,12 @@ function movePunctuationInside(order: Item[], isMovable: (items: Item[], index: 
     // its content ends in whitespace on purpose, and pulling the punctuation
     // inside would attach it to that verbatim trailing space.
     if (beforeIndex >= 0 && !order[beforeIndex].boundary && SPACE_RE.test(order[beforeIndex].ch)) {
+      position++
+      continue
+    }
+    // A comma between two quoted items inside brackets delimits a list; keep it
+    // outside the closer instead of corrupting the item's text (`"a,"`).
+    if (isBracketedListSeparator(order, runStart, punctIndex, depths)) {
       position++
       continue
     }

--- a/src/tests/quotes.test.ts
+++ b/src/tests/quotes.test.ts
@@ -482,15 +482,51 @@ describe("niceQuotes", () => {
       // A closing double quote before `]` curls, mirroring the opener after `[`.
       ['x ["foo"] y', `x [${LEFT_DOUBLE_QUOTE}foo${RIGHT_DOUBLE_QUOTE}] y`],
       ['a ["quoted"] item', `a [${LEFT_DOUBLE_QUOTE}quoted${RIGHT_DOUBLE_QUOTE}] item`],
-      // A bracketed list of quoted items: the closer before `]` curls, and the
-      // separating comma moves inside its preceding closer (American style),
-      // just as it does in prose (`"A", "B"` → `“A,” “B”`).
+      // The final closer of a bracketed list curls before `]`.
       ['["B"]', `[${LEFT_DOUBLE_QUOTE}B${RIGHT_DOUBLE_QUOTE}]`],
-      [
-        '["A", "-athryn"]',
-        `[${LEFT_DOUBLE_QUOTE}A,${RIGHT_DOUBLE_QUOTE} ${LEFT_DOUBLE_QUOTE}-athryn${RIGHT_DOUBLE_QUOTE}]`,
-      ],
     ])('curls quotes before a closing colon/bracket: "%s"', (input, expected) => {
+      expect(niceQuotes(input)).toBe(expected)
+      expect(niceQuotes(niceQuotes(input))).toBe(expected)
+    })
+  })
+
+  describe("commas between quoted items in brackets", () => {
+    // A comma separating quoted items inside (), [], or {} is a list delimiter,
+    // so American placement leaves it outside the closer instead of pulling it
+    // in (which would corrupt the item's exact text, `"A,"`). Prose lists with
+    // no brackets keep the American comma-inside rule.
+    const l = LEFT_DOUBLE_QUOTE
+    const r = RIGHT_DOUBLE_QUOTE
+    it.each([
+      ['["A", "-athryn"]', `[${l}A${r}, ${l}-athryn${r}]`],
+      ['["A", "B", "C"]', `[${l}A${r}, ${l}B${r}, ${l}C${r}]`],
+      ['("abc", "def")', `(${l}abc${r}, ${l}def${r})`],
+      ['{"x", "y"}', `{${l}x${r}, ${l}y${r}}`],
+      ['a list ["A", "B"] here', `a list [${l}A${r}, ${l}B${r}] here`],
+      ['[["A", "B"], ["C", "D"]]', `[[${l}A${r}, ${l}B${r}], [${l}C${r}, ${l}D${r}]]`],
+      // A stray closer before the list (e.g. an emoticon) floors the bracket
+      // count at 0, so the list that follows is still detected as enclosed.
+      [':) ["a", "b"]', `:) [${l}a${r}, ${l}b${r}]`],
+      // Single-quoted items in brackets get the same treatment.
+      ["('a', 'b', 'c')", `(${LEFT_SINGLE_QUOTE}a${RIGHT_SINGLE_QUOTE}, ${LEFT_SINGLE_QUOTE}b${RIGHT_SINGLE_QUOTE}, ${LEFT_SINGLE_QUOTE}c${RIGHT_SINGLE_QUOTE})`],
+      // A comma before a non-quoted item is not a between-items separator, so
+      // the American rule still applies (`"A"` closes a quotation before `42`).
+      ['["A", 42]', `[${l}A,${r} 42]`],
+      // No space after the comma is likewise not a list separator.
+      ['["a",42]', `[${l}a,${r}42]`],
+      // Only commas delimit list items; a period between quoted items stays on
+      // the American rule and moves inside its closer.
+      ['("A". "B")', `(${l}A.${r} ${l}B${r})`],
+      // No brackets: running prose keeps the comma inside its closer.
+      ['"cat", "dog"', `${l}cat,${r} ${l}dog${r}`],
+      // Bracketed prose (comma followed by a word) is not a list separator.
+      ['(He said "yes", and left.)', `(He said ${l}yes,${r} and left.)`],
+      // Once a bracket closes, a following bare list is outside it again and
+      // keeps the American comma-inside rule.
+      ['("x") "a", "b"', `(${l}x${r}) ${l}a,${r} ${l}b${r}`],
+      // A dangling comma with no following item is not a separator.
+      ['("a", ', `(${l}a,${r} `],
+    ])('places list-separator commas outside: "%s"', (input, expected) => {
       expect(niceQuotes(input)).toBe(expected)
       expect(niceQuotes(niceQuotes(input))).toBe(expected)
     })

--- a/src/tests/quotes.test.ts
+++ b/src/tests/quotes.test.ts
@@ -482,6 +482,14 @@ describe("niceQuotes", () => {
       // A closing double quote before `]` curls, mirroring the opener after `[`.
       ['x ["foo"] y', `x [${LEFT_DOUBLE_QUOTE}foo${RIGHT_DOUBLE_QUOTE}] y`],
       ['a ["quoted"] item', `a [${LEFT_DOUBLE_QUOTE}quoted${RIGHT_DOUBLE_QUOTE}] item`],
+      // A bracketed list of quoted items: the closer before `]` curls, and the
+      // separating comma moves inside its preceding closer (American style),
+      // just as it does in prose (`"A", "B"` → `“A,” “B”`).
+      ['["B"]', `[${LEFT_DOUBLE_QUOTE}B${RIGHT_DOUBLE_QUOTE}]`],
+      [
+        '["A", "-athryn"]',
+        `[${LEFT_DOUBLE_QUOTE}A,${RIGHT_DOUBLE_QUOTE} ${LEFT_DOUBLE_QUOTE}-athryn${RIGHT_DOUBLE_QUOTE}]`,
+      ],
     ])('curls quotes before a closing colon/bracket: "%s"', (input, expected) => {
       expect(niceQuotes(input)).toBe(expected)
       expect(niceQuotes(niceQuotes(input))).toBe(expected)


### PR DESCRIPTION
## Summary

Closes #247. The reported bug — a closing double quote before `]` staying straight (`-athryn"]`) — was already fixed on `main` by `9ac149e`. But investigating the reporter's `["A", "-athryn"]` case surfaced a real, related issue: American placement pulls the separating comma **inside** the closer (`[“A,” “-athryn”]`), attaching the list delimiter to the quoted item's text.

This PR fixes that: a comma is now kept **outside** the closer when it delimits quoted items inside a bracket pair.

## Behavior

| Input | Before | After |
|-------|--------|-------|
| `["A", "-athryn"]` | `[“A,” “-athryn”]` | `[“A”, “-athryn”]` |
| `("abc", "def")` | `(“abc,” “def”)` | `(“abc”, “def”)` |
| `{"x", "y"}` | `{“x,” “y”}` | `{“x”, “y”}` |
| `"cat", "dog"` (prose, no brackets) | `“cat,” “dog”` | `“cat,” “dog”` (unchanged) |
| `(He said "yes", and left.)` (bracketed prose) | `(He said “yes,” and left.)` | unchanged |

## Scope & design

The change is deliberately narrow, because `"cat", "dog"` in English prose and `"abc", "def"` in a data list are character-for-character identical — a blanket "comma between quotes stays outside" rule would regress correct American prose typography (Chicago keeps `“cat,” “dog,”` commas inside).

A comma is treated as a list delimiter only when **both**:
1. its quoted item sits inside a bracket pair `()` / `[]` / `{}` (bracket-depth > 0), and
2. it separates two quoted items (`", "` followed by the next item's opener).

So bare prose lists and bracketed prose whose comma precedes a word keep the American rule. A comma before a non-quoted item (`["A", 42]`) also stays American.

Implemented as a guard in `movePunctuationInside` (American path only — British/German/French place commas outside already), gated on a `bracketDepths` scan of the item stream.

## Verification

- Full suite: **2504 passing**, 100% coverage, lint + typecheck clean.
- All new cases verified idempotent (`niceQuotes(niceQuotes(x)) === niceQuotes(x)`).
- Mutation testing on the new code: 90% score; the 3 survivors are provably-equivalent mutants (accumulator-array init, boundary-item no-op, and an unreachable no-space path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)