### PR TITLE
fix(rehype): expose loose runs via collectProseUnits so consumers format them

### DIFF
--- a/src/rehype.ts
+++ b/src/rehype.ts
@@ -1,21 +1,36 @@
-import type { Element, ElementContent, Parent, Root, RootContent, Text } from "hast"
-import type { Transformer } from "unified"
+import type {
+  Element,
+  ElementContent,
+  Parent,
+  Root,
+  RootContent,
+  Text,
+} from "hast";
+import type { Transformer } from "unified";
 
-import { SKIP, visitParents } from "unist-util-visit-parents"
+import { SKIP, visitParents } from "unist-util-visit-parents";
 
-import { transformView } from "./index.js"
-import { TRANSFORM_OPTION_KEYS, type TransformOptions } from "./transform-options.js"
-import { MAX_RECURSION_DEPTH } from "./constants.js"
-import { assertKnownOptionKeys, formatErrorString } from "./utils.js"
-import { buildProseView, type ProsePass, type ProseView, splitAtIndices } from "./prose-view.js"
+import { transformView } from "./index.js";
+import {
+  TRANSFORM_OPTION_KEYS,
+  type TransformOptions,
+} from "./transform-options.js";
+import { MAX_RECURSION_DEPTH } from "./constants.js";
+import { assertKnownOptionKeys, formatErrorString } from "./utils.js";
+import {
+  buildProseView,
+  type ProsePass,
+  type ProseView,
+  splitAtIndices,
+} from "./prose-view.js";
 
-export type ElementPredicate = (node: Element) => boolean
+export type ElementPredicate = (node: Element) => boolean;
 
 /** Per-text-node skip predicate, called after element-level `shouldSkip`. */
 export type TextNodeSkipPredicate = (
   textNode: Text,
   ancestors: readonly Element[],
-) => boolean
+) => boolean;
 
 export interface ElementTransformOptions {
   /**
@@ -24,19 +39,18 @@ export interface ElementTransformOptions {
    * not passed to the transform function, and its `.value` is left
    * untouched. Applied after element-level `shouldSkip`.
    */
-  shouldSkipText?: TextNodeSkipPredicate
+  shouldSkipText?: TextNodeSkipPredicate;
 }
 
 export interface RehypePunctilioOptions
-  extends TransformOptions,
-    ElementTransformOptions {
+  extends TransformOptions, ElementTransformOptions {
   /**
    * HTML tag names to skip when applying transformations.
    * Content inside these elements won't have formatting improvements applied.
    *
    * Default: ["code", "pre", "script", "style", "kbd", "var", "samp", "template", "math", "svg"]
    */
-  skipTags?: string[]
+  skipTags?: string[];
 
   /**
    * CSS class names that indicate content should skip formatting.
@@ -45,7 +59,7 @@ export interface RehypePunctilioOptions
    *
    * Default: []
    */
-  skipClasses?: string[]
+  skipClasses?: string[];
 
   /**
    * Invert the element model: transform text inside every element except the
@@ -56,95 +70,136 @@ export interface RehypePunctilioOptions
    *
    * Default: false
    */
-  transformAllElements?: boolean
+  transformAllElements?: boolean;
 }
 
-const DEFAULT_SKIP_TAGS = ["code", "pre", "script", "style", "kbd", "var", "samp", "template", "math", "svg"]
+const DEFAULT_SKIP_TAGS = [
+  "code",
+  "pre",
+  "script",
+  "style",
+  "kbd",
+  "var",
+  "samp",
+  "template",
+  "math",
+  "svg",
+];
 
 // Form elements whose text content is a literal control value, not prose.
 // Hard-skipped (whole subtree) under `transformAllElements`, on top of the
 // user skip-list, so their values are protected even when nested inside a
 // transformable element.
-const FORM_VALUE_TAGS = ["textarea", "input"]
+const FORM_VALUE_TAGS = ["textarea", "input"];
 
 // `<select>` is not prose itself, but its `<option>` children are (and are
 // transformed under the default allowlist). Under `transformAllElements` we
 // exclude `select` as a transform *unit* while still recursing into — and
 // transforming — its options, so the inverted mode never transforms less than
 // the allowlist.
-const NON_PROSE_CONTAINER_TAGS = new Set(["select"])
+const NON_PROSE_CONTAINER_TAGS = new Set(["select"]);
 
 /** Option keys handled by `rehypePunctilio` itself rather than `transform()`. */
-export const REHYPE_ONLY_OPTION_KEYS: readonly string[] = ["skipTags", "skipClasses", "shouldSkipText", "transformAllElements"]
+export const REHYPE_ONLY_OPTION_KEYS: readonly string[] = [
+  "skipTags",
+  "skipClasses",
+  "shouldSkipText",
+  "transformAllElements",
+];
 
 /** Runtime list of valid `rehypePunctilio` option keys. */
-export const REHYPE_OPTION_KEYS: readonly string[] = [...TRANSFORM_OPTION_KEYS, ...REHYPE_ONLY_OPTION_KEYS]
+export const REHYPE_OPTION_KEYS: readonly string[] = [
+  ...TRANSFORM_OPTION_KEYS,
+  ...REHYPE_ONLY_OPTION_KEYS,
+];
 
 // Void/replaced inline elements that render atomic content (or a hard break)
 // and carry no transformable text. When one sits between two text nodes it is a
 // real visual separator, so the flattener records an opaque gap there.
 const OPAQUE_VOID_TAGS = new Set([
-  "img", "br", "wbr", "input", "hr", "embed",
-  "area", "source", "track", "col", "param", "keygen",
-])
+  "img",
+  "br",
+  "wbr",
+  "input",
+  "hr",
+  "embed",
+  "area",
+  "source",
+  "track",
+  "col",
+  "param",
+  "keygen",
+]);
 
 /** Flattened text nodes plus the opaque gaps that fell between adjacent ones. */
 export interface FlattenedProse {
-  nodes: Text[]
+  nodes: Text[];
   /** Indices into `nodes` (1..n-1) with removed opaque content immediately before them. */
-  opaqueBefore: Set<number>
+  opaqueBefore: Set<number>;
 }
 
 interface ProseCollector {
-  nodes: Text[]
-  opaqueBefore: Set<number>
-  shouldSkip: ElementPredicate
-  shouldSkipText: TextNodeSkipPredicate | undefined
-  ancestors: Element[] | null
+  nodes: Text[];
+  opaqueBefore: Set<number>;
+  shouldSkip: ElementPredicate;
+  shouldSkipText: TextNodeSkipPredicate | undefined;
+  ancestors: Element[] | null;
   // An opaque element was dropped since the last emitted text node; the next
   // emitted node records an opaque gap before it.
-  pendingOpaque: boolean
+  pendingOpaque: boolean;
 }
 
-function collectProse(node: Element | ElementContent, depth: number, c: ProseCollector): void {
+function collectProse(
+  node: Element | ElementContent,
+  depth: number,
+  c: ProseCollector,
+): void {
   if (depth > MAX_RECURSION_DEPTH) {
-    return
+    return;
   }
 
   if (node.type === "element") {
     if (c.shouldSkip(node)) {
       // A skipped element with content is a visual separator; an empty one
       // renders nothing and leaves its neighbors genuinely adjacent.
-      if (node.children.length > 0) c.pendingOpaque = true
-      return
+      if (node.children.length > 0) c.pendingOpaque = true;
+      return;
     }
     if (OPAQUE_VOID_TAGS.has(node.tagName)) {
-      c.pendingOpaque = true
-      return
+      c.pendingOpaque = true;
+      return;
     }
-    if (c.ancestors) c.ancestors.push(node)
-    for (const child of node.children) collectProse(child, depth + 1, c)
-    if (c.ancestors) c.ancestors.pop()
-    return
+    if (c.ancestors) c.ancestors.push(node);
+    for (const child of node.children) collectProse(child, depth + 1, c);
+    if (c.ancestors) c.ancestors.pop();
+    return;
   }
 
   if (node.type === "text") {
     // Snapshot ancestors at the callback boundary — the walker mutates the
     // shared array as it recurses, so handing it out directly would let a
     // caller observe a stale view if they captured the reference.
-    if (c.shouldSkipText && c.ancestors && c.shouldSkipText(node, c.ancestors.slice())) {
+    if (
+      c.shouldSkipText &&
+      c.ancestors &&
+      c.shouldSkipText(node, c.ancestors.slice())
+    ) {
       // Preserved-but-untransformed text is a separator between its neighbors.
-      c.pendingOpaque = true
-      return
+      c.pendingOpaque = true;
+      return;
     }
-    if (c.pendingOpaque && c.nodes.length > 0) c.opaqueBefore.add(c.nodes.length)
-    c.pendingOpaque = false
-    c.nodes.push(node)
+    if (c.pendingOpaque && c.nodes.length > 0)
+      c.opaqueBefore.add(c.nodes.length);
+    c.pendingOpaque = false;
+    c.nodes.push(node);
   }
 }
 
-function newCollector(shouldSkip: ElementPredicate, options?: ElementTransformOptions): ProseCollector {
-  const shouldSkipText = options?.shouldSkipText
+function newCollector(
+  shouldSkip: ElementPredicate,
+  options?: ElementTransformOptions,
+): ProseCollector {
+  const shouldSkipText = options?.shouldSkipText;
   return {
     nodes: [],
     opaqueBefore: new Set(),
@@ -154,87 +209,94 @@ function newCollector(shouldSkip: ElementPredicate, options?: ElementTransformOp
     // O(n²) allocation cost of copying the ancestor chain at every level.
     ancestors: shouldSkipText ? [] : null,
     pendingOpaque: false,
-  }
+  };
 }
 
 /** Flattens an element's transformable text nodes, tracking opaque gaps. */
 export function flattenProse(
   node: Element | ElementContent,
   shouldSkip: ElementPredicate,
-  options?: ElementTransformOptions
+  options?: ElementTransformOptions,
 ): FlattenedProse {
-  const c = newCollector(shouldSkip, options)
-  collectProse(node, 0, c)
-  return { nodes: c.nodes, opaqueBefore: c.opaqueBefore }
+  const c = newCollector(shouldSkip, options);
+  collectProse(node, 0, c);
+  return { nodes: c.nodes, opaqueBefore: c.opaqueBefore };
 }
 
 export function flattenTextNodes(
   node: Element | ElementContent,
   shouldSkip: ElementPredicate,
-  options?: ElementTransformOptions
+  options?: ElementTransformOptions,
 ): Text[] {
-  return flattenProse(node, shouldSkip, options).nodes
+  return flattenProse(node, shouldSkip, options).nodes;
 }
 
 export function getTextContent(
   node: Element,
-  shouldSkip: ElementPredicate = () => false
+  shouldSkip: ElementPredicate = () => false,
 ): string {
   return flattenTextNodes(node, shouldSkip)
     .map((n) => n.value)
-    .join("")
+    .join("");
 }
 
 export function getFirstTextNode(
   node: Parent | RootContent,
-  depth: number = 0
+  depth: number = 0,
 ): Text | null {
-  if (!node || depth > MAX_RECURSION_DEPTH) return null
+  if (!node || depth > MAX_RECURSION_DEPTH) return null;
 
   if (node.type === "text") {
-    return node as Text
+    return node as Text;
   }
 
   if ("children" in node && node.children.length > 0) {
     for (const child of node.children) {
-      const textNode = getFirstTextNode(child as Parent, depth + 1)
-      if (textNode) return textNode
+      const textNode = getFirstTextNode(child as Parent, depth + 1);
+      if (textNode) return textNode;
     }
   }
 
-  return null
+  return null;
 }
 
-const QUOTE_OPENERS = new Set(["\u201C"])
-const CLOSER_TO_OPENER: Record<string, string> = { "\u201D": "\u201C" }
+const QUOTE_OPENERS = new Set(["\u201C"]);
+const CLOSER_TO_OPENER: Record<string, string> = { "\u201D": "\u201C" };
 
 // Only checks double quotes \u2014 single quotes are excluded because
 // U+2019 doubles as an apostrophe, making balance-checking unreliable.
 export function assertSmartQuotesMatch(input: string): void {
-  if (!input) return
+  if (!input) return;
 
-  const stack: string[] = []
+  const stack: string[] = [];
 
   for (const char of input) {
     if (QUOTE_OPENERS.has(char)) {
-      stack.push(char)
+      stack.push(char);
     } else if (char in CLOSER_TO_OPENER) {
-      if (stack.length > 0 && stack[stack.length - 1] === CLOSER_TO_OPENER[char]) {
-        stack.pop()
+      if (
+        stack.length > 0 &&
+        stack[stack.length - 1] === CLOSER_TO_OPENER[char]
+      ) {
+        stack.pop();
       } else {
-        throw new Error(`Mismatched quotes in ${formatErrorString(input, "input")}`)
+        throw new Error(
+          `Mismatched quotes in ${formatErrorString(input, "input")}`,
+        );
       }
     }
   }
 
   if (stack.length > 0) {
-    throw new Error(`Mismatched quotes in ${formatErrorString(input, "input")}`)
+    throw new Error(
+      `Mismatched quotes in ${formatErrorString(input, "input")}`,
+    );
   }
 }
 
 export interface ProseViewOfOptions extends ElementTransformOptions {
   /** Element-level skip predicate; skipped subtrees contribute no text nodes. */
-  shouldSkip?: ElementPredicate
+  shouldSkip?: ElementPredicate;
 }
 
 /**
@@ -244,19 +306,22 @@ export interface ProseViewOfOptions extends ElementTransformOptions {
  * view spans opaque gaps; the transform pipeline uses {@link proseViewsOf},
  * which splits on them so no pass rewrites across removed atomic content.
  */
-export function proseViewOf(element: Element, options: ProseViewOfOptions = {}): ProseView | null {
+export function proseViewOf(
+  element: Element,
+  options: ProseViewOfOptions = {},
+): ProseView | null {
   /* istanbul ignore if -- defensive: elements should always have children array */
   if (!element?.children) {
-    return null
+    return null;
   }
 
-  const shouldSkip = options.shouldSkip ?? (() => false)
-  const textNodes = flattenTextNodes(element, shouldSkip, options)
+  const shouldSkip = options.shouldSkip ?? (() => false);
+  const textNodes = flattenTextNodes(element, shouldSkip, options);
   if (textNodes.length === 0) {
-    return null
+    return null;
   }
 
-  return buildProseView(textNodes)
+  return buildProseView(textNodes);
 }
 
 /**
@@ -265,14 +330,19 @@ export function proseViewOf(element: Element, options: ProseViewOfOptions = {}):
  * inline content) keeps their surrounding text in separate views, so a pass can
  * never treat text as adjacent across content that visually separates it.
  */
-export function proseViewsOf(element: Element, options: ProseViewOfOptions = {}): ProseView[] {
+export function proseViewsOf(
+  element: Element,
+  options: ProseViewOfOptions = {},
+): ProseView[] {
   /* istanbul ignore if -- defensive: elements should always have children array */
   if (!element?.children) {
-    return []
+    return [];
   }
-  const shouldSkip = options.shouldSkip ?? (() => false)
-  const { nodes, opaqueBefore } = flattenProse(element, shouldSkip, options)
-  return splitAtIndices(nodes, opaqueBefore).map((group) => buildProseView(group))
+  const shouldSkip = options.shouldSkip ?? (() => false);
+  const { nodes, opaqueBefore } = flattenProse(element, shouldSkip, options);
+  return splitAtIndices(nodes, opaqueBefore).map((group) =>
+    buildProseView(group),
+  );
 }
 
 /**
@@ -282,16 +352,20 @@ export function proseViewsOf(element: Element, options: ProseViewOfOptions = {})
  */
 export type PassEntry =
   | ProsePass
-  | { pass: ProsePass; shouldSkip?: ElementPredicate; shouldSkipText?: TextNodeSkipPredicate }
+  | {
+      pass: ProsePass;
+      shouldSkip?: ElementPredicate;
+      shouldSkipText?: TextNodeSkipPredicate;
+    };
 
 interface ResolvedPassEntry {
-  pass: ProsePass
-  shouldSkip?: ElementPredicate
-  shouldSkipText?: TextNodeSkipPredicate
+  pass: ProsePass;
+  shouldSkip?: ElementPredicate;
+  shouldSkipText?: TextNodeSkipPredicate;
 }
 
 function resolvePassEntry(entry: PassEntry): ResolvedPassEntry {
-  return typeof entry === "function" ? { pass: entry } : entry
+  return typeof entry === "function" ? { pass: entry } : entry;
 }
 
 /** OR-combines an optional entry predicate onto an optional base predicate. */
@@ -299,9 +373,9 @@ function mergePredicates<Args extends unknown[]>(
   base: ((...args: Args) => boolean) | undefined,
   extra: ((...args: Args) => boolean) | undefined,
 ): ((...args: Args) => boolean) | undefined {
-  if (!base) return extra
-  if (!extra) return base
-  return (...args) => base(...args) || extra(...args)
+  if (!base) return extra;
+  if (!extra) return base;
+  return (...args) => base(...args) || extra(...args);
 }
 
 /**
@@ -315,55 +389,100 @@ function mergePredicates<Args extends unknown[]>(
  * fresh view (built after the previous pass committed) over the text nodes
  * that survive both the base `options` predicates and its own.
  *
- * The view is a single {@link proseViewOf} spanning the whole element, with a
- * boundary recorded at every opaque gap (removed skipped element, image, …).
- * Caller passes stay boundary-aware via `view.hasBoundary`, so each pass
- * decides for itself whether to act across a gap — spacing a slash between two
- * skipped `<code>` runs, gluing a dash after a skipped element — rather than
- * being blocked wholesale. Passes that must not cross a gap consult the same
- * boundary marks; use {@link proseViewsOf} directly for hard per-segment views.
+ * The view is a single spanning view (over the whole element, or a run's loose
+ * inline children), with a boundary recorded at every opaque gap (removed
+ * skipped element, image, …). Caller passes stay boundary-aware via
+ * `view.hasBoundary`, so each pass decides for itself whether to act across a
+ * gap — spacing a slash between two skipped `<code>` runs, gluing a dash after a
+ * skipped element — rather than being blocked wholesale. Passes that must not
+ * cross a gap consult the same boundary marks; use {@link proseViewsOf} directly
+ * for hard per-segment views.
+ *
+ * Accepts a bare element (formatted whole) or a {@link ProseUnit} from
+ * {@link collectProseUnits}; a "run" unit formats a container's loose inline
+ * text without pulling in its block children.
  */
 export function applyPasses(
-  element: Element,
+  target: Element | ProseUnit,
   passes: readonly PassEntry[],
   options: ProseViewOfOptions = {},
 ): void {
-  let currentView: ProseView | null = null
-  let currentPredicates: Pick<ResolvedPassEntry, "shouldSkip" | "shouldSkipText"> | null = null
+  const makeView = (viewOptions: ProseViewOfOptions): ProseView | null => {
+    if ("kind" in target) {
+      return target.kind === "element"
+        ? proseViewOf(target.element, viewOptions)
+        : runViewOf(target.container, target.children, viewOptions);
+    }
+    return proseViewOf(target, viewOptions);
+  };
+
+  let currentView: ProseView | null = null;
+  let currentPredicates: Pick<
+    ResolvedPassEntry,
+    "shouldSkip" | "shouldSkipText"
+  > | null = null;
 
   for (const entry of passes) {
-    const { pass, shouldSkip, shouldSkipText } = resolvePassEntry(entry)
+    const { pass, shouldSkip, shouldSkipText } = resolvePassEntry(entry);
 
     const samePredicates =
       currentPredicates !== null &&
       currentPredicates.shouldSkip === shouldSkip &&
-      currentPredicates.shouldSkipText === shouldSkipText
+      currentPredicates.shouldSkipText === shouldSkipText;
     if (!samePredicates) {
-      currentView = proseViewOf(element, {
+      currentView = makeView({
         shouldSkip: mergePredicates(options.shouldSkip, shouldSkip),
         shouldSkipText: mergePredicates(options.shouldSkipText, shouldSkipText),
-      })
-      currentPredicates = { shouldSkip, shouldSkipText }
+      });
+      currentPredicates = { shouldSkip, shouldSkipText };
     }
 
     // No transformable text under this entry's predicates; a later entry may
     // still see text (its skip set differs), so keep going.
     if (currentView === null) {
-      continue
+      continue;
     }
-    pass(currentView)
+    pass(currentView);
   }
 }
 
 // Block children cause per-block processing to avoid merging text across
 // semantically independent blocks (e.g., separate <p>s inside a <div>).
 const BLOCK_ELEMENTS = new Set([
-  "address", "article", "aside", "blockquote", "details", "dialog",
-  "dd", "div", "dl", "dt", "fieldset", "figcaption", "figure",
-  "footer", "form", "h1", "h2", "h3", "h4", "h5", "h6",
-  "header", "hgroup", "hr", "li", "main", "nav", "ol",
-  "p", "pre", "section", "table", "ul",
-])
+  "address",
+  "article",
+  "aside",
+  "blockquote",
+  "details",
+  "dialog",
+  "dd",
+  "div",
+  "dl",
+  "dt",
+  "fieldset",
+  "figcaption",
+  "figure",
+  "footer",
+  "form",
+  "h1",
+  "h2",
+  "h3",
+  "h4",
+  "h5",
+  "h6",
+  "header",
+  "hgroup",
+  "hr",
+  "li",
+  "main",
+  "nav",
+  "ol",
+  "p",
+  "pre",
+  "section",
+  "table",
+  "ul",
+]);
 
 const TRANSFORMABLE_ELEMENTS = new Set([
   "p",
@@ -424,36 +543,38 @@ const TRANSFORMABLE_ELEMENTS = new Set([
   "button",
   "option",
   "output",
-])
+]);
 
 // A tag name containing "-" is a custom element per the HTML custom-element
 // naming rule; assume those hold transformable prose like built-in elements.
 function isTransformableElement(tagName: string): boolean {
-  return TRANSFORMABLE_ELEMENTS.has(tagName) || tagName.includes("-")
+  return TRANSFORMABLE_ELEMENTS.has(tagName) || tagName.includes("-");
 }
 
 function hasTextDescendant(
   node: Element | ElementContent,
   shouldSkip: ElementPredicate,
-  depth: number = 0
+  depth: number = 0,
 ): boolean {
   if (depth > MAX_RECURSION_DEPTH) {
-    return false
+    return false;
   }
 
   if (node.type === "element" && shouldSkip(node)) {
-    return false
+    return false;
   }
 
   if (node.type === "text") {
-    return true
+    return true;
   }
 
   if (node.type === "element") {
-    return node.children.some((child) => hasTextDescendant(child, shouldSkip, depth + 1))
+    return node.children.some((child) =>
+      hasTextDescendant(child, shouldSkip, depth + 1),
+    );
   }
 
-  return false
+  return false;
 }
 
 export interface CollectProseBlocksOptions {
@@ -461,77 +582,117 @@ export interface CollectProseBlocksOptions {
    * HTML tag names to skip. Default: the plugin's default skip list
    * ("code", "pre", "script", ...).
    */
-  skipTags?: string[]
+  skipTags?: string[];
   /** CSS class names whose elements (and their subtrees) are skipped. Default: [] */
-  skipClasses?: string[]
+  skipClasses?: string[];
   /** Additional element-level skip predicate, OR-ed with the tag/class skips. */
-  shouldSkip?: ElementPredicate
+  shouldSkip?: ElementPredicate;
   /** Invert the element model as in {@link RehypePunctilioOptions.transformAllElements}. Default: false */
-  transformAllElements?: boolean
+  transformAllElements?: boolean;
 }
 
 /** Skip predicate and transformable-tag test resolved from the options. */
 interface ResolvedCollectOptions {
-  shouldSkip: ElementPredicate
-  isTransformable: (tagName: string) => boolean
+  shouldSkip: ElementPredicate;
+  isTransformable: (tagName: string) => boolean;
 }
 
-function resolveCollectOptions(options: CollectProseBlocksOptions): ResolvedCollectOptions {
-  const { skipTags = DEFAULT_SKIP_TAGS, skipClasses = [], shouldSkip, transformAllElements = false } = options
+function resolveCollectOptions(
+  options: CollectProseBlocksOptions,
+): ResolvedCollectOptions {
+  const {
+    skipTags = DEFAULT_SKIP_TAGS,
+    skipClasses = [],
+    shouldSkip,
+    transformAllElements = false,
+  } = options;
 
   // In inverted mode, form-value elements join the skip-list so their literal
   // values are neither transformed nor flattened into a transformable ancestor.
-  const skipTagSet = new Set(transformAllElements ? [...skipTags, ...FORM_VALUE_TAGS] : skipTags)
-  const skipClassSet = new Set(skipClasses)
+  const skipTagSet = new Set(
+    transformAllElements ? [...skipTags, ...FORM_VALUE_TAGS] : skipTags,
+  );
+  const skipClassSet = new Set(skipClasses);
 
   const hasSkipClass = (node: Element): boolean => {
-    if (skipClassSet.size === 0) return false
-    const classNames = node.properties?.className
+    if (skipClassSet.size === 0) return false;
+    const classNames = node.properties?.className;
     const classes = Array.isArray(classNames)
       ? classNames.filter((c): c is string => typeof c === "string")
-      : typeof classNames === "string" ? classNames.split(/\s+/) : []
-    return classes.some((cls) => skipClassSet.has(cls))
-  }
+      : typeof classNames === "string"
+        ? classNames.split(/\s+/)
+        : [];
+    return classes.some((cls) => skipClassSet.has(cls));
+  };
 
   return {
     shouldSkip: (node) =>
-      skipTagSet.has(node.tagName) || hasSkipClass(node) || (shouldSkip?.(node) ?? false),
+      skipTagSet.has(node.tagName) ||
+      hasSkipClass(node) ||
+      (shouldSkip?.(node) ?? false),
     // Inverted mode transforms every non-skipped element except non-prose
     // containers; the default keeps the `TRANSFORMABLE_ELEMENTS` allowlist
     // (plus custom elements).
     isTransformable: transformAllElements
       ? (tagName) => !NON_PROSE_CONTAINER_TAGS.has(tagName)
       : isTransformableElement,
-  }
+  };
 }
 
 // A prose unit is either a whole transformable element (an inline-only leaf) or
 // a "run" of consecutive inline siblings that sit alongside block-level
 // children. Runs let a container's loose inline text transform independently of
 // its block children instead of merging across the block boundary.
-type ProseUnit =
+export type ProseUnit =
   | { kind: "element"; element: Element }
-  | { kind: "run"; container: Element; children: ElementContent[] }
+  | { kind: "run"; container: Element; children: ElementContent[] };
 
 /**
  * Collects the leaf elements under `root` (inclusive) whose text should be
  * transformed as one prose block: transformable elements with direct text or
  * inline-only text descendants. Elements with block-level children recurse so
  * each block transforms independently. Loose inline text mixed among block
- * children is handled by the plugin as its own run and is not represented here.
+ * children is NOT represented here — use {@link collectProseUnits} to reach it.
  */
-export function collectProseBlocks(root: Element, options: CollectProseBlocksOptions = {}): Element[] {
-  const { shouldSkip, isTransformable } = resolveCollectOptions(options)
-  return collectProseUnitsImpl(root, shouldSkip, 0, undefined, isTransformable)
-    .flatMap((unit) => (unit.kind === "element" ? [unit.element] : []))
+export function collectProseBlocks(
+  root: Element,
+  options: CollectProseBlocksOptions = {},
+): Element[] {
+  const { shouldSkip, isTransformable } = resolveCollectOptions(options);
+  return collectProseUnitsImpl(
+    root,
+    shouldSkip,
+    0,
+    undefined,
+    isTransformable,
+  ).flatMap((unit) => (unit.kind === "element" ? [unit.element] : []));
 }
 
-function runHasProse(children: readonly ElementContent[], shouldSkip: ElementPredicate): boolean {
+/**
+ * Like {@link collectProseBlocks}, but also returns "run" units — maximal groups
+ * of loose inline siblings sitting beside block children (e.g. the bare text in
+ * `<blockquote><p>…</p>loose text</blockquote>`). A consumer that walks elements
+ * cannot otherwise reach that text (it belongs to no element of its own); pass
+ * each unit to {@link applyPasses}, which formats a run without merging its
+ * container's block children.
+ */
+export function collectProseUnits(
+  root: Element,
+  options: CollectProseBlocksOptions = {},
+): ProseUnit[] {
+  const { shouldSkip, isTransformable } = resolveCollectOptions(options);
+  return collectProseUnitsImpl(root, shouldSkip, 0, undefined, isTransformable);
+}
+
+function runHasProse(
+  children: readonly ElementContent[],
+  shouldSkip: ElementPredicate,
+): boolean {
   return children.some(
     (child) =>
       (child.type === "text" && child.value.trim() !== "") ||
-      (child.type === "element" && hasTextDescendant(child, shouldSkip))
-  )
+      (child.type === "element" && hasTextDescendant(child, shouldSkip)),
+  );
 }
 
 function collectProseUnitsImpl(
@@ -539,15 +700,15 @@ function collectProseUnitsImpl(
   shouldSkip: ElementPredicate,
   depth: number,
   alreadyTransformed: ReadonlySet<Element> | undefined,
-  isTransformable: (tagName: string) => boolean
+  isTransformable: (tagName: string) => boolean,
 ): ProseUnit[] {
   /* istanbul ignore if -- defensive: prevents stack overflow from malicious HTML */
   if (depth > MAX_RECURSION_DEPTH) {
-    return []
+    return [];
   }
 
   if (shouldSkip(node) || alreadyTransformed?.has(node)) {
-    return []
+    return [];
   }
 
   // Whitespace-only text nodes between block siblings (the newlines a parser
@@ -556,11 +717,11 @@ function collectProseUnitsImpl(
   // and merge its blocks into one transform unit, pairing quotes across the
   // paragraph boundary. Real (non-whitespace) direct text still marks a leaf.
   const hasDirectText = node.children.some(
-    (child) => child.type === "text" && child.value.trim() !== ""
-  )
+    (child) => child.type === "text" && child.value.trim() !== "",
+  );
   const hasBlockChildren = node.children.some(
-    (child) => child.type === "element" && BLOCK_ELEMENTS.has(child.tagName)
-  )
+    (child) => child.type === "element" && BLOCK_ELEMENTS.has(child.tagName),
+  );
 
   // Inline-only transformable node: a single leaf unit. `hasTextDescendant` is
   // only walked when there's no direct text (short-circuit avoids the traversal).
@@ -569,41 +730,54 @@ function collectProseUnitsImpl(
     !hasBlockChildren &&
     (hasDirectText || hasTextDescendant(node, shouldSkip))
   ) {
-    return [{ kind: "element", element: node }]
+    return [{ kind: "element", element: node }];
   }
 
-  const units: ProseUnit[] = []
+  const units: ProseUnit[] = [];
   if (isTransformable(node.tagName) && hasBlockChildren) {
     // Mixed content: split each maximal run of inline siblings from the block
     // children so loose text transforms on its own, then recurse per block.
-    let run: ElementContent[] = []
+    let run: ElementContent[] = [];
     const flushRun = () => {
-      if (runHasProse(run, shouldSkip)) units.push({ kind: "run", container: node, children: run })
-      run = []
-    }
+      if (runHasProse(run, shouldSkip))
+        units.push({ kind: "run", container: node, children: run });
+      run = [];
+    };
     for (const child of node.children) {
       if (child.type === "element" && BLOCK_ELEMENTS.has(child.tagName)) {
-        flushRun()
-        for (const u of collectProseUnitsImpl(child, shouldSkip, depth + 1, alreadyTransformed, isTransformable)) {
-          units.push(u)
+        flushRun();
+        for (const u of collectProseUnitsImpl(
+          child,
+          shouldSkip,
+          depth + 1,
+          alreadyTransformed,
+          isTransformable,
+        )) {
+          units.push(u);
         }
       } else {
-        run.push(child)
+        run.push(child);
       }
     }
-    flushRun()
+    flushRun();
   } else {
     // Non-transformable, or transformable but textless: recurse into elements.
     for (const child of node.children) {
       if (child.type === "element") {
-        for (const u of collectProseUnitsImpl(child, shouldSkip, depth + 1, alreadyTransformed, isTransformable)) {
-          units.push(u)
+        for (const u of collectProseUnitsImpl(
+          child,
+          shouldSkip,
+          depth + 1,
+          alreadyTransformed,
+          isTransformable,
+        )) {
+          units.push(u);
         }
       }
     }
   }
 
-  return units
+  return units;
 }
 
 // Flatten a run's inline siblings to their text nodes (with opaque gaps),
@@ -613,32 +787,51 @@ function flattenRunProse(
   container: Element,
   children: readonly ElementContent[],
   shouldSkip: ElementPredicate,
-  options: ProseViewOfOptions
+  options: ProseViewOfOptions,
 ): FlattenedProse {
-  const c = newCollector(shouldSkip, options)
-  if (c.ancestors) c.ancestors.push(container)
-  for (const child of children) collectProse(child, 1, c)
-  return { nodes: c.nodes, opaqueBefore: c.opaqueBefore }
+  const c = newCollector(shouldSkip, options);
+  if (c.ancestors) c.ancestors.push(container);
+  for (const child of children) collectProse(child, 1, c);
+  return { nodes: c.nodes, opaqueBefore: c.opaqueBefore };
 }
 
-function markDescendants(node: Element, set: Set<Element>, depth: number = 0): void {
+/**
+ * A single spanning ProseView over a run's loose inline children, with a
+ * boundary at every opaque gap — the run analogue of {@link proseViewOf}. Null
+ * when the run holds no transformable text.
+ */
+function runViewOf(
+  container: Element,
+  children: readonly ElementContent[],
+  options: ProseViewOfOptions,
+): ProseView | null {
+  const shouldSkip = options.shouldSkip ?? (() => false);
+  const { nodes } = flattenRunProse(container, children, shouldSkip, options);
+  return nodes.length === 0 ? null : buildProseView(nodes);
+}
+
+function markDescendants(
+  node: Element,
+  set: Set<Element>,
+  depth: number = 0,
+): void {
   /* istanbul ignore if -- defensive: prevents stack overflow from malicious HTML */
   if (depth > MAX_RECURSION_DEPTH) {
-    return
+    return;
   }
 
   for (const child of node.children) {
     if (child.type === "element") {
-      set.add(child)
-      markDescendants(child, set, depth + 1)
+      set.add(child);
+      markDescendants(child, set, depth + 1);
     }
   }
 }
 
 export function rehypePunctilio(
-  options: RehypePunctilioOptions = {}
+  options: RehypePunctilioOptions = {},
 ): Transformer<Root, Root> {
-  assertKnownOptionKeys(options, REHYPE_OPTION_KEYS, "rehypePunctilio")
+  assertKnownOptionKeys(options, REHYPE_OPTION_KEYS, "rehypePunctilio");
 
   const {
     skipTags,
@@ -646,61 +839,76 @@ export function rehypePunctilio(
     shouldSkipText,
     transformAllElements,
     ...transformOptions
-  } = options
+  } = options;
 
-  const { shouldSkip, isTransformable } = resolveCollectOptions({ skipTags, skipClasses, transformAllElements })
+  const { shouldSkip, isTransformable } = resolveCollectOptions({
+    skipTags,
+    skipClasses,
+    transformAllElements,
+  });
 
   // Allocate the per-element options object once; it's read-only inside
   // proseViewOf, so sharing across calls is safe and avoids a fresh
   // allocation per transformable element.
   const viewOptions: ProseViewOfOptions = shouldSkipText
     ? { shouldSkip, shouldSkipText }
-    : { shouldSkip }
+    : { shouldSkip };
 
   return (tree: Root) => {
     // Track transformed elements to avoid double-processing
-    const transformed = new Set<Element>()
+    const transformed = new Set<Element>();
 
     visitParents(tree, "element", (node) => {
       // Skip subtree if already transformed
       if (transformed.has(node)) {
-        return SKIP
+        return SKIP;
       }
 
       if (shouldSkip(node)) {
-        return SKIP
+        return SKIP;
       }
 
       // Collect and transform every prose unit in this subtree.
-      const units = collectProseUnitsImpl(node, shouldSkip, 0, transformed, isTransformable)
+      const units = collectProseUnitsImpl(
+        node,
+        shouldSkip,
+        0,
+        transformed,
+        isTransformable,
+      );
       for (const unit of units) {
         if (unit.kind === "element") {
           if (!transformed.has(unit.element)) {
             for (const view of proseViewsOf(unit.element, viewOptions)) {
-              transformView(view, transformOptions)
+              transformView(view, transformOptions);
             }
-            transformed.add(unit.element)
+            transformed.add(unit.element);
             // Mark all descendants as processed since their text was included
-            markDescendants(unit.element, transformed)
+            markDescendants(unit.element, transformed);
           }
         } else {
-          const { nodes, opaqueBefore } = flattenRunProse(unit.container, unit.children, shouldSkip, viewOptions)
+          const { nodes, opaqueBefore } = flattenRunProse(
+            unit.container,
+            unit.children,
+            shouldSkip,
+            viewOptions,
+          );
           for (const group of splitAtIndices(nodes, opaqueBefore)) {
-            transformView(buildProseView(group), transformOptions)
+            transformView(buildProseView(group), transformOptions);
           }
           // Mark the container so a later visit doesn't re-collect its runs,
           // and mark the run's inline-element members' subtrees.
-          transformed.add(unit.container)
+          transformed.add(unit.container);
           for (const child of unit.children) {
             if (child.type === "element") {
-              transformed.add(child)
-              markDescendants(child, transformed)
+              transformed.add(child);
+              markDescendants(child, transformed);
             }
           }
         }
       }
-    })
-  }
+    });
+  };
 }
 
-export default rehypePunctilio
+export default rehypePunctilio;

--- a/src/tests/apply-passes.test.ts
+++ b/src/tests/apply-passes.test.ts
@@ -1,71 +1,108 @@
-import type { Element } from "hast"
-import { h } from "hastscript"
+import type { Element } from "hast";
+import { h } from "hastscript";
 
-import { applyPasses, getTextContent, type PassEntry } from "../rehype.js"
-import { definePass, makeProsePass, type ProseView } from "../prose-view.js"
-import { hyphenReplace } from "../dashes.js"
-import { UNICODE_SYMBOLS } from "../constants.js"
+import {
+  applyPasses,
+  collectProseUnits,
+  getTextContent,
+  type PassEntry,
+} from "../rehype.js";
+import { definePass, makeProsePass, type ProseView } from "../prose-view.js";
+import { hyphenReplace } from "../dashes.js";
+import { UNICODE_SYMBOLS } from "../constants.js";
 
-const isAnchor = (node: Element): boolean => node.tagName === "a"
+const isAnchor = (node: Element): boolean => node.tagName === "a";
 
 describe("applyPasses", () => {
   it("runs passes in order, each seeing the previous pass's committed output", () => {
-    const element = h("p", "a")
-    applyPasses(element, [definePass(/a/g, "b"), definePass(/b/g, "c")])
-    expect(getTextContent(element)).toBe("c")
-  })
+    const element = h("p", "a");
+    applyPasses(element, [definePass(/a/g, "b"), definePass(/b/g, "c")]);
+    expect(getTextContent(element)).toBe("c");
+  });
 
   it("is order-sensitive: swapping the passes changes the result", () => {
-    const element = h("p", "a")
-    applyPasses(element, [definePass(/b/g, "c"), definePass(/a/g, "b")])
-    expect(getTextContent(element)).toBe("b")
-  })
+    const element = h("p", "a");
+    applyPasses(element, [definePass(/b/g, "c"), definePass(/a/g, "b")]);
+    expect(getTextContent(element)).toBe("b");
+  });
 
   it("composes with built-in passes across element boundaries", () => {
-    const element = h("p", ["word -- ", h("em", "word")])
-    applyPasses(element, [hyphenReplace])
-    expect(getTextContent(element)).toBe(`word${UNICODE_SYMBOLS.EM_DASH}word`)
-  })
+    const element = h("p", ["word -- ", h("em", "word")]);
+    applyPasses(element, [hyphenReplace]);
+    expect(getTextContent(element)).toBe(`word${UNICODE_SYMBOLS.EM_DASH}word`);
+  });
 
   it("applies a per-entry shouldSkip on top of the base options", () => {
-    const element = h("p", ["1/2 and ", h("a", "1/2")])
-    const fractions = definePass(/1\/2/g, "½")
-    applyPasses(element, [{ pass: fractions, shouldSkip: isAnchor }])
-    expect(getTextContent(element)).toBe("½ and 1/2")
-  })
+    const element = h("p", ["1/2 and ", h("a", "1/2")]);
+    const fractions = definePass(/1\/2/g, "½");
+    applyPasses(element, [{ pass: fractions, shouldSkip: isAnchor }]);
+    expect(getTextContent(element)).toBe("½ and 1/2");
+  });
+
+  it("formats a run's loose text and inline elements without merging block children", () => {
+    const block = h("p", "b");
+    const em = h("em", "b");
+    const container = h("blockquote", [block, "b ", em]) as Element;
+    const run = collectProseUnits(container).find((u) => u.kind === "run");
+    if (!run || run.kind !== "run") throw new Error("expected a run unit");
+    applyPasses(run, [definePass(/b/g, "X")]);
+    // The run's loose text and its inline element transform; the block child
+    // stays untouched (no cross-block merge).
+    expect(getTextContent(block)).toBe("b");
+    expect(getTextContent(em)).toBe("X");
+    const loose = container.children[1];
+    expect(loose.type === "text" ? loose.value : null).toBe("X ");
+  });
+
+  it("formats an element ProseUnit like the bare element", () => {
+    const element = h("p", "a");
+    applyPasses({ kind: "element", element }, [definePass(/a/g, "b")]);
+    expect(getTextContent(element)).toBe("b");
+  });
+
+  it("is a no-op on a run unit with no transformable text", () => {
+    const container = h("div", [h("p", "block")]) as Element;
+    applyPasses({ kind: "run", container, children: [] }, [
+      definePass(/o/g, "0"),
+    ]);
+    expect(getTextContent(container)).toBe("block");
+  });
 
   it("builds a fresh view after an entry with different predicates", () => {
-    const element = h("p", ["1/2 and ", h("a", "1/2 a-cat")])
-    const fractions = definePass(/1\/2/g, "½")
-    const dehyphenate = definePass(/-/g, " ")
+    const element = h("p", ["1/2 and ", h("a", "1/2 a-cat")]);
+    const fractions = definePass(/1\/2/g, "½");
+    const dehyphenate = definePass(/-/g, " ");
     // The second entry's view must include the <a> text the first skipped,
     // and must be built after the first pass committed.
-    applyPasses(element, [{ pass: fractions, shouldSkip: isAnchor }, dehyphenate])
-    expect(getTextContent(element)).toBe("½ and 1/2 a cat")
-  })
+    applyPasses(element, [
+      { pass: fractions, shouldSkip: isAnchor },
+      dehyphenate,
+    ]);
+    expect(getTextContent(element)).toBe("½ and 1/2 a cat");
+  });
 
   it("reuses the view across consecutive entries with identical predicates", () => {
-    const element = h("p", ["x and ", h("a", "x")])
+    const element = h("p", ["x and ", h("a", "x")]);
     const entries: readonly PassEntry[] = [
       { pass: definePass(/x/g, "y"), shouldSkip: isAnchor },
       { pass: definePass(/y/g, "z"), shouldSkip: isAnchor },
-    ]
-    applyPasses(element, entries)
-    expect(getTextContent(element)).toBe("z and x")
-  })
+    ];
+    applyPasses(element, entries);
+    expect(getTextContent(element)).toBe("z and x");
+  });
 
   it("merges the base shouldSkip with a per-entry shouldSkip", () => {
-    const element = h("p", ["a ", h("a", "a"), " ", h("em", "a")])
+    const element = h("p", ["a ", h("a", "a"), " ", h("em", "a")]);
     applyPasses(
       element,
       [{ pass: definePass(/a/g, "b"), shouldSkip: isAnchor }],
       { shouldSkip: (node) => node.tagName === "em" },
-    )
-    expect(getTextContent(element)).toBe("b a a")
-  })
+    );
+    expect(getTextContent(element)).toBe("b a a");
+  });
 
   it("merges the base shouldSkipText with a per-entry shouldSkipText", () => {
-    const element = h("p", ["aa ", "ab ", "ba"])
+    const element = h("p", ["aa ", "ab ", "ba"]);
     applyPasses(
       element,
       [
@@ -75,60 +112,63 @@ describe("applyPasses", () => {
         },
       ],
       { shouldSkipText: (textNode) => textNode.value.startsWith("ab") },
-    )
-    expect(getTextContent(element)).toBe("xx ab ba")
-  })
+    );
+    expect(getTextContent(element)).toBe("xx ab ba");
+  });
 
   it("applies a base predicate alone when the entry has none", () => {
-    const element = h("p", ["a ", h("a", "a")])
-    applyPasses(element, [definePass(/a/g, "b")], { shouldSkip: isAnchor })
-    expect(getTextContent(element)).toBe("b a")
-  })
+    const element = h("p", ["a ", h("a", "a")]);
+    applyPasses(element, [definePass(/a/g, "b")], { shouldSkip: isAnchor });
+    expect(getTextContent(element)).toBe("b a");
+  });
 
   it("is a no-op for an empty pass list", () => {
-    const element = h("p", "a")
-    applyPasses(element, [])
-    expect(getTextContent(element)).toBe("a")
-  })
+    const element = h("p", "a");
+    applyPasses(element, []);
+    expect(getTextContent(element)).toBe("a");
+  });
 
   it("skips entries whose predicates leave no transformable text", () => {
-    const element = h("p", h("a", "a"))
-    const skipped = definePass(/a/g, "b")
-    applyPasses(element, [{ pass: skipped, shouldSkip: isAnchor }, definePass(/a/g, "c")])
-    expect(getTextContent(element)).toBe("c")
-  })
+    const element = h("p", h("a", "a"));
+    const skipped = definePass(/a/g, "b");
+    applyPasses(element, [
+      { pass: skipped, shouldSkip: isAnchor },
+      definePass(/a/g, "c"),
+    ]);
+    expect(getTextContent(element)).toBe("c");
+  });
 
   it("does nothing for an element with no text nodes", () => {
-    const element = h("p")
-    expect(() => applyPasses(element, [definePass(/a/g, "b")])).not.toThrow()
-    expect(getTextContent(element)).toBe("")
-  })
+    const element = h("p");
+    expect(() => applyPasses(element, [definePass(/a/g, "b")])).not.toThrow();
+    expect(getTextContent(element)).toBe("");
+  });
 
   // A pass receives one view spanning the whole element, with a boundary
   // recorded at each opaque gap (a removed skipped element) — not a separate
   // view per gap-delimited segment. This keeps boundary-aware passes able to
   // act across an inline-element boundary instead of seeing isolated fragments.
-  const skipCode = (node: Element): boolean => node.tagName === "code"
+  const skipCode = (node: Element): boolean => node.tagName === "code";
 
   it("hands each pass one spanning view with a boundary at an opaque gap", () => {
-    const element = h("p", ["a", h("code", "x"), "/", h("code", "y"), "b"])
-    const seen: Array<{ text: string; boundaryAtSlash: boolean }> = []
+    const element = h("p", ["a", h("code", "x"), "/", h("code", "y"), "b"]);
+    const seen: Array<{ text: string; boundaryAtSlash: boolean }> = [];
     const capture = makeProsePass((view: ProseView) => {
-      const slash = view.text.indexOf("/")
-      seen.push({ text: view.text, boundaryAtSlash: view.hasBoundary(slash) })
-    })
-    applyPasses(element, [capture], { shouldSkip: skipCode })
-    expect(seen).toEqual([{ text: "a/b", boundaryAtSlash: true }])
-  })
+      const slash = view.text.indexOf("/");
+      seen.push({ text: view.text, boundaryAtSlash: view.hasBoundary(slash) });
+    });
+    applyPasses(element, [capture], { shouldSkip: skipCode });
+    expect(seen).toEqual([{ text: "a/b", boundaryAtSlash: true }]);
+  });
 
   it("lets a boundary-aware pass act across an opaque gap", () => {
-    const element = h("p", ["a", h("code", "x"), "/", h("code", "y"), "b"])
+    const element = h("p", ["a", h("code", "x"), "/", h("code", "y"), "b"]);
     // Pads the slash only when it can see a following character — reachable
     // only if the code-separated neighbors share one spanning view.
     const padSlash = definePass(/\//g, (match, view) =>
       view.text[match.index + 1] !== undefined ? " / " : "/",
-    )
-    applyPasses(element, [padSlash], { shouldSkip: skipCode })
-    expect(getTextContent(element)).toBe("ax / yb")
-  })
-})
+    );
+    applyPasses(element, [padSlash], { shouldSkip: skipCode });
+    expect(getTextContent(element)).toBe("ax / yb");
+  });
+});

--- a/src/tests/rehype.test.ts
+++ b/src/tests/rehype.test.ts
@@ -1,11 +1,12 @@
-import type { Element, ElementContent, Parent, Root, Text } from "hast"
-import { h } from "hastscript"
-import { unified } from "unified"
-import rehypeParse from "rehype-parse"
-import rehypeStringify from "rehype-stringify"
+import type { Element, ElementContent, Parent, Root, Text } from "hast";
+import { h } from "hastscript";
+import { unified } from "unified";
+import rehypeParse from "rehype-parse";
+import rehypeStringify from "rehype-stringify";
 import {
   assertSmartQuotesMatch,
   collectProseBlocks,
+  collectProseUnits,
   flattenTextNodes,
   getFirstTextNode,
   getTextContent,
@@ -13,8 +14,8 @@ import {
   proseViewsOf,
   rehypePunctilio,
   type RehypePunctilioOptions,
-} from "../rehype.js"
-import { UNICODE_SYMBOLS } from "../constants.js"
+} from "../rehype.js";
+import { UNICODE_SYMBOLS } from "../constants.js";
 
 const {
   LEFT_DOUBLE_QUOTE: LDQ,
@@ -27,15 +28,18 @@ const {
   NOT_EQUAL,
   COPYRIGHT,
   FRACTION_1_2,
-} = UNICODE_SYMBOLS
+} = UNICODE_SYMBOLS;
 
-async function processHtml(html: string, options?: RehypePunctilioOptions): Promise<string> {
+async function processHtml(
+  html: string,
+  options?: RehypePunctilioOptions,
+): Promise<string> {
   const result = await unified()
     .use(rehypeParse, { fragment: true })
     .use(rehypePunctilio, options)
     .use(rehypeStringify)
-    .process(html)
-  return String(result)
+    .process(html);
+  return String(result);
 }
 
 describe("rehypePunctilio", () => {
@@ -43,101 +47,188 @@ describe("rehypePunctilio", () => {
     it.each(["fragment", "emphasisMarker", "fraction"])(
       'rejects unknown option key "%s" at plugin construction',
       (key) => {
-        expect(() => rehypePunctilio({ [key]: true } as never))
-          .toThrow(`Unknown option "${key}" for rehypePunctilio`)
+        expect(() => rehypePunctilio({ [key]: true } as never)).toThrow(
+          `Unknown option "${key}" for rehypePunctilio`,
+        );
       },
-    )
-  })
+    );
+  });
 
   describe("basic transformations", () => {
     it.each([
-      ["quotes", '<p>"Hello," she said.</p>', `<p>${LDQ}Hello,${RDQ} she said.</p>`],
+      [
+        "quotes",
+        '<p>"Hello," she said.</p>',
+        `<p>${LDQ}Hello,${RDQ} she said.</p>`,
+      ],
       ["apostrophes", "<p>It's a test.</p>", `<p>It${RSQ}s a test.</p>`],
-      ["em dashes", "<p>Wait -- here it comes.</p>", `<p>Wait${EM_DASH}here it comes.</p>`],
+      [
+        "em dashes",
+        "<p>Wait -- here it comes.</p>",
+        `<p>Wait${EM_DASH}here it comes.</p>`,
+      ],
       ["en dashes", "<p>Pages 1-5</p>", `<p>Pages 1${EN_DASH}5</p>`],
       ["ellipses", "<p>Wait...</p>", `<p>Wait${ELLIPSIS}</p>`],
       ["multiplication", "<p>5x5</p>", `<p>5${MULTIPLICATION}5</p>`],
       ["math symbols", "<p>x != y</p>", `<p>x ${NOT_EQUAL} y</p>`],
       ["legal symbols", "<p>(c) 2024</p>", `<p>${COPYRIGHT} 2024</p>`],
     ])("transforms %s", async (_name, html, expected) => {
-      expect(await processHtml(html, { nbsp: false })).toEqual(expected)
-    })
-  })
+      expect(await processHtml(html, { nbsp: false })).toEqual(expected);
+    });
+  });
 
   describe("expanded transformable elements", () => {
     it.each([
-      ["custom element", '<my-card>"hi" -- there</my-card>', `<my-card>${LDQ}hi${RDQ}${EM_DASH}there</my-card>`],
+      [
+        "custom element",
+        '<my-card>"hi" -- there</my-card>',
+        `<my-card>${LDQ}hi${RDQ}${EM_DASH}there</my-card>`,
+      ],
       ["title", '<title>"Hi"</title>', `<title>${LDQ}Hi${RDQ}</title>`],
       ["button", '<button>"Hi"</button>', `<button>${LDQ}Hi${RDQ}</button>`],
-      ["option", '<select><option>"Hi"</option></select>', `<select><option>${LDQ}Hi${RDQ}</option></select>`],
+      [
+        "option",
+        '<select><option>"Hi"</option></select>',
+        `<select><option>${LDQ}Hi${RDQ}</option></select>`,
+      ],
       ["output", '<output>"Hi"</output>', `<output>${LDQ}Hi${RDQ}</output>`],
     ])("transforms %s text", async (_name, html, expected) => {
-      expect(await processHtml(html, { nbsp: false })).toEqual(expected)
-    })
+      expect(await processHtml(html, { nbsp: false })).toEqual(expected);
+    });
 
     it("skipTags wins over the custom-element predicate", async () => {
-      expect(await processHtml('<my-card>"hi" -- there</my-card>', { skipTags: ["my-card"] }))
-        .toEqual('<my-card>"hi" -- there</my-card>')
-    })
-  })
+      expect(
+        await processHtml('<my-card>"hi" -- there</my-card>', {
+          skipTags: ["my-card"],
+        }),
+      ).toEqual('<my-card>"hi" -- there</my-card>');
+    });
+  });
 
   describe("transformAllElements (inverted mode)", () => {
     it("default allowlist leaves non-allowlisted elements untouched", async () => {
-      expect(await processHtml('<form>"hi" -- there</form>', { nbsp: false }))
-        .toEqual('<form>"hi" -- there</form>')
-    })
+      expect(
+        await processHtml('<form>"hi" -- there</form>', { nbsp: false }),
+      ).toEqual('<form>"hi" -- there</form>');
+    });
 
     it.each([
-      ["non-allowlisted element", '<form>"hi" -- there</form>', `<form>${LDQ}hi${RDQ}${EM_DASH}there</form>`],
-      ["still transforms allowlisted prose", '<p>"hi"</p>', `<p>${LDQ}hi${RDQ}</p>`],
+      [
+        "non-allowlisted element",
+        '<form>"hi" -- there</form>',
+        `<form>${LDQ}hi${RDQ}${EM_DASH}there</form>`,
+      ],
+      [
+        "still transforms allowlisted prose",
+        '<p>"hi"</p>',
+        `<p>${LDQ}hi${RDQ}</p>`,
+      ],
     ])("transforms %s", async (_name, html, expected) => {
-      expect(await processHtml(html, { nbsp: false, transformAllElements: true })).toEqual(expected)
-    })
+      expect(
+        await processHtml(html, { nbsp: false, transformAllElements: true }),
+      ).toEqual(expected);
+    });
 
     it.each([
       ["textarea value", '<textarea>"hi" -- there</textarea>'],
-      ["input is void with no text", '<input>'],
+      ["input is void with no text", "<input>"],
     ])("skips %s in inverted mode", async (_name, html) => {
-      expect(await processHtml(html, { nbsp: false, transformAllElements: true })).toEqual(html)
-    })
+      expect(
+        await processHtml(html, { nbsp: false, transformAllElements: true }),
+      ).toEqual(html);
+    });
 
     it("keeps textarea literal even inside a transformable parent", async () => {
-      expect(await processHtml('<div>"hi"<textarea>"x"</textarea></div>', { nbsp: false, transformAllElements: true }))
-        .toEqual(`<div>${LDQ}hi${RDQ}<textarea>"x"</textarea></div>`)
-    })
+      expect(
+        await processHtml('<div>"hi"<textarea>"x"</textarea></div>', {
+          nbsp: false,
+          transformAllElements: true,
+        }),
+      ).toEqual(`<div>${LDQ}hi${RDQ}<textarea>"x"</textarea></div>`);
+    });
 
     it("skips select but still transforms its option children", async () => {
-      expect(await processHtml('<select><option>"Hi"</option></select>', { nbsp: false, transformAllElements: true }))
-        .toEqual(`<select><option>${LDQ}Hi${RDQ}</option></select>`)
-    })
+      expect(
+        await processHtml('<select><option>"Hi"</option></select>', {
+          nbsp: false,
+          transformAllElements: true,
+        }),
+      ).toEqual(`<select><option>${LDQ}Hi${RDQ}</option></select>`);
+    });
 
     it("skipTags still wins in inverted mode", async () => {
-      expect(await processHtml('<form>"hi" -- there</form>', { nbsp: false, transformAllElements: true, skipTags: ["form"] }))
-        .toEqual('<form>"hi" -- there</form>')
-    })
+      expect(
+        await processHtml('<form>"hi" -- there</form>', {
+          nbsp: false,
+          transformAllElements: true,
+          skipTags: ["form"],
+        }),
+      ).toEqual('<form>"hi" -- there</form>');
+    });
 
     it("skipClasses still wins in inverted mode", async () => {
-      expect(await processHtml('<form class="no-formatting">"hi"</form>', { nbsp: false, transformAllElements: true, skipClasses: ["no-formatting"] }))
-        .toEqual('<form class="no-formatting">"hi"</form>')
-    })
-  })
+      expect(
+        await processHtml('<form class="no-formatting">"hi"</form>', {
+          nbsp: false,
+          transformAllElements: true,
+          skipClasses: ["no-formatting"],
+        }),
+      ).toEqual('<form class="no-formatting">"hi"</form>');
+    });
+  });
 
   describe("HTML structure preservation", () => {
     it.each([
-      ["nested elements", '<p><em>"Hello,"</em> she said.</p>', `<p><em>${LDQ}Hello,${RDQ}</em> she said.</p>`],
-      ["text spanning elements", '<p><em>"Wait</em>..."</p>', `<p><em>${LDQ}Wait</em>${ELLIPSIS}${RDQ}</p>`],
-      ["deeply nested", '<div><p><span><strong>"Hello"</strong></span></p></div>', `<div><p><span><strong>${LDQ}Hello${RDQ}</strong></span></p></div>`],
-      ["attributes", '<p class="intro" id="first">"Hello"</p>', `<p class="intro" id="first">${LDQ}Hello${RDQ}</p>`],
+      [
+        "nested elements",
+        '<p><em>"Hello,"</em> she said.</p>',
+        `<p><em>${LDQ}Hello,${RDQ}</em> she said.</p>`,
+      ],
+      [
+        "text spanning elements",
+        '<p><em>"Wait</em>..."</p>',
+        `<p><em>${LDQ}Wait</em>${ELLIPSIS}${RDQ}</p>`,
+      ],
+      [
+        "deeply nested",
+        '<div><p><span><strong>"Hello"</strong></span></p></div>',
+        `<div><p><span><strong>${LDQ}Hello${RDQ}</strong></span></p></div>`,
+      ],
+      [
+        "attributes",
+        '<p class="intro" id="first">"Hello"</p>',
+        `<p class="intro" id="first">${LDQ}Hello${RDQ}</p>`,
+      ],
       // Regression: inline-only containers must share transformation context
-      ["quotes across inline-only children", '<p><em>"Hello</em><span>, world"</span></p>', `<p><em>${LDQ}Hello</em><span>, world${RDQ}</span></p>`],
-      ["dash across inline-only children", '<p><em>pages 1</em><span>-5</span></p>', `<p><em>pages 1</em><span>${EN_DASH}5</span></p>`],
-      ["dialog with text", '<dialog>"Hello" -- world</dialog>', `<dialog>${LDQ}Hello${RDQ}${EM_DASH}world</dialog>`],
-      ["details with direct text", '<details>"Hello" -- world</details>', `<details>${LDQ}Hello${RDQ}${EM_DASH}world</details>`],
-      ["details with summary", '<details><summary>"Hello"</summary></details>', `<details><summary>${LDQ}Hello${RDQ}</summary></details>`],
+      [
+        "quotes across inline-only children",
+        '<p><em>"Hello</em><span>, world"</span></p>',
+        `<p><em>${LDQ}Hello</em><span>, world${RDQ}</span></p>`,
+      ],
+      [
+        "dash across inline-only children",
+        "<p><em>pages 1</em><span>-5</span></p>",
+        `<p><em>pages 1</em><span>${EN_DASH}5</span></p>`,
+      ],
+      [
+        "dialog with text",
+        '<dialog>"Hello" -- world</dialog>',
+        `<dialog>${LDQ}Hello${RDQ}${EM_DASH}world</dialog>`,
+      ],
+      [
+        "details with direct text",
+        '<details>"Hello" -- world</details>',
+        `<details>${LDQ}Hello${RDQ}${EM_DASH}world</details>`,
+      ],
+      [
+        "details with summary",
+        '<details><summary>"Hello"</summary></details>',
+        `<details><summary>${LDQ}Hello${RDQ}</summary></details>`,
+      ],
     ])("preserves %s", async (_name, html, expected) => {
-      expect(await processHtml(html, { nbsp: false })).toEqual(expected)
-    })
-  })
+      expect(await processHtml(html, { nbsp: false })).toEqual(expected);
+    });
+  });
 
   describe("quotes do not pair across block boundaries", () => {
     // Whitespace text nodes between block siblings must not merge the blocks
@@ -145,12 +236,11 @@ describe("rehypePunctilio", () => {
     // see the next paragraph's opening `"` and flip to an opener.
     it("closes an interrupted line ending before a new quoted paragraph", async () => {
       const html =
-        '<blockquote>\n<p>Riesz spoke. "We make them do analysis, because they deserve --"</p>\n<p>"Frigyes, some might do that."</p>\n</blockquote>'
-      const expected =
-        `<blockquote>\n<p>Riesz spoke. ${LDQ}We make them do analysis, because they deserve${EM_DASH}${RDQ}</p>\n<p>${LDQ}Frigyes, some might do that.${RDQ}</p>\n</blockquote>`
-      expect(await processHtml(html, { nbsp: false })).toEqual(expected)
-    })
-  })
+        '<blockquote>\n<p>Riesz spoke. "We make them do analysis, because they deserve --"</p>\n<p>"Frigyes, some might do that."</p>\n</blockquote>';
+      const expected = `<blockquote>\n<p>Riesz spoke. ${LDQ}We make them do analysis, because they deserve${EM_DASH}${RDQ}</p>\n<p>${LDQ}Frigyes, some might do that.${RDQ}</p>\n</blockquote>`;
+      expect(await processHtml(html, { nbsp: false })).toEqual(expected);
+    });
+  });
 
   describe("loose inline text among block children", () => {
     // A container with both direct/inline text and block-level children must
@@ -158,7 +248,11 @@ describe("rehypePunctilio", () => {
     // merging the loose text with a block child's text across the boundary.
     it.each([
       // Regression: the div's "5" must not pair with the paragraph's "x 3".
-      ["digit not merged with block child", "<div>5<p>x 3</p></div>", "<div>5<p>x 3</p></div>"],
+      [
+        "digit not merged with block child",
+        "<div>5<p>x 3</p></div>",
+        "<div>5<p>x 3</p></div>",
+      ],
       // Regression: quotes open/close within their own block, not across it.
       [
         "quotes stay within their block",
@@ -172,154 +266,301 @@ describe("rehypePunctilio", () => {
         `<div>a <em>1</em>${EN_DASH}5 done<ul><li>item</li></ul></div>`,
       ],
     ])("%s", async (_name, html, expected) => {
-      expect(await processHtml(html, { nbsp: false })).toEqual(expected)
-    })
+      expect(await processHtml(html, { nbsp: false })).toEqual(expected);
+    });
 
     it("applies shouldSkipText within a loose run, honoring the container ancestor", async () => {
       const skipInSpan = (_t: Text, ancestors: readonly Element[]) =>
-        ancestors.some((a) => a.tagName === "span")
+        ancestors.some((a) => a.tagName === "span");
       // The loose text transforms (ancestors = [div]); the span's text is
       // skipped (ancestors = [div, span]).
       expect(
-        await processHtml('<div>loose "text" <span>keep"x"</span><p>"para"</p></div>', {
-          nbsp: false,
-          shouldSkipText: skipInSpan,
-        }),
-      ).toEqual(`<div>loose ${LDQ}text${RDQ} <span>keep"x"</span><p>${LDQ}para${RDQ}</p></div>`)
-    })
+        await processHtml(
+          '<div>loose "text" <span>keep"x"</span><p>"para"</p></div>',
+          {
+            nbsp: false,
+            shouldSkipText: skipInSpan,
+          },
+        ),
+      ).toEqual(
+        `<div>loose ${LDQ}text${RDQ} <span>keep"x"</span><p>${LDQ}para${RDQ}</p></div>`,
+      );
+    });
 
     it("leaves a loose run untouched when shouldSkipText excludes all its text", async () => {
       const skipInSpan = (_t: Text, ancestors: readonly Element[]) =>
-        ancestors.some((a) => a.tagName === "span")
+        ancestors.some((a) => a.tagName === "span");
       expect(
         await processHtml('<div><span>only"x"</span><p>"para"</p></div>', {
           nbsp: false,
           shouldSkipText: skipInSpan,
         }),
-      ).toEqual(`<div><span>only"x"</span><p>${LDQ}para${RDQ}</p></div>`)
-    })
-  })
+      ).toEqual(`<div><span>only"x"</span><p>${LDQ}para${RDQ}</p></div>`);
+    });
+  });
 
   describe("opaque inline content is an impassable gap", () => {
     // Content removed from the flattened text (a skipped element with content,
     // an image, or other atomic inline node) visually separates its neighbors,
     // so passes must not treat the surrounding text as adjacent.
     it.each([
-      ["skipped element blocks multiplication", "<p>5<code>c</code>x 3</p>", "<p>5<code>c</code>x 3</p>"],
-      ["image blocks multiplication", '<p>5<img src="a">x 3</p>', '<p>5<img src="a">x 3</p>'],
-      ["skipped element blocks a numeric range", "<p>1<code>c</code>-5</p>", `<p>1<code>c</code>${UNICODE_SYMBOLS.MINUS}5</p>`],
-      ["two gaps keep three independent segments", '<p>1<img src="a">5<code>c</code>x 3</p>', '<p>1<img src="a">5<code>c</code>x 3</p>'],
+      [
+        "skipped element blocks multiplication",
+        "<p>5<code>c</code>x 3</p>",
+        "<p>5<code>c</code>x 3</p>",
+      ],
+      [
+        "image blocks multiplication",
+        '<p>5<img src="a">x 3</p>',
+        '<p>5<img src="a">x 3</p>',
+      ],
+      [
+        "skipped element blocks a numeric range",
+        "<p>1<code>c</code>-5</p>",
+        `<p>1<code>c</code>${UNICODE_SYMBOLS.MINUS}5</p>`,
+      ],
+      [
+        "two gaps keep three independent segments",
+        '<p>1<img src="a">5<code>c</code>x 3</p>',
+        '<p>1<img src="a">5<code>c</code>x 3</p>',
+      ],
       // An empty skipped element renders nothing, so its neighbors stay adjacent.
-      ["empty skipped element does not block", "<p>5<code></code>x5</p>", `<p>5<code></code>${MULTIPLICATION}5</p>`],
+      [
+        "empty skipped element does not block",
+        "<p>5<code></code>x5</p>",
+        `<p>5<code></code>${MULTIPLICATION}5</p>`,
+      ],
       // Leading opaque content has no left neighbor, so it never splits.
-      ["leading opaque content does not split", '<p><img src="a">5x5</p>', `<p><img src="a">5${MULTIPLICATION}5</p>`],
+      [
+        "leading opaque content does not split",
+        '<p><img src="a">5x5</p>',
+        `<p><img src="a">5${MULTIPLICATION}5</p>`,
+      ],
     ])("%s", async (_name, html, expected) => {
-      expect(await processHtml(html, { nbsp: false })).toEqual(expected)
-    })
+      expect(await processHtml(html, { nbsp: false })).toEqual(expected);
+    });
 
     it("skipped-text nodes act as an opaque gap between their neighbors", async () => {
       // The skipped "MID" text separates "5" from "x5", so no × forms across it.
-      const skipMid = (t: Text) => t.value === "MID"
+      const skipMid = (t: Text) => t.value === "MID";
       expect(
-        await processHtml("<p>5<span>MID</span>x5</p>", { nbsp: false, shouldSkipText: skipMid }),
-      ).toEqual("<p>5<span>MID</span>x5</p>")
-    })
-  })
+        await processHtml("<p>5<span>MID</span>x5</p>", {
+          nbsp: false,
+          shouldSkipText: skipMid,
+        }),
+      ).toEqual("<p>5<span>MID</span>x5</p>");
+    });
+  });
 
   describe("dashes across element boundaries", () => {
     it.each([
-      ["multi-segment number preserved", "<p>1-<em>2</em>-3</p>", "<p>1-<em>2</em>-3</p>"],
-      ["model name preserved", "<p><em>GPT</em>-3</p>", "<p><em>GPT</em>-3</p>"],
-      ["simple range still converts", "<p>pages <em>1</em>-5</p>", `<p>pages <em>1</em>${EN_DASH}5</p>`],
-      ["genuine negative at element start", "<p><em>-5</em> degrees</p>", `<p><em>${UNICODE_SYMBOLS.MINUS}5</em> degrees</p>`],
+      [
+        "multi-segment number preserved",
+        "<p>1-<em>2</em>-3</p>",
+        "<p>1-<em>2</em>-3</p>",
+      ],
+      [
+        "model name preserved",
+        "<p><em>GPT</em>-3</p>",
+        "<p><em>GPT</em>-3</p>",
+      ],
+      [
+        "simple range still converts",
+        "<p>pages <em>1</em>-5</p>",
+        `<p>pages <em>1</em>${EN_DASH}5</p>`,
+      ],
+      [
+        "genuine negative at element start",
+        "<p><em>-5</em> degrees</p>",
+        `<p><em>${UNICODE_SYMBOLS.MINUS}5</em> degrees</p>`,
+      ],
       // Regression: trailing space after a skipped element must survive em-dash conversion.
       // The space is the next text node's leading boundary, not whitespace around the dash.
-      ["em-dash preserves space after skip element", "<p>a - <code>x</code> b</p>", `<p>a${EM_DASH}<code>x</code> b</p>`],
+      [
+        "em-dash preserves space after skip element",
+        "<p>a - <code>x</code> b</p>",
+        `<p>a${EM_DASH}<code>x</code> b</p>`,
+      ],
       // Regression: a sentence-final period before a skipped element must not be
       // swallowed into an ellipsis sequence that lives in the next text node.
-      ["ellipsis after skip element does not eat preceding period", "<p>a. <code>x</code>... b</p>", `<p>a. <code>x</code>${ELLIPSIS} b</p>`],
+      [
+        "ellipsis after skip element does not eat preceding period",
+        "<p>a. <code>x</code>... b</p>",
+        `<p>a. <code>x</code>${ELLIPSIS} b</p>`,
+      ],
       // Regression: a math operator split across an element boundary must
       // preserve the separator so transformTextNodes doesn't throw.
-      ["math operator split across element boundary", "<p>x <em>!</em>= y</p>", `<p>x <em>${NOT_EQUAL}</em> y</p>`],
+      [
+        "math operator split across element boundary",
+        "<p>x <em>!</em>= y</p>",
+        `<p>x <em>${NOT_EQUAL}</em> y</p>`,
+      ],
       // Arrow split across element boundary: dash pass must not em-dash the
       // `-`, then the arrows pass converts the whole shape. The match starts
       // in the first text node, so the arrow lands there and the em empties.
-      ["right arrow split across element boundary", "<p>foo -<em>></em> bar</p>", `<p>foo ${UNICODE_SYMBOLS.ARROW_RIGHT}<em></em> bar</p>`],
-      ["bidirectional arrow split across element boundary", "<p>foo <-<em>--</em>> bar</p>", `<p>foo ${UNICODE_SYMBOLS.ARROW_LEFT_RIGHT}<em></em> bar</p>`],
+      [
+        "right arrow split across element boundary",
+        "<p>foo -<em>></em> bar</p>",
+        `<p>foo ${UNICODE_SYMBOLS.ARROW_RIGHT}<em></em> bar</p>`,
+      ],
+      [
+        "bidirectional arrow split across element boundary",
+        "<p>foo <-<em>--</em>> bar</p>",
+        `<p>foo ${UNICODE_SYMBOLS.ARROW_LEFT_RIGHT}<em></em> bar</p>`,
+      ],
       // The math-symbol lookahead must see through the separator so split
       // `!==` is not misclassified as `!=`.
-      ["!== split across element boundary preserved", "<p>x !<em>=</em>= y</p>", "<p>x !<em>=</em>= y</p>"],
+      [
+        "!== split across element boundary preserved",
+        "<p>x !<em>=</em>= y</p>",
+        "<p>x !<em>=</em>= y</p>",
+      ],
     ])("%s", async (_name, html, expected) => {
-      expect(await processHtml(html, { nbsp: false })).toEqual(expected)
-    })
+      expect(await processHtml(html, { nbsp: false })).toEqual(expected);
+    });
 
     // Regression: 3+ punctuation chars split across 3+ text nodes must
     // preserve every separator so the ligature pass doesn't crash. Ligatures
     // are opt-in, so this test enables them explicitly.
     it("punctuation ligature across 3 text nodes preserves every separator", async () => {
-      const html = "<p>What<em>?</em>?<em>?</em> done</p>"
-      const expected = `<p>What<em>${UNICODE_SYMBOLS.DOUBLE_QUESTION}</em><em></em> done</p>`
-      expect(await processHtml(html, { nbsp: false, ligatures: true })).toEqual(expected)
-    })
-  })
+      const html = "<p>What<em>?</em>?<em>?</em> done</p>";
+      const expected = `<p>What<em>${UNICODE_SYMBOLS.DOUBLE_QUESTION}</em><em></em> done</p>`;
+      expect(await processHtml(html, { nbsp: false, ligatures: true })).toEqual(
+        expected,
+      );
+    });
+  });
 
   describe("skipped elements", () => {
-    it.each(["code", "pre", "script", "style", "kbd", "var", "samp", "template", "math", "svg"])(
-      "skips %s elements",
-      async (tag) => {
-        expect(await processHtml(`<${tag}>"Hello"</${tag}>`)).toEqual(`<${tag}>"Hello"</${tag}>`)
-      }
-    )
+    it.each([
+      "code",
+      "pre",
+      "script",
+      "style",
+      "kbd",
+      "var",
+      "samp",
+      "template",
+      "math",
+      "svg",
+    ])("skips %s elements", async (tag) => {
+      expect(await processHtml(`<${tag}>"Hello"</${tag}>`)).toEqual(
+        `<${tag}>"Hello"</${tag}>`,
+      );
+    });
 
     it("skips nested content inside code blocks", async () => {
-      expect(await processHtml('<pre><code>"Hello" -- test...</code></pre>')).toEqual(
-        '<pre><code>"Hello" -- test...</code></pre>'
-      )
-    })
+      expect(
+        await processHtml('<pre><code>"Hello" -- test...</code></pre>'),
+      ).toEqual('<pre><code>"Hello" -- test...</code></pre>');
+    });
 
     it("skips template content while transforming siblings", async () => {
-      expect(await processHtml('<div><p>"Hello"</p><template>"Untouched" -- raw</template></div>', { nbsp: false })).toEqual(
-        `<div><p>${LDQ}Hello${RDQ}</p><template>"Untouched" -- raw</template></div>`
-      )
-    })
+      expect(
+        await processHtml(
+          '<div><p>"Hello"</p><template>"Untouched" -- raw</template></div>',
+          { nbsp: false },
+        ),
+      ).toEqual(
+        `<div><p>${LDQ}Hello${RDQ}</p><template>"Untouched" -- raw</template></div>`,
+      );
+    });
 
     it("skips MathML content", async () => {
-      expect(await processHtml('<p>Formula: <math><mi>x</mi><mo>!=</mo><mn>5</mn></math></p>', { nbsp: false })).toEqual(
-        '<p>Formula: <math><mi>x</mi><mo>!=</mo><mn>5</mn></math></p>'
-      )
-    })
+      expect(
+        await processHtml(
+          "<p>Formula: <math><mi>x</mi><mo>!=</mo><mn>5</mn></math></p>",
+          { nbsp: false },
+        ),
+      ).toEqual("<p>Formula: <math><mi>x</mi><mo>!=</mo><mn>5</mn></math></p>");
+    });
 
     it("transforms siblings of skipped elements", async () => {
       expect(await processHtml('<p><code>code</code> "Hello"</p>')).toEqual(
-        `<p><code>code</code> ${LDQ}Hello${RDQ}</p>`
-      )
-    })
-  })
+        `<p><code>code</code> ${LDQ}Hello${RDQ}</p>`,
+      );
+    });
+  });
 
   describe("custom skip options", () => {
     it.each([
-      ["custom tags", '<custom-tag>"Hello"</custom-tag>', { skipTags: ["custom-tag"] }, '<custom-tag>"Hello"</custom-tag>'],
-      ["custom classes", '<p class="no-transform">"Hello"</p>', { skipClasses: ["no-transform"] }, '<p class="no-transform">"Hello"</p>'],
-      ["descendants of skip classes", '<div class="raw"><p>"Hello"</p></div>', { skipClasses: ["raw"] }, '<div class="raw"><p>"Hello"</p></div>'],
+      [
+        "custom tags",
+        '<custom-tag>"Hello"</custom-tag>',
+        { skipTags: ["custom-tag"] },
+        '<custom-tag>"Hello"</custom-tag>',
+      ],
+      [
+        "custom classes",
+        '<p class="no-transform">"Hello"</p>',
+        { skipClasses: ["no-transform"] },
+        '<p class="no-transform">"Hello"</p>',
+      ],
+      [
+        "descendants of skip classes",
+        '<div class="raw"><p>"Hello"</p></div>',
+        { skipClasses: ["raw"] },
+        '<div class="raw"><p>"Hello"</p></div>',
+      ],
     ])("skips %s", async (_name, html, options, expected) => {
-      expect(await processHtml(html, options)).toEqual(expected)
-    })
-  })
+      expect(await processHtml(html, options)).toEqual(expected);
+    });
+  });
 
   describe("transform options passthrough", () => {
     it.each([
-      ["punctuationStyle american", '<p>"Hello."</p>', { punctuationStyle: "american" as const, nbsp: false as const }, `<p>${LDQ}Hello.${RDQ}</p>`],
-      ["punctuationStyle british", '<p>"Hello."</p>', { punctuationStyle: "british" as const, nbsp: false as const }, `<p>${LDQ}Hello${RDQ}.</p>`],
-      ["dashStyle american", "<p>word - word</p>", { dashStyle: "american" as const, nbsp: false as const }, `<p>word${EM_DASH}word</p>`],
-      ["dashStyle british", "<p>word - word</p>", { dashStyle: "british" as const, nbsp: false as const }, `<p>word ${EN_DASH} word</p>`],
-      ["symbols enabled", "<p>5x5</p>", { symbols: true, nbsp: false as const }, `<p>5${MULTIPLICATION}5</p>`],
-      ["symbols disabled", "<p>5x5</p>", { symbols: false, nbsp: false as const }, "<p>5x5</p>"],
-      ["fractions enabled", "<p>1/2 cup</p>", { fractions: true, nbsp: false as const }, `<p>${FRACTION_1_2} cup</p>`],
-      ["fractions disabled", "<p>1/2 cup</p>", { fractions: false, nbsp: false as const }, "<p>1/2 cup</p>"],
+      [
+        "punctuationStyle american",
+        '<p>"Hello."</p>',
+        { punctuationStyle: "american" as const, nbsp: false as const },
+        `<p>${LDQ}Hello.${RDQ}</p>`,
+      ],
+      [
+        "punctuationStyle british",
+        '<p>"Hello."</p>',
+        { punctuationStyle: "british" as const, nbsp: false as const },
+        `<p>${LDQ}Hello${RDQ}.</p>`,
+      ],
+      [
+        "dashStyle american",
+        "<p>word - word</p>",
+        { dashStyle: "american" as const, nbsp: false as const },
+        `<p>word${EM_DASH}word</p>`,
+      ],
+      [
+        "dashStyle british",
+        "<p>word - word</p>",
+        { dashStyle: "british" as const, nbsp: false as const },
+        `<p>word ${EN_DASH} word</p>`,
+      ],
+      [
+        "symbols enabled",
+        "<p>5x5</p>",
+        { symbols: true, nbsp: false as const },
+        `<p>5${MULTIPLICATION}5</p>`,
+      ],
+      [
+        "symbols disabled",
+        "<p>5x5</p>",
+        { symbols: false, nbsp: false as const },
+        "<p>5x5</p>",
+      ],
+      [
+        "fractions enabled",
+        "<p>1/2 cup</p>",
+        { fractions: true, nbsp: false as const },
+        `<p>${FRACTION_1_2} cup</p>`,
+      ],
+      [
+        "fractions disabled",
+        "<p>1/2 cup</p>",
+        { fractions: false, nbsp: false as const },
+        "<p>1/2 cup</p>",
+      ],
     ])("respects %s", async (_name, html, options, expected) => {
-      expect(await processHtml(html, options)).toEqual(expected)
-    })
-  })
+      expect(await processHtml(html, options)).toEqual(expected);
+    });
+  });
 
   describe("complex scenarios", () => {
     it.each([
@@ -344,45 +585,61 @@ describe("rehypePunctilio", () => {
         `<ul><li>${LDQ}First${RDQ}${EM_DASH}important</li><li>Pages 1${EN_DASH}5</li></ul>`,
       ],
     ])("handles %s", async (_name, html, expected) => {
-      expect(await processHtml(html, { nbsp: false })).toEqual(expected)
-    })
-  })
+      expect(await processHtml(html, { nbsp: false })).toEqual(expected);
+    });
+  });
 
   describe("edge cases", () => {
     it.each([
       ["empty paragraphs", "<p></p>", "<p></p>"],
       ["whitespace-only", "<p>   </p>", "<p>   </p>"],
-      ["special characters", "<p>Café &amp; résumé</p>", "<p>Café &#x26; résumé</p>"],
+      [
+        "special characters",
+        "<p>Café &amp; résumé</p>",
+        "<p>Café &#x26; résumé</p>",
+      ],
       ["emoji", '<p>"Hello 👋"</p>', `<p>${LDQ}Hello 👋${RDQ}</p>`],
-      ["links", '<p><a href="https://example.com">"Link"</a></p>', `<p><a href="https://example.com">${LDQ}Link${RDQ}</a></p>`],
+      [
+        "links",
+        '<p><a href="https://example.com">"Link"</a></p>',
+        `<p><a href="https://example.com">${LDQ}Link${RDQ}</a></p>`,
+      ],
     ])("handles %s", async (_name, html, expected) => {
-      expect(await processHtml(html, { nbsp: false })).toEqual(expected)
-    })
+      expect(await processHtml(html, { nbsp: false })).toEqual(expected);
+    });
 
     it("is idempotent", async () => {
-      const html = '<p>"Hello," she said -- "it\'s nice."</p>'
-      const firstPass = await processHtml(html)
-      const secondPass = await processHtml(firstPass)
-      expect(secondPass).toBe(firstPass)
-    })
-  })
+      const html = '<p>"Hello," she said -- "it\'s nice."</p>';
+      const firstPass = await processHtml(html);
+      const secondPass = await processHtml(firstPass);
+      expect(secondPass).toBe(firstPass);
+    });
+  });
 
   describe("default export", () => {
     it("exports rehypePunctilio as default", async () => {
-      const { default: defaultExport } = await import("../rehype.js")
-      expect(defaultExport).toBe(rehypePunctilio)
-    })
-  })
+      const { default: defaultExport } = await import("../rehype.js");
+      expect(defaultExport).toBe(rehypePunctilio);
+    });
+  });
 
   describe("exported utilities", () => {
-    const ignoreNone = () => false
-    const ignoreCode = (el: Element) => el.tagName === "code"
+    const ignoreNone = () => false;
+    const ignoreCode = (el: Element) => el.tagName === "code";
 
     const fixtures = {
       empty: h("div", []) as Element,
       simple: h("p", "Hello, world!") as Element,
-      nested: h("div", ["This is ", h("em", "emphasized"), " text."]) as Element,
-      withCode: h("div", ["This is ", h("code", "ignored"), " text."]) as Element,
+      nested: h("div", [
+        "This is ",
+        h("em", "emphasized"),
+        " text.",
+      ]) as Element,
+      withCode: h("div", [
+        "This is ",
+        h("code", "ignored"),
+        " text.",
+      ]) as Element,
       emptyAndComment: h("div", [
         h("span"),
         { type: "comment", value: "comment" } as unknown as ElementContent,
@@ -392,149 +649,181 @@ describe("rehypePunctilio", () => {
         h("span", ["Level 2 ", h("em", "Level 3")]),
         " End",
       ]) as Element,
-    }
+    };
 
     describe("flattenTextNodes", () => {
       it.each([
         ["empty element", fixtures.empty, ignoreNone, []],
-        ["simple text", fixtures.simple, ignoreNone, [{ type: "text", value: "Hello, world!" }]],
-        ["nested elements", fixtures.nested, ignoreNone, [
-          { type: "text", value: "This is " },
-          { type: "text", value: "emphasized" },
-          { type: "text", value: " text." },
-        ]],
-        ["with ignored code", fixtures.withCode, ignoreCode, [
-          { type: "text", value: "This is " },
-          { type: "text", value: " text." },
-        ]],
+        [
+          "simple text",
+          fixtures.simple,
+          ignoreNone,
+          [{ type: "text", value: "Hello, world!" }],
+        ],
+        [
+          "nested elements",
+          fixtures.nested,
+          ignoreNone,
+          [
+            { type: "text", value: "This is " },
+            { type: "text", value: "emphasized" },
+            { type: "text", value: " text." },
+          ],
+        ],
+        [
+          "with ignored code",
+          fixtures.withCode,
+          ignoreCode,
+          [
+            { type: "text", value: "This is " },
+            { type: "text", value: " text." },
+          ],
+        ],
         ["empty spans and comments", fixtures.emptyAndComment, ignoreNone, []],
-        ["deeply nested", fixtures.deeplyNested, ignoreNone, [
-          { type: "text", value: "Level 1 " },
-          { type: "text", value: "Level 2 " },
-          { type: "text", value: "Level 3" },
-          { type: "text", value: " End" },
-        ]],
+        [
+          "deeply nested",
+          fixtures.deeplyNested,
+          ignoreNone,
+          [
+            { type: "text", value: "Level 1 " },
+            { type: "text", value: "Level 2 " },
+            { type: "text", value: "Level 3" },
+            { type: "text", value: " End" },
+          ],
+        ],
       ])("handles %s", (_name, node, skip, expected) => {
-        expect(flattenTextNodes(node, skip)).toEqual(expected)
-      })
+        expect(flattenTextNodes(node, skip)).toEqual(expected);
+      });
 
       it("extracts from single text node", () => {
-        const textNode: Text = { type: "text", value: "Hello" }
-        expect(flattenTextNodes(textNode, ignoreNone)).toEqual([textNode])
-      })
+        const textNode: Text = { type: "text", value: "Hello" };
+        expect(flattenTextNodes(textNode, ignoreNone)).toEqual([textNode]);
+      });
 
       it("stops at max recursion depth", () => {
-        let deep: Element = h("span", "deep") as Element
-        for (let i = 0; i < 1005; i++) deep = h("div", [deep]) as Element
-        expect(flattenTextNodes(deep, ignoreNone)).toHaveLength(0)
-      })
-    })
+        let deep: Element = h("span", "deep") as Element;
+        for (let i = 0; i < 1005; i++) deep = h("div", [deep]) as Element;
+        expect(flattenTextNodes(deep, ignoreNone)).toHaveLength(0);
+      });
+    });
 
     describe("proseViewsOf", () => {
       it("returns one view spanning the element when there is no opaque content", () => {
-        const element = h("p", ["hello ", h("em", "world")]) as Element
-        const views = proseViewsOf(element)
-        expect(views).toHaveLength(1)
-        expect(views[0].text).toBe("hello world")
-      })
+        const element = h("p", ["hello ", h("em", "world")]) as Element;
+        const views = proseViewsOf(element);
+        expect(views).toHaveLength(1);
+        expect(views[0].text).toBe("hello world");
+      });
 
       it("splits into one view per opaque-delimited segment", () => {
-        const element = h("p", ["1", h("code", "c"), "-5"]) as Element
-        const views = proseViewsOf(element, { shouldSkip: ignoreCode })
-        expect(views.map((v) => v.text)).toEqual(["1", "-5"])
-      })
+        const element = h("p", ["1", h("code", "c"), "-5"]) as Element;
+        const views = proseViewsOf(element, { shouldSkip: ignoreCode });
+        expect(views.map((v) => v.text)).toEqual(["1", "-5"]);
+      });
 
       it("returns no views for an element with no text", () => {
-        expect(proseViewsOf(h("div", []) as Element)).toEqual([])
-      })
-    })
+        expect(proseViewsOf(h("div", []) as Element)).toEqual([]);
+      });
+    });
 
     describe("proseViewOf", () => {
       it("builds a view over the element's text nodes", () => {
-        const element = h("p", ["hello ", h("em", "world")]) as Element
-        const view = proseViewOf(element)!
-        expect(view.text).toBe("hello world")
-        expect(view.boundaries).toEqual([6])
-      })
+        const element = h("p", ["hello ", h("em", "world")]) as Element;
+        const view = proseViewOf(element)!;
+        expect(view.text).toBe("hello world");
+        expect(view.boundaries).toEqual([6]);
+      });
 
       it("commits edits back onto the source text nodes", () => {
-        const element = h("p", ["pages 1", h("em", "-5")]) as Element
-        const view = proseViewOf(element)!
-        view.replace(7, 8, EN_DASH)
-        view.commit()
-        expect((element.children[0] as Text).value).toBe("pages 1")
-        expect(((element.children[1] as Element).children[0] as Text).value).toBe(`${EN_DASH}5`)
-      })
+        const element = h("p", ["pages 1", h("em", "-5")]) as Element;
+        const view = proseViewOf(element)!;
+        view.replace(7, 8, EN_DASH);
+        view.commit();
+        expect((element.children[0] as Text).value).toBe("pages 1");
+        expect(
+          ((element.children[1] as Element).children[0] as Text).value,
+        ).toBe(`${EN_DASH}5`);
+      });
 
       it("excludes text inside elements matching shouldSkip", () => {
-        const element = h("p", ["before ", h("code", "unchanged"), " after"]) as Element
-        const view = proseViewOf(element, { shouldSkip: ignoreCode })!
-        expect(view.text).toBe("before  after")
-        view.replace(0, 6, "BEFORE")
-        view.commit()
-        expect((element.children[0] as Text).value).toBe("BEFORE ")
-        expect(((element.children[1] as Element).children[0] as Text).value).toBe("unchanged")
-      })
+        const element = h("p", [
+          "before ",
+          h("code", "unchanged"),
+          " after",
+        ]) as Element;
+        const view = proseViewOf(element, { shouldSkip: ignoreCode })!;
+        expect(view.text).toBe("before  after");
+        view.replace(0, 6, "BEFORE");
+        view.commit();
+        expect((element.children[0] as Text).value).toBe("BEFORE ");
+        expect(
+          ((element.children[1] as Element).children[0] as Text).value,
+        ).toBe("unchanged");
+      });
 
       it("returns null for an element with no text nodes", () => {
-        expect(proseViewOf(h("div", []) as Element)).toBeNull()
-      })
+        expect(proseViewOf(h("div", []) as Element)).toBeNull();
+      });
 
       it("returns null for missing children", () => {
-        const node = h("div") as Element
-        node.children = undefined as unknown as Element["children"]
-        expect(proseViewOf(node)).toBeNull()
-      })
-    })
+        const node = h("div") as Element;
+        node.children = undefined as unknown as Element["children"];
+        expect(proseViewOf(node)).toBeNull();
+      });
+    });
 
     describe("shouldSkipText", () => {
       it("is not called for text inside elements excluded by shouldSkip", () => {
-        const element = h("p", ["before ", h("code", "unchanged"), " after"]) as Element
-        const visitedValues: string[] = []
+        const element = h("p", [
+          "before ",
+          h("code", "unchanged"),
+          " after",
+        ]) as Element;
+        const visitedValues: string[] = [];
         proseViewOf(element, {
           shouldSkip: ignoreCode,
           shouldSkipText: (textNode) => {
-            visitedValues.push(textNode.value)
-            return false
+            visitedValues.push(textNode.value);
+            return false;
           },
-        })
+        });
         // Only "before " and " after" are visited — the code child short-circuits.
-        expect(visitedValues).toEqual(["before ", " after"])
-      })
+        expect(visitedValues).toEqual(["before ", " after"]);
+      });
 
       it("returns null when every text node is skipped, leaving values untouched", () => {
-        const element = h("p", "hello") as Element
-        expect(proseViewOf(element, { shouldSkipText: () => true })).toBeNull()
-        expect((element.children[0] as Text).value).toBe("hello")
-      })
+        const element = h("p", "hello") as Element;
+        expect(proseViewOf(element, { shouldSkipText: () => true })).toBeNull();
+        expect((element.children[0] as Text).value).toBe("hello");
+      });
 
       it("passes ancestors root-first, nearest-last", () => {
-        const tree = h("div", [h("p", [h("em", "inner")])]) as Element
-        const captured: string[][] = []
+        const tree = h("div", [h("p", [h("em", "inner")])]) as Element;
+        const captured: string[][] = [];
         flattenTextNodes(tree, ignoreNone, {
           shouldSkipText: (_textNode, ancestors) => {
-            captured.push(ancestors.map((a) => a.tagName))
-            return false
+            captured.push(ancestors.map((a) => a.tagName));
+            return false;
           },
-        })
-        expect(captured).toEqual([["div", "p", "em"]])
-      })
+        });
+        expect(captured).toEqual([["div", "p", "em"]]);
+      });
 
       it("hands out a snapshot of ancestors, not the live mutable array", () => {
         // If the walker handed out the shared live array, the captured
         // reference would be empty (or partially popped) by the time we
         // inspect it after the walk completes.
-        const tree = h("div", [h("p", [h("em", "inner")])]) as Element
-        let captured: readonly Element[] | null = null
+        const tree = h("div", [h("p", [h("em", "inner")])]) as Element;
+        let captured: readonly Element[] | null = null;
         flattenTextNodes(tree, ignoreNone, {
           shouldSkipText: (_textNode, ancestors) => {
-            captured = ancestors
-            return false
+            captured = ancestors;
+            return false;
           },
-        })
-        expect(captured).not.toBeNull()
-        expect(captured!.map((a) => a.tagName)).toEqual(["div", "p", "em"])
-      })
+        });
+        expect(captured).not.toBeNull();
+        expect(captured!.map((a) => a.tagName)).toEqual(["div", "p", "em"]);
+      });
 
       it("gives each text node its own ancestor chain across the same walk", () => {
         // shallow text under <div>, deep text under <div><p><em>; the chains
@@ -543,62 +832,79 @@ describe("rehypePunctilio", () => {
         const tree = h("div", [
           "shallow",
           h("p", [h("em", "deep")]),
-        ]) as Element
-        const captured: Record<string, string[]> = {}
+        ]) as Element;
+        const captured: Record<string, string[]> = {};
         flattenTextNodes(tree, ignoreNone, {
           shouldSkipText: (textNode, ancestors) => {
-            captured[textNode.value] = ancestors.map((a) => a.tagName)
-            return false
+            captured[textNode.value] = ancestors.map((a) => a.tagName);
+            return false;
           },
-        })
+        });
         expect(captured).toEqual({
           shallow: ["div"],
           deep: ["div", "p", "em"],
-        })
-      })
+        });
+      });
 
       it("excludes rejected text from the view while accepted text edits land", () => {
-        const element = h("p", ["hello ", h("em", "world")]) as Element
-        const view = proseViewOf(element, { shouldSkipText: (textNode) => textNode.value === "hello " })!
-        expect(view.text).toBe("world")
-        view.replace(0, 5, "WORLD")
-        view.commit()
-        expect((element.children[0] as Text).value).toBe("hello ")
-        expect(((element.children[1] as Element).children[0] as Text).value).toBe("WORLD")
-      })
+        const element = h("p", ["hello ", h("em", "world")]) as Element;
+        const view = proseViewOf(element, {
+          shouldSkipText: (textNode) => textNode.value === "hello ",
+        })!;
+        expect(view.text).toBe("world");
+        view.replace(0, 5, "WORLD");
+        view.commit();
+        expect((element.children[0] as Text).value).toBe("hello ");
+        expect(
+          ((element.children[1] as Element).children[0] as Text).value,
+        ).toBe("WORLD");
+      });
 
       it("plugin option skips text matching predicate end-to-end", async () => {
-        const html = '<p>Visit <a href="https://example.com/x">https://example.com/x</a> now.</p>'
+        const html =
+          '<p>Visit <a href="https://example.com/x">https://example.com/x</a> now.</p>';
         const result = await processHtml(html, {
           nbsp: false,
           shouldSkipText: (textNode, ancestors) => {
-            const parent = ancestors[ancestors.length - 1]
-            if (parent?.tagName !== "a") return false
-            const href = parent.properties?.href
-            return typeof href === "string" && href === textNode.value
+            const parent = ancestors[ancestors.length - 1];
+            if (parent?.tagName !== "a") return false;
+            const href = parent.properties?.href;
+            return typeof href === "string" && href === textNode.value;
           },
-        })
+        });
         // The anchor text is preserved literally (slashes unchanged); surrounding
         // text is transformed (nothing to change here, but no crash).
-        expect(result).toBe('<p>Visit <a href="https://example.com/x">https://example.com/x</a> now.</p>')
-      })
-    })
+        expect(result).toBe(
+          '<p>Visit <a href="https://example.com/x">https://example.com/x</a> now.</p>',
+        );
+      });
+    });
 
     describe("getTextContent", () => {
       it.each([
         ["simple text", fixtures.simple, ignoreNone, "Hello, world!"],
-        ["nested elements", fixtures.nested, ignoreNone, "This is emphasized text."],
+        [
+          "nested elements",
+          fixtures.nested,
+          ignoreNone,
+          "This is emphasized text.",
+        ],
         ["with ignored code", fixtures.withCode, ignoreCode, "This is  text."],
         ["empty element", fixtures.empty, ignoreNone, ""],
-        ["deeply nested", fixtures.deeplyNested, ignoreNone, "Level 1 Level 2 Level 3 End"],
+        [
+          "deeply nested",
+          fixtures.deeplyNested,
+          ignoreNone,
+          "Level 1 Level 2 Level 3 End",
+        ],
       ])("extracts from %s", (_name, node, skip, expected) => {
-        expect(getTextContent(node, skip)).toBe(expected)
-      })
+        expect(getTextContent(node, skip)).toBe(expected);
+      });
 
       it("uses default shouldSkip when not provided", () => {
-        expect(getTextContent(fixtures.simple)).toBe("Hello, world!")
-      })
-    })
+        expect(getTextContent(fixtures.simple)).toBe("Hello, world!");
+      });
+    });
 
     describe("getFirstTextNode", () => {
       it.each([
@@ -606,37 +912,37 @@ describe("rehypePunctilio", () => {
         ["nested", fixtures.nested, "This is "],
         ["deeply nested", fixtures.deeplyNested, "Level 1 "],
       ])("finds first text in %s", (_name, node, expectedValue) => {
-        const result = getFirstTextNode(node as Parent)
-        expect(result).not.toBeNull()
-        expect(result!.value).toBe(expectedValue)
-      })
+        const result = getFirstTextNode(node as Parent);
+        expect(result).not.toBeNull();
+        expect(result!.value).toBe(expectedValue);
+      });
 
       it("returns null for empty element", () => {
-        expect(getFirstTextNode(fixtures.empty as Parent)).toBeNull()
-      })
+        expect(getFirstTextNode(fixtures.empty as Parent)).toBeNull();
+      });
 
       it("returns text node directly", () => {
-        const textNode: Text = { type: "text", value: "Direct" }
-        expect(getFirstTextNode(textNode as unknown as Parent)).toBe(textNode)
-      })
+        const textNode: Text = { type: "text", value: "Direct" };
+        expect(getFirstTextNode(textNode as unknown as Parent)).toBe(textNode);
+      });
 
       it("returns null for null input", () => {
-        expect(getFirstTextNode(null as unknown as Parent)).toBeNull()
-      })
+        expect(getFirstTextNode(null as unknown as Parent)).toBeNull();
+      });
 
       it("returns null for comments-only element", () => {
         const node = h("div", [
           { type: "comment", value: "comment" } as unknown as ElementContent,
-        ]) as Element
-        expect(getFirstTextNode(node as Parent)).toBeNull()
-      })
+        ]) as Element;
+        expect(getFirstTextNode(node as Parent)).toBeNull();
+      });
 
       it("stops at max recursion depth", () => {
-        let deep: Element = h("span", "deep") as Element
-        for (let i = 0; i < 1005; i++) deep = h("div", [deep]) as Element
-        expect(getFirstTextNode(deep as Parent)).toBeNull()
-      })
-    })
+        let deep: Element = h("span", "deep") as Element;
+        for (let i = 0; i < 1005; i++) deep = h("div", [deep]) as Element;
+        expect(getFirstTextNode(deep as Parent)).toBeNull();
+      });
+    });
 
     describe("assertSmartQuotesMatch", () => {
       it.each([
@@ -645,8 +951,8 @@ describe("rehypePunctilio", () => {
         ["empty string", ""],
         ["no quotes", "Hello, world!"],
       ])("passes for %s", (_name, input) => {
-        expect(() => assertSmartQuotesMatch(input)).not.toThrow()
-      })
+        expect(() => assertSmartQuotesMatch(input)).not.toThrow();
+      });
 
       it.each([
         ["unmatched opening", `${LDQ}Hello`],
@@ -654,41 +960,45 @@ describe("rehypePunctilio", () => {
         ["extra opening", `${LDQ}${LDQ}Hello${RDQ}`],
         ["reversed quotes", `${RDQ}Hello${LDQ}`],
       ])("throws for %s", (_name, input) => {
-        expect(() => assertSmartQuotesMatch(input)).toThrow("Mismatched quotes")
-      })
-    })
+        expect(() => assertSmartQuotesMatch(input)).toThrow(
+          "Mismatched quotes",
+        );
+      });
+    });
 
     describe("collectProseBlocks", () => {
       it("collects elements with direct text children", () => {
         const tree = h("div", [
           h("p", "First paragraph"),
           h("div", [h("p", "Nested paragraph")]),
-        ]) as Element
-        const result = collectProseBlocks(tree)
-        expect(result).toHaveLength(2)
-        expect(result[0].tagName).toBe("p")
-        expect(result[1].tagName).toBe("p")
-      })
+        ]) as Element;
+        const result = collectProseBlocks(tree);
+        expect(result).toHaveLength(2);
+        expect(result[0].tagName).toBe("p");
+        expect(result[1].tagName).toBe("p");
+      });
 
       it("skips elements matching shouldSkip", () => {
         const tree = h("div", [
           h("p", "Normal"),
           h("code", "Skipped"),
-        ]) as Element
-        const result = collectProseBlocks(tree, { shouldSkip: ignoreCode })
-        expect(result).toHaveLength(1)
-        expect(result[0].tagName).toBe("p")
-      })
+        ]) as Element;
+        const result = collectProseBlocks(tree, { shouldSkip: ignoreCode });
+        expect(result).toHaveLength(1);
+        expect(result[0].tagName).toBe("p");
+      });
 
       it("returns empty for skipped root", () => {
-        const tree = h("code", "Skipped") as Element
-        expect(collectProseBlocks(tree, { shouldSkip: ignoreCode })).toHaveLength(0)
-      })
+        const tree = h("code", "Skipped") as Element;
+        expect(
+          collectProseBlocks(tree, { shouldSkip: ignoreCode }),
+        ).toHaveLength(0);
+      });
 
       it("returns empty for elements without text children", () => {
-        const tree = h("div", [h("img")]) as Element
-        expect(collectProseBlocks(tree)).toHaveLength(0)
-      })
+        const tree = h("div", [h("img")]) as Element;
+        expect(collectProseBlocks(tree)).toHaveLength(0);
+      });
 
       it("collects phrasing container with only inline element children", () => {
         // <p><em>"Hello</em><span>, world"</span></p>
@@ -697,24 +1007,21 @@ describe("rehypePunctilio", () => {
         const tree = h("p", [
           h("em", '"Hello'),
           h("span", ', world"'),
-        ]) as Element
-        const result = collectProseBlocks(tree)
-        expect(result).toHaveLength(1)
-        expect(result[0].tagName).toBe("p")
-      })
+        ]) as Element;
+        const result = collectProseBlocks(tree);
+        expect(result).toHaveLength(1);
+        expect(result[0].tagName).toBe("p");
+      });
 
       it("recurses when element has block-level children", () => {
         // <div><p>Hello</p><p>World</p></div> — block children mean
         // each <p> should be independent, not merged.
-        const tree = h("div", [
-          h("p", "Hello"),
-          h("p", "World"),
-        ]) as Element
-        const result = collectProseBlocks(tree)
-        expect(result).toHaveLength(2)
-        expect(result[0].tagName).toBe("p")
-        expect(result[1].tagName).toBe("p")
-      })
+        const tree = h("div", [h("p", "Hello"), h("p", "World")]) as Element;
+        const result = collectProseBlocks(tree);
+        expect(result).toHaveLength(2);
+        expect(result[0].tagName).toBe("p");
+        expect(result[1].tagName).toBe("p");
+      });
 
       it("recurses past whitespace-only text between block children", () => {
         // Parsers leave newline text nodes between block siblings. They must
@@ -731,11 +1038,11 @@ describe("rehypePunctilio", () => {
             h("p", "Second") as ElementContent,
             { type: "text", value: "\n" },
           ],
-        }
-        const result = collectProseBlocks(tree)
-        expect(result).toHaveLength(2)
-        expect(result.map((b) => b.tagName)).toEqual(["p", "p"])
-      })
+        };
+        const result = collectProseBlocks(tree);
+        expect(result).toHaveLength(2);
+        expect(result.map((b) => b.tagName)).toEqual(["p", "p"]);
+      });
 
       it("returns only the block children, not loose inline text, for mixed content", () => {
         // <div>loose<p>Hello</p></div> — the loose "loose" text is a run unit
@@ -748,183 +1055,281 @@ describe("rehypePunctilio", () => {
             { type: "text", value: "loose" },
             h("p", "Hello") as ElementContent,
           ],
-        }
-        const result = collectProseBlocks(tree)
-        expect(result).toHaveLength(1)
-        expect(result[0].tagName).toBe("p")
-      })
+        };
+        const result = collectProseBlocks(tree);
+        expect(result).toHaveLength(1);
+        expect(result[0].tagName).toBe("p");
+      });
 
       it("collects inline-only div as single unit", () => {
         // <div><span>Hello</span><em>World</em></div> — no block children
         const tree = h("div", [
           h("span", "Hello"),
           h("em", "World"),
-        ]) as Element
-        const result = collectProseBlocks(tree)
-        expect(result).toHaveLength(1)
-        expect(result[0].tagName).toBe("div")
-      })
+        ]) as Element;
+        const result = collectProseBlocks(tree);
+        expect(result).toHaveLength(1);
+        expect(result[0].tagName).toBe("div");
+      });
 
       it("skips inline-only container when children are skip-tagged", () => {
-        const tree = h("p", [h("code", "skip me")]) as Element
-        expect(collectProseBlocks(tree, { shouldSkip: ignoreCode })).toHaveLength(0)
-      })
+        const tree = h("p", [h("code", "skip me")]) as Element;
+        expect(
+          collectProseBlocks(tree, { shouldSkip: ignoreCode }),
+        ).toHaveLength(0);
+      });
 
       it("returns empty when only non-text, non-element children exist", () => {
         const tree: Element = {
           type: "element",
           tagName: "p",
           properties: {},
-          children: [{ type: "comment", value: "a comment" } as unknown as ElementContent],
-        }
-        expect(collectProseBlocks(tree)).toHaveLength(0)
-      })
+          children: [
+            {
+              type: "comment",
+              value: "a comment",
+            } as unknown as ElementContent,
+          ],
+        };
+        expect(collectProseBlocks(tree)).toHaveLength(0);
+      });
 
       it("stops at max recursion depth", () => {
-        let deep: Element = h("p", "deep") as Element
-        for (let i = 0; i < 1100; i++) deep = h("div", [deep]) as Element
-        expect(collectProseBlocks(deep)).toHaveLength(0)
-      })
-    })
-  })
+        let deep: Element = h("p", "deep") as Element;
+        for (let i = 0; i < 1100; i++) deep = h("div", [deep]) as Element;
+        expect(collectProseBlocks(deep)).toHaveLength(0);
+      });
+    });
+
+    describe("collectProseUnits", () => {
+      it("returns a run for loose inline text beside block children", () => {
+        // <div>loose<p>Hello</p></div> — collectProseBlocks drops the loose run,
+        // but collectProseUnits surfaces it so a consumer can format it.
+        const tree: Element = {
+          type: "element",
+          tagName: "div",
+          properties: {},
+          children: [
+            { type: "text", value: "loose" },
+            h("p", "Hello") as ElementContent,
+          ],
+        };
+        const units = collectProseUnits(tree);
+        expect(units).toHaveLength(2);
+        expect(units[0].kind).toBe("run");
+        const run = units[0];
+        if (run.kind !== "run") throw new Error("expected a run unit");
+        expect(run.container).toBe(tree);
+        expect(
+          run.children.map((c) => (c.type === "text" ? c.value : c.tagName)),
+        ).toEqual(["loose"]);
+        expect(units[1]).toEqual({
+          kind: "element",
+          element: tree.children[1],
+        });
+      });
+
+      it("returns a single element unit for inline-only content (no runs)", () => {
+        const tree = h("p", ["say ", h("em", "hi")]) as Element;
+        expect(collectProseUnits(tree)).toEqual([
+          { kind: "element", element: tree },
+        ]);
+      });
+    });
+  });
 
   describe("nbsp option", () => {
-    const NBSP = UNICODE_SYMBOLS.NBSP
+    const NBSP = UNICODE_SYMBOLS.NBSP;
 
     it("inserts nbsp when option enabled", async () => {
-      const result = await processHtml('<p>Dr. Smith has 5 kg of items.</p>', { nbsp: true })
-      expect(result).toBe(`<p>Dr.${NBSP}Smith has 5${NBSP}kg of${NBSP}items.</p>`)
-    })
+      const result = await processHtml("<p>Dr. Smith has 5 kg of items.</p>", {
+        nbsp: true,
+      });
+      expect(result).toBe(
+        `<p>Dr.${NBSP}Smith has 5${NBSP}kg of${NBSP}items.</p>`,
+      );
+    });
 
     it("inserts nbsp by default", async () => {
-      const result = await processHtml('<p>Dr. Smith has 5 kg of items.</p>')
-      expect(result).toBe(`<p>Dr.${NBSP}Smith has 5${NBSP}kg of${NBSP}items.</p>`)
-    })
+      const result = await processHtml("<p>Dr. Smith has 5 kg of items.</p>");
+      expect(result).toBe(
+        `<p>Dr.${NBSP}Smith has 5${NBSP}kg of${NBSP}items.</p>`,
+      );
+    });
 
     it("does not insert nbsp when option disabled", async () => {
-      const result = await processHtml('<p>Dr. Smith has 5 kg of items.</p>', { nbsp: false })
-      expect(result).not.toContain(NBSP)
-    })
+      const result = await processHtml("<p>Dr. Smith has 5 kg of items.</p>", {
+        nbsp: false,
+      });
+      expect(result).not.toContain(NBSP);
+    });
 
     it("works across element boundaries", async () => {
-      const result = await processHtml('<p>See <em>Fig.</em> 1</p>', { nbsp: true })
-      expect(result).toBe(`<p>See <em>Fig.</em>${NBSP}1</p>`)
-    })
-  })
+      const result = await processHtml("<p>See <em>Fig.</em> 1</p>", {
+        nbsp: true,
+      });
+      expect(result).toBe(`<p>See <em>Fig.</em>${NBSP}1</p>`);
+    });
+  });
 
   describe("coverage edge cases", () => {
     it.each([
-      ["space-separated class string", '<p class="foo bar no-transform">"Hello"</p>', { skipClasses: ["no-transform"] }, '<p class="foo bar no-transform">"Hello"</p>'],
-      ["HTML comments", '<p>"Hello"<!-- comment --></p>', {}, `<p>${LDQ}Hello${RDQ}<!-- comment --></p>`],
-      ["non-text children only", '<div><img src="test.jpg" alt="test"></div>', {}, '<div><img src="test.jpg" alt="test"></div>'],
-      ["skip class at root", '<p class="skip">"Hello"</p>', { skipClasses: ["skip"] }, '<p class="skip">"Hello"</p>'],
-      ["nested skipped elements", '<pre><p>"Hello"</p></pre>', {}, '<pre><p>"Hello"</p></pre>'],
-      ["multiple skip classes", '<p class="a b">"Hello"</p>', { skipClasses: ["b"] }, '<p class="a b">"Hello"</p>'],
+      [
+        "space-separated class string",
+        '<p class="foo bar no-transform">"Hello"</p>',
+        { skipClasses: ["no-transform"] },
+        '<p class="foo bar no-transform">"Hello"</p>',
+      ],
+      [
+        "HTML comments",
+        '<p>"Hello"<!-- comment --></p>',
+        {},
+        `<p>${LDQ}Hello${RDQ}<!-- comment --></p>`,
+      ],
+      [
+        "non-text children only",
+        '<div><img src="test.jpg" alt="test"></div>',
+        {},
+        '<div><img src="test.jpg" alt="test"></div>',
+      ],
+      [
+        "skip class at root",
+        '<p class="skip">"Hello"</p>',
+        { skipClasses: ["skip"] },
+        '<p class="skip">"Hello"</p>',
+      ],
+      [
+        "nested skipped elements",
+        '<pre><p>"Hello"</p></pre>',
+        {},
+        '<pre><p>"Hello"</p></pre>',
+      ],
+      [
+        "multiple skip classes",
+        '<p class="a b">"Hello"</p>',
+        { skipClasses: ["b"] },
+        '<p class="a b">"Hello"</p>',
+      ],
     ])("handles %s", async (_name, html, options, expected) => {
-      expect(await processHtml(html, options)).toEqual(expected)
-    })
+      expect(await processHtml(html, options)).toEqual(expected);
+    });
 
     it("handles skipped child within non-skipped parent", async () => {
-      expect(await processHtml('<div>"Before" <code>"Inside"</code> "After"</div>', { nbsp: false })).toEqual(
-        `<div>${LDQ}Before${RDQ} <code>"Inside"</code> ${LDQ}After${RDQ}</div>`
-      )
-    })
+      expect(
+        await processHtml('<div>"Before" <code>"Inside"</code> "After"</div>', {
+          nbsp: false,
+        }),
+      ).toEqual(
+        `<div>${LDQ}Before${RDQ} <code>"Inside"</code> ${LDQ}After${RDQ}</div>`,
+      );
+    });
 
     it("handles string className property (non-standard AST)", async () => {
       // rehype-parse always produces array classNames, but hand-crafted ASTs
       // may use strings. The plugin should handle both.
       const tree: Root = {
         type: "root",
-        children: [{
-          type: "element",
-          tagName: "p",
-          // Cast to bypass hast's typed className (which expects string[])
-          properties: { className: "no-transform" as unknown as string[] },
-          children: [{ type: "text", value: '"Hello"' }],
-        }],
-      }
+        children: [
+          {
+            type: "element",
+            tagName: "p",
+            // Cast to bypass hast's typed className (which expects string[])
+            properties: { className: "no-transform" as unknown as string[] },
+            children: [{ type: "text", value: '"Hello"' }],
+          },
+        ],
+      };
       const processor = unified()
         .use(rehypePunctilio, { skipClasses: ["no-transform"] })
-        .use(rehypeStringify)
-      await processor.run(tree)
+        .use(rehypeStringify);
+      await processor.run(tree);
       // Text should remain untransformed because the class matches
-      const textNode = (tree.children[0] as Element).children[0] as Text
-      expect(textNode.value).toBe('"Hello"')
-    })
+      const textNode = (tree.children[0] as Element).children[0] as Text;
+      expect(textNode.value).toBe('"Hello"');
+    });
 
     it("handles mixed skip and non-skip siblings", async () => {
-      expect(await processHtml('<article><p>"Hello"</p><pre>"Code"</pre><p>"World"</p></article>', { nbsp: false })).toEqual(
-        `<article><p>${LDQ}Hello${RDQ}</p><pre>"Code"</pre><p>${LDQ}World${RDQ}</p></article>`
-      )
-    })
+      expect(
+        await processHtml(
+          '<article><p>"Hello"</p><pre>"Code"</pre><p>"World"</p></article>',
+          { nbsp: false },
+        ),
+      ).toEqual(
+        `<article><p>${LDQ}Hello${RDQ}</p><pre>"Code"</pre><p>${LDQ}World${RDQ}</p></article>`,
+      );
+    });
 
     it("skipClasses with elements that have no className property", async () => {
       const tree: Root = {
         type: "root",
-        children: [{
-          type: "element",
-          tagName: "p",
-          properties: {},
-          children: [{ type: "text", value: '"Hello"' }],
-        }],
-      }
+        children: [
+          {
+            type: "element",
+            tagName: "p",
+            properties: {},
+            children: [{ type: "text", value: '"Hello"' }],
+          },
+        ],
+      };
       const processor = unified()
         .use(rehypePunctilio, { skipClasses: ["no-transform"] })
-        .use(rehypeStringify)
-      await processor.run(tree)
-      const textNode = (tree.children[0] as Element).children[0] as Text
-      expect(textNode.value).toBe(`${LDQ}Hello${RDQ}`)
-    })
-  })
+        .use(rehypeStringify);
+      await processor.run(tree);
+      const textNode = (tree.children[0] as Element).children[0] as Text;
+      expect(textNode.value).toBe(`${LDQ}Hello${RDQ}`);
+    });
+  });
 
   describe("stress tests", () => {
     it("handles many sibling paragraphs", async () => {
       // 100 siblings: enough to exercise the visitor/transformed-set logic
       // without spending seconds on HTML parsing
-      const count = 100
-      const html = '<div>' + '<p>"Hello," she said.</p>'.repeat(count) + '</div>'
-      const result = await processHtml(html, { nbsp: false })
-      const matchCount = (result.match(new RegExp(LDQ, "g")) ?? []).length
-      expect(matchCount).toBe(count)
-    })
+      const count = 100;
+      const html =
+        "<div>" + '<p>"Hello," she said.</p>'.repeat(count) + "</div>";
+      const result = await processHtml(html, { nbsp: false });
+      const matchCount = (result.match(new RegExp(LDQ, "g")) ?? []).length;
+      expect(matchCount).toBe(count);
+    });
 
     it("handles paragraph with many inline elements", async () => {
-      const count = 100
-      const inlineElements = Array.from({ length: count }, (_, i) =>
-        `<em>"word${i}"</em>`
-      ).join(" ")
-      const html = `<p>${inlineElements}</p>`
-      const result = await processHtml(html, { nbsp: false })
-      const matchCount = (result.match(new RegExp(LDQ, "g")) ?? []).length
-      expect(matchCount).toBe(count)
-    })
+      const count = 100;
+      const inlineElements = Array.from(
+        { length: count },
+        (_, i) => `<em>"word${i}"</em>`,
+      ).join(" ");
+      const html = `<p>${inlineElements}</p>`;
+      const result = await processHtml(html, { nbsp: false });
+      const matchCount = (result.match(new RegExp(LDQ, "g")) ?? []).length;
+      expect(matchCount).toBe(count);
+    });
 
     it("transforms text at 100-level deep nesting", async () => {
-      let html = '"Hello"'
+      let html = '"Hello"';
       for (let i = 0; i < 100; i++) {
-        html = `<span>${html}</span>`
+        html = `<span>${html}</span>`;
       }
-      html = `<p>${html}</p>`
-      const result = await processHtml(html, { nbsp: false })
-      let expected = `${LDQ}Hello${RDQ}`
-      for (let i = 0; i < 100; i++) expected = `<span>${expected}</span>`
-      expected = `<p>${expected}</p>`
-      expect(result).toBe(expected)
-    })
+      html = `<p>${html}</p>`;
+      const result = await processHtml(html, { nbsp: false });
+      let expected = `${LDQ}Hello${RDQ}`;
+      for (let i = 0; i < 100; i++) expected = `<span>${expected}</span>`;
+      expected = `<p>${expected}</p>`;
+      expect(result).toBe(expected);
+    });
 
     it("does not crash beyond MAX_RECURSION_DEPTH", async () => {
-      let html = '"Hello"'
+      let html = '"Hello"';
       for (let i = 0; i < 1050; i++) {
-        html = `<span>${html}</span>`
+        html = `<span>${html}</span>`;
       }
-      html = `<p>${html}</p>`
+      html = `<p>${html}</p>`;
       // Should not throw — deep nesting is silently skipped
-      const result = await processHtml(html, { nbsp: false })
+      const result = await processHtml(html, { nbsp: false });
       // Build expected: same structure with smart quotes applied
-      let expected = `${LDQ}Hello${RDQ}`
-      for (let i = 0; i < 1050; i++) expected = `<span>${expected}</span>`
-      expected = `<p>${expected}</p>`
-      expect(result).toBe(expected)
-    })
-  })
-})
+      let expected = `${LDQ}Hello${RDQ}`;
+      for (let i = 0; i < 1050; i++) expected = `<span>${expected}</span>`;
+      expected = `<p>${expected}</p>`;
+      expect(result).toBe(expected);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

`4f2f350` correctly stopped a mixed container from *merging* loose inline text with a block child's text across the boundary — but it did so by **dropping the loose "run" units from `collectProseBlocks`'s return set entirely**. A consumer that walks elements (`visitParents(tree, "element")`) and calls `collectProseBlocks(node)` then has **no way to reach loose text that owns no element of its own** (e.g. the bare text in `<blockquote><p>…</p>loose "text"</blockquote>`), so that text goes untransformed.

Downstream (turntrout.com) this regressed **60+ real pages**: straight quotes stopped curling, spacing/ellipses were missed — everywhere loose text sits beside block children in a `<blockquote>`, `<div>`, `<li>`, etc.

## Fix

Expose the runs instead of dropping them, without reintroducing the merge:

- **`collectProseUnits(root, options): ProseUnit[]`** (new public export) returns both `element` units *and* `run` units (a container's maximal groups of loose inline siblings beside block children). `ProseUnit` is now exported.
- **`applyPasses` accepts an `Element | ProseUnit`.** A `run` unit is formatted over a single spanning view of just its loose children (`runViewOf`) — so the loose text transforms, while the container's block children stay in their own units and never merge across the boundary.
- **`collectProseBlocks` is unchanged** (still elements-only) — no break for existing callers; consumers that need loose text switch to `collectProseUnits`.

## Tests

- `collectProseUnits` returns a run for `<div>loose<p>Hello</p></div>` (and only an element unit for inline-only content).
- `applyPasses` on a run transforms its loose text + inline elements, leaving the container's block child untouched (proves no cross-block merge); plus the element-unit and empty-run paths.
- Full suite: **2509 passed, 100%** statement/branch/function/line coverage.

## End-to-end verification

Packed this build into turntrout.com (switching its consumer to `collectProseUnits`): the previously-straight loose quotes now curl (`<blockquote><p>a</p>loose “quote” text</blockquote>`), its formatting suite stays at 618 passed / 100% coverage, and the 62 new `site-build-checks` regressions the 5.1.x line introduced are resolved.

## Lessons Learned

- **Don't drop a public collection's members to fix a *grouping* bug — re-model, don't remove.** When `collectProseBlocks` needed to stop merging loose text with block children, returning the loose text as its own *unit* (not discarding it) preserves every consumer that reaches text by walking that collection. A returned-set that silently omits a category breaks element-walking consumers in a way unit tests on the return shape don't catch — only a full-content downstream check does. Applies to any library exposing a "collect the things to transform" API.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AjQ1rd6bcW6mYjTa7WopbM)_