### PR TITLE
Auto-scale mutation test shards by measured test cost

### DIFF
--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -31,13 +31,12 @@ jobs:
 
       - id: plan
         env:
-          # MAX_SHARDS caps the fan-out at GitHub's practical concurrency; this
-          # static-mutant-heavy suite's cold work (~3h single-threaded) makes the
-          # cap bind, so a cold run fans out to ~20 shards of ~10-15 min each,
-          # balanced by measured weight. SHARD_BUDGET (executions/shard) takes over
-          # only if the total ever drops below the cap. Tune if wall times drift.
+          # MAX_SHARDS caps the fan-out; the committed weights make its cold work
+          # exceed the cap, so a cold run fans out to MAX_SHARDS shards balanced by
+          # measured weight (~10-15 min each). SHARD_BUDGET (executions/shard) takes
+          # over only if the total drops below the cap. Tune if wall times drift.
           SHARD_BUDGET: "25000"
-          MAX_SHARDS: "20"
+          MAX_SHARDS: "12"
         run: echo "shards=$(node scripts/mutation-shards.mjs)" >> "$GITHUB_OUTPUT"
 
   mutation:

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -15,11 +15,10 @@ permissions:
 
 jobs:
   # Balance the shards from the committed per-file weights (measured test
-  # executions, refreshed by refresh-mutation-weights.yml). The shard count
-  # autoscales so no shard exceeds SHARD_BUDGET test executions — roughly the
-  # 5-minute wall-time target — so the matrix stays balanced as the source grows
-  # without anyone re-tuning file groups by hand. Runs on the runner's bundled
-  # node; the planner reads only source files and needs no dependencies.
+  # executions, refreshed by refresh-mutation-weights.yml). The fan-out is bounded
+  # by SHARD_BUDGET (executions per shard) and MAX_SHARDS, so the matrix stays
+  # balanced as the source grows without re-tuning file groups by hand. Runs on
+  # the runner's bundled node; the planner reads only source files, no deps.
   prep:
     name: Plan mutation shards
     runs-on: ubuntu-latest

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -43,9 +43,11 @@ jobs:
     name: mutation (shard ${{ matrix.index }})
     needs: prep
     runs-on: ubuntu-latest
-    # ~10-15 min per balanced cold shard; the headroom covers a shard that packs
-    # a dense static-mutant line range that can't be split any finer.
-    timeout-minutes: 30
+    # Steady-state a balanced cold shard is ~15-20 min; the wide headroom is a
+    # backstop for the timeout-mutant-heavy quote-classifier regex ranges and for
+    # a cache-transition run (after a MAX_SHARDS change a shard's incremental
+    # cache mismatches and it re-tests fully cold). Warm PR runs finish in minutes.
+    timeout-minutes: 40
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -14,28 +14,40 @@ permissions:
   contents: read
 
 jobs:
-  mutation:
-    name: mutation (${{ matrix.shard }})
+  # Balance the shards from the committed per-file weights (measured test
+  # executions, refreshed by refresh-mutation-weights.yml). The shard count
+  # autoscales so no shard exceeds SHARD_BUDGET test executions — roughly the
+  # 5-minute wall-time target — so the matrix stays balanced as the source grows
+  # without anyone re-tuning file groups by hand. Runs on the runner's bundled
+  # node; the planner reads only source files and needs no dependencies.
+  prep:
+    name: Plan mutation shards
     runs-on: ubuntu-latest
-    timeout-minutes: 300
+    timeout-minutes: 5
+    outputs:
+      shards: ${{ steps.plan.outputs.shards }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - id: plan
+        env:
+          # Max test executions per shard, calibrated so a shard runs in roughly
+          # the 5-minute wall-time budget on ubuntu-latest (dry-run/setup overhead
+          # plus the shard's mutation work). Tune if CI shard wall times drift.
+          SHARD_BUDGET: "25000"
+          MAX_SHARDS: "12"
+        run: echo "shards=$(node scripts/mutation-shards.mjs)" >> "$GITHUB_OUTPUT"
+
+  mutation:
+    name: mutation (shard ${{ matrix.index }})
+    needs: prep
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
     strategy:
       fail-fast: false
-      # Shards are balanced by file size (≈ mutant count) so the matrix
-      # finishes in roughly the wall time of the largest single file.
       matrix:
-        include:
-          - shard: quote-classifier
-            mutate: src/quote-classifier.ts
-          - shard: dashes
-            mutate: src/dashes.ts
-          - shard: symbols
-            mutate: src/symbols.ts,src/quotes.ts
-          - shard: cli-nbsp
-            mutate: src/cli.ts,src/nbsp.ts
-          - shard: plugins
-            mutate: src/rehype.ts,src/remark.ts,src/html.ts,src/markdown.ts,src/prettier-plugin.ts
-          - shard: core
-            mutate: src/prose-view.ts,src/index.ts,src/constants.ts,src/transform-options.ts,src/utils.ts
+        include: ${{ fromJSON(needs.prep.outputs.shards) }}
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -45,57 +57,35 @@ jobs:
         with:
           node-version: 22
 
-      # Cache entries are immutable, so the primary key includes the commit
-      # and restore-keys falls back to the most recent entry for the shard
-      # (Stryker revalidates incremental results against the actual code and
-      # test diffs, so a stale file is safe and still prunes unchanged work).
+      # Cache entries are immutable, so the primary key includes the commit and
+      # restore-keys falls back to the most recent entry for this shard index.
+      # Stryker revalidates incremental results against the actual code and test
+      # diffs, so a stale entry (files may pack onto a different index as the plan
+      # rebalances) is safe and still prunes unchanged work.
       - name: Restore incremental mutation state
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
-          path: reports/stryker-incremental-${{ matrix.shard }}.json
-          key: stryker-incremental-${{ matrix.shard }}-${{ github.sha }}
+          path: reports/stryker-incremental-${{ matrix.index }}.json
+          key: stryker-incremental-${{ matrix.index }}-${{ github.sha }}
           restore-keys: |
-            stryker-incremental-${{ matrix.shard }}-
+            stryker-incremental-${{ matrix.index }}-
 
       - name: Run mutation tests
         # No `--` before the flags: pnpm forwards it literally and Stryker's
         # CLI rejects it as a positional argument.
-        run: pnpm run mutation --mutate "${{ matrix.mutate }}" --incrementalFile "reports/stryker-incremental-${{ matrix.shard }}.json"
+        run: pnpm run mutation --mutate "${{ matrix.mutate }}" --incrementalFile "reports/stryker-incremental-${{ matrix.index }}.json"
 
       - name: Upload HTML report
         if: always()
         uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
         with:
-          name: mutation-report-${{ matrix.shard }}
+          name: mutation-report-${{ matrix.index }}
           path: reports/mutation/
           if-no-files-found: ignore
 
-  shard-coverage:
-    name: Shards cover all source files
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    steps:
-      - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-
-      - name: Every src file appears in a shard
-        run: |
-          covered="src/quote-classifier.ts src/dashes.ts src/symbols.ts src/quotes.ts \
-            src/cli.ts src/nbsp.ts src/rehype.ts src/remark.ts src/html.ts src/markdown.ts \
-            src/prettier-plugin.ts src/prose-view.ts src/index.ts src/constants.ts \
-            src/transform-options.ts src/utils.ts"
-          status=0
-          for f in src/*.ts; do
-            case " $covered " in
-              *" $f "*) ;;
-              *) echo "::error::$f is not covered by any mutation shard; add it to the matrix in mutation.yml"; status=1 ;;
-            esac
-          done
-          exit "$status"
-
   mutation-all:
     name: Mutation checks passed
-    needs: [mutation, shard-coverage]
+    needs: [prep, mutation]
     runs-on: ubuntu-latest
     if: always()
     steps:

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -44,8 +44,9 @@ jobs:
     needs: prep
     runs-on: ubuntu-latest
     # Steady-state a balanced cold shard is ~15-20 min; the wide headroom is a
-    # backstop for the timeout-mutant-heavy quote-classifier regex ranges and for
-    # a cache-transition run (after a MAX_SHARDS change a shard's incremental
+    # backstop for the dense files (quote-classifier alone is ~270 mutants per
+    # ~190 lines, each running a large covering-test set — ~30 min fully cold) and
+    # for a cache-transition run (after a MAX_SHARDS change a shard's incremental
     # cache mismatches and it re-tests fully cold). Warm PR runs finish in minutes.
     timeout-minutes: 40
     strategy:

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -46,7 +46,7 @@ jobs:
     runs-on: ubuntu-latest
     # ~10-15 min per balanced cold shard; the headroom covers a shard that packs
     # a dense static-mutant line range that can't be split any finer.
-    timeout-minutes: 25
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
@@ -77,6 +77,18 @@ jobs:
         # No `--` before the flags: pnpm forwards it literally and Stryker's
         # CLI rejects it as a positional argument.
         run: pnpm run mutation --mutate "${{ matrix.mutate }}" --incrementalFile "reports/stryker-incremental-${{ matrix.index }}.json"
+
+      # Print this shard's measured weights between markers so the map can be
+      # harvested from the job log (Actions artifacts aren't reachable from every
+      # environment). Cheap and a useful record of what each shard measured.
+      - name: Emit measured weights
+        if: always()
+        run: |
+          if [ -f reports/mutation/mutation.json ]; then
+            echo "PUNCTILIO_WEIGHTS_BEGIN"
+            node scripts/mutation-weights.mjs report
+            echo "PUNCTILIO_WEIGHTS_END"
+          fi
 
       - name: Upload HTML report
         if: always()

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -78,25 +78,41 @@ jobs:
         # CLI rejects it as a positional argument.
         run: pnpm run mutation --mutate "${{ matrix.mutate }}" --incrementalFile "reports/stryker-incremental-${{ matrix.index }}.json"
 
-      # Print this shard's measured weights between markers so the map can be
-      # harvested from the job log (Actions artifacts aren't reachable from every
-      # environment). Cheap and a useful record of what each shard measured.
-      - name: Emit measured weights
-        if: always()
-        run: |
-          if [ -f reports/mutation/mutation.json ]; then
-            echo "PUNCTILIO_WEIGHTS_BEGIN"
-            node scripts/mutation-weights.mjs report
-            echo "PUNCTILIO_WEIGHTS_END"
-          fi
-
-      - name: Upload HTML report
+      - name: Upload mutation report
         if: always()
         uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
         with:
           name: mutation-report-${{ matrix.index }}
           path: reports/mutation/
           if-no-files-found: ignore
+
+  # Merge every shard's measured weights and print the map between markers, so it
+  # can be read from one job log and committed to config/mutation-weights.json.
+  # The weekly refresh does the same from a clean (cache-disabled) run; this is a
+  # live view of what the current run measured and the seed source for the map.
+  weights-map:
+    name: Merged weights map
+    needs: mutation
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Download shard reports
+        uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4.2.1
+        with:
+          pattern: mutation-report-*
+          path: shard-reports
+      - name: Merge and print the weights map
+        run: |
+          shopt -s nullglob
+          for report in shard-reports/mutation-report-*/mutation.json; do
+            node scripts/mutation-weights.mjs report --report "$report" --out "$report.weights.json"
+          done
+          echo "PUNCTILIO_MERGED_WEIGHTS_BEGIN"
+          node scripts/mutation-weights.mjs merge shard-reports/mutation-report-*/mutation.json.weights.json
+          echo "PUNCTILIO_MERGED_WEIGHTS_END"
 
   mutation-all:
     name: Mutation checks passed

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -36,7 +36,7 @@ jobs:
           # measured weight (~10-15 min each). SHARD_BUDGET (executions/shard) takes
           # over only if the total drops below the cap. Tune if wall times drift.
           SHARD_BUDGET: "25000"
-          MAX_SHARDS: "12"
+          MAX_SHARDS: "16"
         run: echo "shards=$(node scripts/mutation-shards.mjs)" >> "$GITHUB_OUTPUT"
 
   mutation:

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -31,18 +31,22 @@ jobs:
 
       - id: plan
         env:
-          # Max test executions per shard, calibrated so a shard runs in roughly
-          # the 5-minute wall-time budget on ubuntu-latest (dry-run/setup overhead
-          # plus the shard's mutation work). Tune if CI shard wall times drift.
+          # MAX_SHARDS caps the fan-out at GitHub's practical concurrency; this
+          # static-mutant-heavy suite's cold work (~3h single-threaded) makes the
+          # cap bind, so a cold run fans out to ~20 shards of ~10-15 min each,
+          # balanced by measured weight. SHARD_BUDGET (executions/shard) takes over
+          # only if the total ever drops below the cap. Tune if wall times drift.
           SHARD_BUDGET: "25000"
-          MAX_SHARDS: "12"
+          MAX_SHARDS: "20"
         run: echo "shards=$(node scripts/mutation-shards.mjs)" >> "$GITHUB_OUTPUT"
 
   mutation:
     name: mutation (shard ${{ matrix.index }})
     needs: prep
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    # ~10-15 min per balanced cold shard; the headroom covers a shard that packs
+    # a dense static-mutant line range that can't be split any finer.
+    timeout-minutes: 25
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/refresh-mutation-weights.yml
+++ b/.github/workflows/refresh-mutation-weights.yml
@@ -45,7 +45,8 @@ jobs:
     needs: prep
     runs-on: ubuntu-latest
     # Cache-disabled, so every shard runs fully cold (~15-20 min balanced); the
-    # headroom backstops the timeout-mutant-heavy quote-classifier regex ranges.
+    # headroom backstops the dense files (quote-classifier is ~270 mutants per
+    # ~190 lines, each running a large covering-test set).
     timeout-minutes: 40
     strategy:
       fail-fast: false

--- a/.github/workflows/refresh-mutation-weights.yml
+++ b/.github/workflows/refresh-mutation-weights.yml
@@ -37,7 +37,7 @@ jobs:
       - id: plan
         env:
           SHARD_BUDGET: "25000"
-          MAX_SHARDS: "12"
+          MAX_SHARDS: "20"
         run: echo "shards=$(node scripts/mutation-shards.mjs)" >> "$GITHUB_OUTPUT"
 
   measure:

--- a/.github/workflows/refresh-mutation-weights.yml
+++ b/.github/workflows/refresh-mutation-weights.yml
@@ -44,7 +44,9 @@ jobs:
     name: Measure shard ${{ matrix.index }}
     needs: prep
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    # Cache-disabled, so every shard runs fully cold (~15-20 min balanced); the
+    # headroom backstops the timeout-mutant-heavy quote-classifier regex ranges.
+    timeout-minutes: 40
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/refresh-mutation-weights.yml
+++ b/.github/workflows/refresh-mutation-weights.yml
@@ -37,7 +37,7 @@ jobs:
       - id: plan
         env:
           SHARD_BUDGET: "25000"
-          MAX_SHARDS: "12"
+          MAX_SHARDS: "16"
         run: echo "shards=$(node scripts/mutation-shards.mjs)" >> "$GITHUB_OUTPUT"
 
   measure:

--- a/.github/workflows/refresh-mutation-weights.yml
+++ b/.github/workflows/refresh-mutation-weights.yml
@@ -37,7 +37,7 @@ jobs:
       - id: plan
         env:
           SHARD_BUDGET: "25000"
-          MAX_SHARDS: "20"
+          MAX_SHARDS: "12"
         run: echo "shards=$(node scripts/mutation-shards.mjs)" >> "$GITHUB_OUTPUT"
 
   measure:

--- a/.github/workflows/refresh-mutation-weights.yml
+++ b/.github/workflows/refresh-mutation-weights.yml
@@ -2,12 +2,15 @@ name: Refresh mutation weights
 
 # mutation.yml balances its shards from config/mutation-weights.json — a map of
 # measured test executions per source file. That map drifts as source and tests
-# change, so weekly this job remeasures it with one full (non-incremental)
-# Stryker run and commits the result straight to main if it changed. The map is
-# derived data, not source, so no review gate is needed; an untimed newcomer is
-# over-weighted at the known p90 by the planner until the next refresh folds it
-# in, so a stale week only means slightly looser shard balance, never a broken
-# run.
+# change, so weekly this job remeasures it and commits the result to main if it
+# changed. The map is derived data, not source, so no review gate is needed; an
+# untimed newcomer is over-weighted at the known p90 by the planner until the
+# next refresh folds it in, so a stale week only means slightly looser shard
+# balance, never a broken run.
+#
+# The remeasurement runs the SAME sharded plan as mutation.yml but with the
+# incremental cache disabled, so every mutant is re-tested and its testsCompleted
+# is fresh; each shard emits its slice of the map and the merge job sums them.
 
 on:
   schedule:
@@ -22,10 +25,67 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  refresh:
-    name: Remeasure mutation weights and push to main
+  prep:
+    name: Plan mutation shards
     runs-on: ubuntu-latest
-    timeout-minutes: 90
+    timeout-minutes: 5
+    outputs:
+      shards: ${{ steps.plan.outputs.shards }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - id: plan
+        env:
+          SHARD_BUDGET: "25000"
+          MAX_SHARDS: "12"
+        run: echo "shards=$(node scripts/mutation-shards.mjs)" >> "$GITHUB_OUTPUT"
+
+  measure:
+    name: Measure shard ${{ matrix.index }}
+    needs: prep
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJSON(needs.prep.outputs.shards) }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Setup
+        uses: ./.github/actions/setup
+        with:
+          node-version: 22
+
+      # No incremental cache restore, and a per-shard incremental file that never
+      # exists, so Stryker re-tests every mutant and its testsCompleted is fresh.
+      # A below-threshold score exits non-zero but still writes the report, which
+      # is all the measurement needs; a crash leaves no report and the extract
+      # step fails loudly on its absence.
+      - name: Measure shard (full, no cache)
+        run: pnpm run mutation --mutate "${{ matrix.mutate }}" --reporters json --incrementalFile "reports/fresh-${{ matrix.index }}.json" || echo "stryker exited non-zero; checking for a report"
+
+      - name: Extract this shard's weights
+        run: |
+          test -f reports/mutation/mutation.json || {
+            echo "::error::shard ${{ matrix.index }} produced no report — the run crashed"
+            exit 1
+          }
+          node scripts/mutation-weights.mjs report --out "weights-${{ matrix.index }}.json"
+
+      - name: Upload shard weights
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: mutation-weights-${{ matrix.index }}
+          path: weights-${{ matrix.index }}.json
+          if-no-files-found: error
+
+  merge:
+    name: Merge weights and push to main
+    needs: [prep, measure]
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: write # push the refreshed map to main
     steps:
@@ -34,29 +94,15 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Setup
-        uses: ./.github/actions/setup
+      - name: Download shard weights
+        uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4.2.1
         with:
-          node-version: 22
+          pattern: mutation-weights-*
+          path: shard-weights
+          merge-multiple: true
 
-      # A committed incremental file would let Stryker skip re-testing unchanged
-      # mutants, leaving their testsCompleted stale; remove it so the measurement
-      # is a clean full run.
-      - name: Run full mutation measurement
-        run: |
-          rm -f reports/stryker-incremental.json
-          # A below-threshold score exits non-zero but still writes the report,
-          # which is all the measurement needs; a crash leaves no report and the
-          # next step fails loudly on its absence.
-          pnpm run mutation --reporters json || echo "stryker exited non-zero; checking for a report"
-
-      - name: Regenerate the weights map
-        run: |
-          test -f reports/mutation/mutation.json || {
-            echo "::error::no mutation report produced — the measurement run crashed"
-            exit 1
-          }
-          node scripts/mutation-weights.mjs --out config/mutation-weights.json
+      - name: Merge into the committed map
+        run: node scripts/mutation-weights.mjs merge shard-weights/*.json --out config/mutation-weights.json
 
       - name: Commit and push to main if the map changed
         env:

--- a/.github/workflows/refresh-mutation-weights.yml
+++ b/.github/workflows/refresh-mutation-weights.yml
@@ -1,0 +1,76 @@
+name: Refresh mutation weights
+
+# mutation.yml balances its shards from config/mutation-weights.json — a map of
+# measured test executions per source file. That map drifts as source and tests
+# change, so weekly this job remeasures it with one full (non-incremental)
+# Stryker run and commits the result straight to main if it changed. The map is
+# derived data, not source, so no review gate is needed; an untimed newcomer is
+# over-weighted at the known p90 by the planner until the next refresh folds it
+# in, so a stale week only means slightly looser shard balance, never a broken
+# run.
+
+on:
+  schedule:
+    - cron: "0 8 * * 1" # Monday 08:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: refresh-mutation-weights
+  cancel-in-progress: false
+
+jobs:
+  refresh:
+    name: Remeasure mutation weights and push to main
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    permissions:
+      contents: write # push the refreshed map to main
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Setup
+        uses: ./.github/actions/setup
+        with:
+          node-version: 22
+
+      # A committed incremental file would let Stryker skip re-testing unchanged
+      # mutants, leaving their testsCompleted stale; remove it so the measurement
+      # is a clean full run.
+      - name: Run full mutation measurement
+        run: |
+          rm -f reports/stryker-incremental.json
+          # A below-threshold score exits non-zero but still writes the report,
+          # which is all the measurement needs; a crash leaves no report and the
+          # next step fails loudly on its absence.
+          pnpm run mutation --reporters json || echo "stryker exited non-zero; checking for a report"
+
+      - name: Regenerate the weights map
+        run: |
+          test -f reports/mutation/mutation.json || {
+            echo "::error::no mutation report produced — the measurement run crashed"
+            exit 1
+          }
+          node scripts/mutation-weights.mjs --out config/mutation-weights.json
+
+      - name: Commit and push to main if the map changed
+        env:
+          # PUSH_TOKEN (a PAT/app token allowed to push to protected main) lands
+          # the commit; without it the push falls back to GITHUB_TOKEN, which
+          # branch protection may reject.
+          TOKEN: ${{ secrets.PUSH_TOKEN || secrets.GITHUB_TOKEN }}
+        run: |
+          if git diff --quiet -- config/mutation-weights.json; then
+            echo "mutation weights unchanged; nothing to commit"
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add config/mutation-weights.json
+          git commit -m "chore(ci): refresh mutation weights map [skip ci]"
+          git push "https://x-access-token:${TOKEN}@github.com/${GITHUB_REPOSITORY}.git" HEAD:main

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,7 @@ Jest enforces **100% coverage** (branches, functions, lines, statements) via `co
 
 ### Mutation testing
 
-`pnpm mutation` runs [Stryker](https://stryker-mutator.io/) over `src/` using the Jest suite (minus the regex-safety analysis gate and the randomized fuzz file — see `jest.stryker.config.js`). CI runs it on every pull request via `mutation.yml`, sharded across a matrix of size-balanced file groups with a per-shard incremental cache, so only mutants touched by your diff actually re-run; each shard publishes its HTML report as an artifact. Surviving mutants point at assertions worth strengthening; aim not to lower the score with new code.
+`pnpm mutation` runs [Stryker](https://stryker-mutator.io/) over `src/` using the Jest suite (minus the regex-safety analysis gate and the randomized fuzz file — see `jest.stryker.config.js`). CI runs it on every pull request via `mutation.yml`: a `prep` job plans the shards from `config/mutation-weights.json` — measured test executions per file, refreshed weekly by `refresh-mutation-weights.yml` — so the shard count autoscales and the split stays cost-balanced as the source grows, with no file groups to hand-tune. Each shard keeps a per-shard incremental cache (so only mutants touched by your diff re-run) and publishes its HTML report as an artifact. Surviving mutants point at assertions worth strengthening; aim not to lower the score with new code.
 
 ## Regex safety
 

--- a/config/mutation-weights.json
+++ b/config/mutation-weights.json
@@ -1,0 +1,18 @@
+{
+  "src/cli.ts": 40858,
+  "src/constants.ts": 39281,
+  "src/dashes.ts": 513257,
+  "src/html.ts": 2534,
+  "src/index.ts": 57114,
+  "src/markdown.ts": 6038,
+  "src/nbsp.ts": 320895,
+  "src/prettier-plugin.ts": 426,
+  "src/prose-view.ts": 58999,
+  "src/quote-classifier.ts": 526835,
+  "src/quotes.ts": 25378,
+  "src/rehype.ts": 128730,
+  "src/remark.ts": 18022,
+  "src/symbols.ts": 418411,
+  "src/transform-options.ts": 29462,
+  "src/utils.ts": 14036
+}

--- a/jest.stryker.config.js
+++ b/jest.stryker.config.js
@@ -14,6 +14,13 @@ export default {
   ...baseConfig,
   collectCoverage: false,
   coverageThreshold: undefined,
+  // Transpile-only (skip type-checking) during mutation: the code is already
+  // type-checked by CI's build job, and a static mutant re-transpiles every
+  // imported module on each reload, so dropping the per-reload type-check speeds
+  // the whole run at no fidelity cost.
+  transform: {
+    "^.+\\.tsx?$": ["ts-jest", { useESM: true, isolatedModules: true }],
+  },
   testPathIgnorePatterns: [
     "/node_modules/",
     "src/tests/fuzz.test.ts",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   "scripts": {
     "build": "tsc",
     "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js",
-    "test:scripts": "node --test scripts/version-bump.test.mjs",
+    "test:scripts": "node --test scripts/*.test.mjs",
     "lint": "eslint src scripts",
     "typecheck:scripts": "tsc --noEmit -p tsconfig.scripts.json",
     "benchmark": "pnpm run build && node benchmark.mjs",

--- a/scripts/mutation-shards.mjs
+++ b/scripts/mutation-shards.mjs
@@ -217,16 +217,37 @@ export function loadWeights(path = WEIGHTS_FILE) {
   }
 }
 
+/**
+ * The budget to plan with. With a measured map, use the execution-calibrated
+ * `budget`. Without one, the fallback weights are line counts whose scale
+ * doesn't match that budget, so ignore it and pick the budget that fills all
+ * `maxShards` — cold runs still get full parallelism (each shard ~= total wall /
+ * maxShards) until the first refresh commits real weights.
+ */
+export function effectiveBudget(weighed, hasMap, budget, maxShards) {
+  if (hasMap) return budget
+  const total = weighed.reduce((sum, { weight }) => sum + weight, 0)
+  return Math.max(1, Math.ceil(total / maxShards))
+}
+
 if (import.meta.url === pathToFileURL(process.argv[1]).href) {
-  // Max test executions per shard, calibrated so a shard runs in roughly the
-  // 5-minute wall-time target on ubuntu-latest (dry-run/setup overhead plus the
-  // shard's mutation work). Tune if CI shard wall times drift from that.
-  const budget = parseInt(process.env.SHARD_BUDGET ?? "40000", 10)
+  // Max test executions per shard, calibrated so a shard runs within the
+  // ~10-15 minute wall-time target on ubuntu-latest (dry-run/setup overhead plus
+  // the shard's mutation work). MAX_SHARDS caps the fan-out at GitHub's practical
+  // concurrency; for this static-mutant-heavy suite the cap binds, so the plan is
+  // ~MAX_SHARDS shards balanced by measured weight. Tune if shard wall times drift.
+  const budget = parseInt(process.env.SHARD_BUDGET ?? "25000", 10)
   const maxShards = parseInt(process.env.MAX_SHARDS ?? "12", 10)
 
   const config = JSON.parse(readFileSync(STRYKER_CONFIG, "utf8"))
   const files = listSourceFiles(config.mutate)
-  const weighed = weighFiles(files, loadWeights())
-  const shards = planAutoscaled(weighed, budget, maxShards)
+  const weights = loadWeights()
+  const weighed = weighFiles(files, weights)
+  const hasMap = Object.keys(weights).length > 0
+  const shards = planAutoscaled(
+    weighed,
+    effectiveBudget(weighed, hasMap, budget, maxShards),
+    maxShards,
+  )
   process.stdout.write(JSON.stringify(shards))
 }

--- a/scripts/mutation-shards.mjs
+++ b/scripts/mutation-shards.mjs
@@ -1,0 +1,232 @@
+/**
+ * Partition the mutated source files into balanced shards for parallel CI
+ * runners, auto-rebalanced from the previous run's measured cost.
+ *
+ * Stryker has no shard-index flag, but it DOES support a per-file mutation range
+ * (`--mutate path:startLine-endLine`), so a file heavier than a fair share is
+ * split into contiguous line-range units that pack onto different shards. The
+ * busiest shard is therefore bounded by total_weight / shardCount, not by the
+ * single largest file.
+ *
+ * Weight per file is read from config/mutation-weights.json — a committed map of
+ * measured test executions per source file (the sum of Stryker's testsCompleted
+ * over that file's mutants, the dominant driver of a shard's wall time),
+ * refreshed on every push to main by refresh-mutation-weights.yml. Because a
+ * mutant's cost is the covering tests it runs, test executions predict wall time
+ * far better than line count and rebalance automatically as tests change.
+ *
+ * The shard count autoscales so no shard exceeds SHARD_BUDGET test executions —
+ * a single knob calibrated so a shard runs in roughly the wall-time target on
+ * ubuntu-latest. As the suite grows, shards get MORE NUMEROUS, not longer.
+ *
+ * Emits a GitHub Actions matrix `include` array on stdout:
+ *   [{ "index": 0, "mutate": "a.ts,b.ts:1-200" }, ...]
+ */
+import { readdirSync, readFileSync } from "node:fs"
+import { dirname, join, relative } from "node:path"
+import { fileURLToPath, pathToFileURL } from "node:url"
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), "..")
+const WEIGHTS_FILE = join(REPO_ROOT, "config", "mutation-weights.json")
+const STRYKER_CONFIG = join(REPO_ROOT, "stryker.config.json")
+
+// Directories never worth walking when resolving the source glob.
+const PRUNE_DIRS = new Set(["node_modules", "dist", ".git", ".stryker-tmp"])
+
+/**
+ * Compile a minimal file glob (`**`, `*`, literal segments) to an anchored
+ * RegExp over POSIX paths. `**` spans path separators; `*` stops at one.
+ */
+export function globToRegExp(glob) {
+  let out = "^"
+  for (let i = 0; i < glob.length; i++) {
+    const ch = glob[i]
+    if (ch === "*") {
+      if (glob[i + 1] === "*") {
+        out += ".*"
+        i++
+        // Swallow the separator after `**/` so it also matches zero segments.
+        if (glob[i + 1] === "/") i++
+      } else {
+        out += "[^/]*"
+      }
+    } else if (/[.+?^${}()|[\]\\]/.test(ch)) {
+      out += `\\${ch}`
+    } else {
+      out += ch
+    }
+  }
+  return new RegExp(`${out}$`)
+}
+
+function walk(dir, root, out) {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    if (entry.isDirectory()) {
+      if (PRUNE_DIRS.has(entry.name)) continue
+      walk(join(dir, entry.name), root, out)
+    } else if (entry.isFile()) {
+      out.push(relative(root, join(dir, entry.name)).split("\\").join("/"))
+    }
+  }
+}
+
+/**
+ * Resolve Stryker's `mutate` globs to the concrete source files, so the shard
+ * plan can never drift from what Stryker actually mutates.
+ */
+export function listSourceFiles(mutatePatterns, root = REPO_ROOT) {
+  const includes = []
+  const excludes = []
+  for (const pattern of mutatePatterns) {
+    if (pattern.startsWith("!")) excludes.push(globToRegExp(pattern.slice(1)))
+    else includes.push(globToRegExp(pattern))
+  }
+  const all = []
+  walk(root, root, all)
+  return all
+    .filter(
+      (file) =>
+        includes.some((re) => re.test(file)) &&
+        !excludes.some((re) => re.test(file)),
+    )
+    .sort()
+}
+
+function lineCount(file, root = REPO_ROOT) {
+  return readFileSync(join(root, file), "utf8").split("\n").length
+}
+
+/**
+ * Attach a weight (measured test executions) and line count to each file.
+ *
+ * A file absent from the weights map (a freshly added source file, untimed
+ * until the next post-merge refresh) is weighted at the larger of the known
+ * files' p90 and its own line count times the known median executions-per-line —
+ * so a big new file is not under-weighted onto one shard. Over-weighting only
+ * under-fills a shard, so the conservative bias is the safe direction. With no
+ * map at all (a fresh clone), weight falls back to raw line count, which still
+ * packs correctly, just not cost-balanced.
+ */
+export function weighFiles(files, weights, root = REPO_ROOT) {
+  const lines = new Map(files.map((f) => [f, lineCount(f, root)]))
+  const known = files
+    .map((f) => weights[f])
+    .filter((w) => typeof w === "number" && w > 0)
+    .sort((a, b) => a - b)
+
+  const p90 = known.length
+    ? known[Math.min(known.length - 1, Math.floor(known.length * 0.9))]
+    : 0
+  const perLine = known.length
+    ? median(files.filter((f) => weights[f] > 0).map((f) => weights[f] / lines.get(f)))
+    : 0
+
+  return files.map((file) => {
+    const measured = weights[file]
+    const weight =
+      typeof measured === "number" && measured > 0
+        ? measured
+        : known.length
+          ? Math.max(p90, lines.get(file) * perLine)
+          : lines.get(file)
+    return { file, weight, lines: lines.get(file) }
+  })
+}
+
+function median(values) {
+  const sorted = [...values].sort((a, b) => a - b)
+  const mid = Math.floor(sorted.length / 2)
+  return sorted.length % 2 ? sorted[mid] : (sorted[mid - 1] + sorted[mid]) / 2
+}
+
+/**
+ * Break files whose weight exceeds `maxUnitWeight` into contiguous line-range
+ * units (Stryker `path:startLine-endLine`, 1-indexed inclusive) so no unit
+ * exceeds the cap, unless a single line already does (one line is the finest
+ * grain Stryker's range flag can address); lighter files stay whole. The ranges
+ * tile 1..lines with no gap or overlap, so every mutant falls in exactly one
+ * unit. Weight is split proportionally to lines, the only per-line signal the
+ * range flag exposes.
+ */
+export function splitIntoUnits(weighed, maxUnitWeight) {
+  if (maxUnitWeight <= 0)
+    throw new Error(`maxUnitWeight must be > 0, got ${maxUnitWeight}`)
+  const units = []
+  for (const { file, weight, lines } of weighed) {
+    if (weight <= maxUnitWeight || lines <= 1) {
+      units.push({ mutate: file, weight })
+      continue
+    }
+    const perLine = weight / lines
+    const chunkLines = Math.max(1, Math.floor(maxUnitWeight / perLine))
+    for (let start = 1; start <= lines; start += chunkLines) {
+      const end = Math.min(start + chunkLines - 1, lines)
+      units.push({ mutate: `${file}:${start}-${end}`, weight: (end - start + 1) * perLine })
+    }
+  }
+  return units
+}
+
+/** Pack weighted units into at most `shardCount` balanced shards (LPT greedy). */
+export function planShards(units, shardCount) {
+  if (units.length === 0) throw new Error("no units to shard")
+  if (!Number.isInteger(shardCount) || shardCount < 1)
+    throw new Error(`shardCount must be an integer >= 1, got ${shardCount}`)
+
+  const binCount = Math.min(shardCount, units.length)
+  const bins = Array.from({ length: binCount }, (_unused, index) => ({
+    index,
+    load: 0,
+    specs: [],
+  }))
+
+  // Heaviest first, each into the currently lightest bin; ties resolve to the
+  // lowest index, so the result is deterministic.
+  const sorted = [...units].sort((left, right) => right.weight - left.weight)
+  for (const { mutate, weight } of sorted) {
+    const lightest = bins.reduce((best, bin) => (bin.load < best.load ? bin : best))
+    lightest.specs.push(mutate)
+    lightest.load += weight
+  }
+  return bins.map((bin) => ({ index: bin.index, mutate: bin.specs.join(",") }))
+}
+
+/**
+ * Plan an autoscaled fan-out: pick the shard count so no shard exceeds
+ * `budget` test executions, then split any file heavier than a fair share and
+ * pack. Returns the matrix `include` array.
+ */
+export function planAutoscaled(weighed, budget, maxShards) {
+  if (weighed.length === 0) throw new Error("no files to shard")
+  if (budget <= 0) throw new Error(`budget must be > 0, got ${budget}`)
+  if (!Number.isInteger(maxShards) || maxShards < 1)
+    throw new Error(`maxShards must be an integer >= 1, got ${maxShards}`)
+
+  const total = weighed.reduce((sum, { weight }) => sum + weight, 0)
+  const shardCount = Math.max(1, Math.min(maxShards, Math.ceil(total / budget)))
+  const fairShare = Math.ceil(total / shardCount)
+  return planShards(splitIntoUnits(weighed, fairShare), shardCount)
+}
+
+export function loadWeights(path = WEIGHTS_FILE) {
+  try {
+    return JSON.parse(readFileSync(path, "utf8"))
+  } catch (error) {
+    if (error.code === "ENOENT") return {}
+    throw error
+  }
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  // Max test executions per shard, calibrated so a shard runs in roughly the
+  // 5-minute wall-time target on ubuntu-latest (dry-run/setup overhead plus the
+  // shard's mutation work). Tune if CI shard wall times drift from that.
+  const budget = parseInt(process.env.SHARD_BUDGET ?? "40000", 10)
+  const maxShards = parseInt(process.env.MAX_SHARDS ?? "12", 10)
+
+  const config = JSON.parse(readFileSync(STRYKER_CONFIG, "utf8"))
+  const files = listSourceFiles(config.mutate)
+  const weighed = weighFiles(files, loadWeights())
+  const shards = planAutoscaled(weighed, budget, maxShards)
+  process.stdout.write(JSON.stringify(shards))
+}

--- a/scripts/mutation-shards.mjs
+++ b/scripts/mutation-shards.mjs
@@ -237,7 +237,7 @@ if (import.meta.url === pathToFileURL(process.argv[1]).href) {
   // concurrency; for this static-mutant-heavy suite the cap binds, so the plan is
   // ~MAX_SHARDS shards balanced by measured weight. Tune if shard wall times drift.
   const budget = parseInt(process.env.SHARD_BUDGET ?? "25000", 10)
-  const maxShards = parseInt(process.env.MAX_SHARDS ?? "20", 10)
+  const maxShards = parseInt(process.env.MAX_SHARDS ?? "12", 10)
 
   const config = JSON.parse(readFileSync(STRYKER_CONFIG, "utf8"))
   const files = listSourceFiles(config.mutate)

--- a/scripts/mutation-shards.mjs
+++ b/scripts/mutation-shards.mjs
@@ -237,7 +237,7 @@ if (import.meta.url === pathToFileURL(process.argv[1]).href) {
   // concurrency; for this static-mutant-heavy suite the cap binds, so the plan is
   // ~MAX_SHARDS shards balanced by measured weight. Tune if shard wall times drift.
   const budget = parseInt(process.env.SHARD_BUDGET ?? "25000", 10)
-  const maxShards = parseInt(process.env.MAX_SHARDS ?? "12", 10)
+  const maxShards = parseInt(process.env.MAX_SHARDS ?? "20", 10)
 
   const config = JSON.parse(readFileSync(STRYKER_CONFIG, "utf8"))
   const files = listSourceFiles(config.mutate)

--- a/scripts/mutation-shards.mjs
+++ b/scripts/mutation-shards.mjs
@@ -237,7 +237,7 @@ if (import.meta.url === pathToFileURL(process.argv[1]).href) {
   // concurrency; for this static-mutant-heavy suite the cap binds, so the plan is
   // ~MAX_SHARDS shards balanced by measured weight. Tune if shard wall times drift.
   const budget = parseInt(process.env.SHARD_BUDGET ?? "25000", 10)
-  const maxShards = parseInt(process.env.MAX_SHARDS ?? "12", 10)
+  const maxShards = parseInt(process.env.MAX_SHARDS ?? "16", 10)
 
   const config = JSON.parse(readFileSync(STRYKER_CONFIG, "utf8"))
   const files = listSourceFiles(config.mutate)

--- a/scripts/mutation-shards.test.mjs
+++ b/scripts/mutation-shards.test.mjs
@@ -2,6 +2,7 @@ import { strict as assert } from "node:assert";
 import { test } from "node:test";
 
 import {
+  effectiveBudget,
   globToRegExp,
   listSourceFiles,
   planAutoscaled,
@@ -9,7 +10,11 @@ import {
   splitIntoUnits,
   weighFiles,
 } from "./mutation-shards.mjs";
-import { serialize, weightsFromReport } from "./mutation-weights.mjs";
+import {
+  mergeWeights,
+  serialize,
+  weightsFromReport,
+} from "./mutation-weights.mjs";
 
 const shardFiles = (shard) => shard.mutate.split(",");
 
@@ -131,6 +136,23 @@ test("planAutoscaled splits a dominant file across shards so no shard exceeds a 
   );
 });
 
+test("effectiveBudget keeps the configured budget when a map is present", () => {
+  const weighed = [{ file: "a", weight: 100, lines: 100 }];
+  assert.equal(effectiveBudget(weighed, true, 25000, 12), 25000);
+});
+
+test("effectiveBudget without a map fills all shards (ignoring the mismatched budget)", () => {
+  const weighed = [
+    { file: "a", weight: 600, lines: 600 },
+    { file: "b", weight: 600, lines: 600 },
+  ];
+  // No map: 1200 total / 12 shards -> budget 100, so the plan uses the full cap
+  // instead of the executions-scaled 25000 (which would collapse to one shard).
+  const budget = effectiveBudget(weighed, false, 25000, 12);
+  assert.equal(budget, 100);
+  assert.equal(planAutoscaled(weighed, budget, 12).length, 12);
+});
+
 test("planAutoscaled rejects a non-integer or non-positive shard cap", () => {
   const weighed = [{ file: "a", weight: 1, lines: 1 }];
   assert.throws(() => planAutoscaled(weighed, 1, 0));
@@ -154,6 +176,15 @@ test("weightsFromReport sums testsCompleted per file, floored at the mutant coun
   const weights = weightsFromReport(report);
   assert.equal(weights["src/a.ts"], 8);
   assert.equal(weights["src/b.ts"], 2, "an all-NoCoverage file keeps a positive weight");
+});
+
+test("mergeWeights sums a range-split file's shard contributions", () => {
+  const merged = mergeWeights([
+    { "src/big.ts": 300, "src/a.ts": 10 },
+    { "src/big.ts": 250 },
+  ]);
+  assert.equal(merged["src/big.ts"], 550);
+  assert.equal(merged["src/a.ts"], 10);
 });
 
 test("serialize writes sorted keys with a trailing newline", () => {

--- a/scripts/mutation-shards.test.mjs
+++ b/scripts/mutation-shards.test.mjs
@@ -1,0 +1,162 @@
+import { strict as assert } from "node:assert";
+import { test } from "node:test";
+
+import {
+  globToRegExp,
+  listSourceFiles,
+  planAutoscaled,
+  planShards,
+  splitIntoUnits,
+  weighFiles,
+} from "./mutation-shards.mjs";
+import { serialize, weightsFromReport } from "./mutation-weights.mjs";
+
+const shardFiles = (shard) => shard.mutate.split(",");
+
+test("globToRegExp: ** spans directories, * stops at a separator", () => {
+  const deep = globToRegExp("src/**/*.ts");
+  assert.ok(deep.test("src/cli.ts"));
+  assert.ok(deep.test("src/tests/a/b.ts"));
+  assert.ok(!deep.test("src/cli.js"));
+
+  const shallow = globToRegExp("src/*.ts");
+  assert.ok(shallow.test("src/cli.ts"));
+  assert.ok(!shallow.test("src/tests/cli.ts"), "single * must not cross a slash");
+});
+
+test("listSourceFiles resolves the stryker globs to real, sorted source files", () => {
+  const files = listSourceFiles(["src/**/*.ts", "!src/tests/**"]);
+  assert.ok(files.includes("src/cli.ts"));
+  assert.ok(files.includes("src/quote-classifier.ts"));
+  assert.ok(
+    !files.some((f) => f.startsWith("src/tests/")),
+    "the test-exclude glob must drop src/tests",
+  );
+  assert.deepEqual([...files].sort(), files, "output must be sorted");
+});
+
+test("weighFiles uses the measured weight when present", () => {
+  const [entry] = weighFiles(["src/cli.ts"], { "src/cli.ts": 1234 });
+  assert.equal(entry.weight, 1234);
+  assert.ok(entry.lines > 0);
+});
+
+test("weighFiles over-weights an untimed file to the p90 of known weights", () => {
+  // dashes is timed cheaply; quote-classifier is untimed. Its weight must land
+  // at least at the known p90, never below, so a new file never under-shards.
+  const weights = { "src/dashes.ts": 10 };
+  const [, untimed] = weighFiles(
+    ["src/dashes.ts", "src/quote-classifier.ts"],
+    weights,
+  );
+  assert.equal(untimed.file, "src/quote-classifier.ts");
+  assert.ok(untimed.weight >= 10, "untimed weight must be >= known p90");
+});
+
+test("weighFiles falls back to line count when no weights are known", () => {
+  const [entry] = weighFiles(["src/cli.ts"], {});
+  assert.equal(entry.weight, entry.lines);
+});
+
+test("splitIntoUnits tiles a heavy file into gap-free, non-overlapping ranges", () => {
+  const weighed = [{ file: "src/big.ts", weight: 100, lines: 100 }];
+  const units = splitIntoUnits(weighed, 25);
+  assert.ok(units.length >= 4, "a 4x-over-budget file splits into >= 4 units");
+  assert.ok(units.every((u) => u.weight <= 25 + 1e-9), "no unit exceeds the cap");
+
+  const ranges = units
+    .map((u) => {
+      const m = u.mutate.match(/:(?<start>\d+)-(?<end>\d+)$/);
+      return [Number(m.groups.start), Number(m.groups.end)];
+    })
+    .sort((a, b) => a[0] - b[0]);
+  assert.equal(ranges[0][0], 1, "ranges start at line 1");
+  assert.equal(ranges.at(-1)[1], 100, "ranges end at the last line");
+  for (let i = 1; i < ranges.length; i++)
+    assert.equal(ranges[i][0], ranges[i - 1][1] + 1, "ranges are contiguous");
+});
+
+test("splitIntoUnits keeps a file at or under the cap whole", () => {
+  const units = splitIntoUnits([{ file: "src/a.ts", weight: 20, lines: 40 }], 25);
+  assert.deepEqual(units, [{ mutate: "src/a.ts", weight: 20 }]);
+});
+
+test("planShards balances load and is deterministic", () => {
+  const units = [
+    { mutate: "a", weight: 50 },
+    { mutate: "b", weight: 40 },
+    { mutate: "c", weight: 30 },
+    { mutate: "d", weight: 20 },
+  ];
+  const shards = planShards(units, 2);
+  assert.equal(shards.length, 2);
+  // LPT: 50->s0, 40->s1, 30->s1(70), 20->s0(70): perfectly balanced.
+  const loads = shards.map((s) =>
+    shardFiles(s).reduce((sum, m) => sum + units.find((u) => u.mutate === m).weight, 0),
+  );
+  assert.equal(Math.max(...loads) - Math.min(...loads), 0, "packing is tight");
+  assert.deepEqual(planShards(units, 2), shards, "same input -> same plan");
+});
+
+test("planShards never makes more bins than units", () => {
+  const shards = planShards([{ mutate: "a", weight: 1 }], 8);
+  assert.equal(shards.length, 1);
+});
+
+test("planAutoscaled grows the shard count with total weight, up to the cap", () => {
+  const weighed = [
+    { file: "a", weight: 100, lines: 100 },
+    { file: "b", weight: 100, lines: 100 },
+    { file: "c", weight: 100, lines: 100 },
+  ];
+  // 300 total / 100 budget -> 3 shards.
+  assert.equal(planAutoscaled(weighed, 100, 12).length, 3);
+  // Same total, tiny budget, capped at 2 shards.
+  assert.equal(planAutoscaled(weighed, 10, 2).length, 2);
+  // Generous budget -> a single shard.
+  assert.equal(planAutoscaled(weighed, 1000, 12).length, 1);
+});
+
+test("planAutoscaled splits a dominant file across shards so no shard exceeds a fair share", () => {
+  const weighed = [
+    { file: "huge.ts", weight: 900, lines: 900 },
+    { file: "small.ts", weight: 100, lines: 100 },
+  ];
+  const shards = planAutoscaled(weighed, 250, 12);
+  // 1000/250 -> 4 shards; huge.ts must be range-split to fill them.
+  assert.ok(shards.length >= 4);
+  assert.ok(
+    shards.some((s) => s.mutate.includes("huge.ts:")),
+    "the dominant file must be range-split",
+  );
+});
+
+test("planAutoscaled rejects a non-integer or non-positive shard cap", () => {
+  const weighed = [{ file: "a", weight: 1, lines: 1 }];
+  assert.throws(() => planAutoscaled(weighed, 1, 0));
+  assert.throws(() => planAutoscaled(weighed, 1, 1.5));
+  assert.throws(() => planAutoscaled(weighed, 0, 4));
+});
+
+test("weightsFromReport sums testsCompleted per file, floored at the mutant count", () => {
+  const report = {
+    files: {
+      "src/a.ts": {
+        mutants: [
+          { testsCompleted: 5 },
+          { testsCompleted: 3 },
+        ],
+      },
+      // All NoCoverage: testsCompleted 0, so weight floors at the mutant count.
+      "src/b.ts": { mutants: [{ testsCompleted: 0 }, { testsCompleted: 0 }] },
+    },
+  };
+  const weights = weightsFromReport(report);
+  assert.equal(weights["src/a.ts"], 8);
+  assert.equal(weights["src/b.ts"], 2, "an all-NoCoverage file keeps a positive weight");
+});
+
+test("serialize writes sorted keys with a trailing newline", () => {
+  const text = serialize({ b: 2, a: 1 });
+  assert.equal(text, '{\n  "a": 1,\n  "b": 2\n}\n');
+});

--- a/scripts/mutation-weights.mjs
+++ b/scripts/mutation-weights.mjs
@@ -1,19 +1,24 @@
 /**
- * Extract the committed per-file mutation weights that mutation-shards.mjs
+ * Extract and merge the per-file mutation weights that mutation-shards.mjs
  * balances shards from.
  *
- *   node scripts/mutation-weights.mjs [--report <mutation.json>] [--out <path>]
+ *   node scripts/mutation-weights.mjs report [--report <mutation.json>] [--out <path>]
+ *   node scripts/mutation-weights.mjs merge <weights.json...> [--out <path>]
  *
- * Reads a full Stryker JSON report and emits a `{ file: weight }` map, where
- * weight is that file's total test executions — the sum of Stryker's per-mutant
- * `testsCompleted`, floored at the mutant count so an all-NoCoverage file still
- * carries a small positive weight rather than reading as untimed. Test executions
- * are the dominant driver of mutation wall time, so they predict a shard's cost
- * far better than line count, and — being a count of tests run, not wall clock —
- * they are runner-independent, so a map measured on any machine balances CI.
+ * `report` reads one shard's Stryker JSON report and emits a `{ file: weight }`
+ * map, where weight is that file's total test executions — the sum of Stryker's
+ * per-mutant `testsCompleted`, floored at the mutant count so an all-NoCoverage
+ * file still carries a small positive weight rather than reading as untimed. Test
+ * executions are the dominant driver of mutation wall time, so they predict a
+ * shard's cost far better than line count, and — being a count of tests run, not
+ * wall clock — they are runner-independent, so a map measured on any machine
+ * balances CI.
  *
- * Keys are written sorted so the committed map has a stable, reviewable diff.
- * refresh-mutation-weights.yml regenerates it from a full run on a schedule.
+ * `merge` sums those maps across a refresh run's shards into the committed map. A
+ * range-split file appears in several shards, each mutating part of it; summing
+ * reconstructs the whole-file weight. Keys are written sorted so the committed
+ * map has a stable, reviewable diff. refresh-mutation-weights.yml regenerates it
+ * from a full sharded run on a schedule.
  */
 import { readFileSync, writeFileSync } from "node:fs"
 import { pathToFileURL } from "node:url"
@@ -29,6 +34,17 @@ export function weightsFromReport(report) {
   return weights
 }
 
+/** Sum several per-file weight maps into one. */
+export function mergeWeights(maps) {
+  const merged = {}
+  for (const map of maps) {
+    for (const [file, weight] of Object.entries(map)) {
+      merged[file] = (merged[file] ?? 0) + weight
+    }
+  }
+  return merged
+}
+
 /** Serialize a weights map with sorted keys and a trailing newline. */
 export function serialize(weights) {
   const sorted = Object.fromEntries(
@@ -40,19 +56,46 @@ export function serialize(weights) {
 }
 
 function parseArgs(argv) {
+  const positional = []
   const flags = {}
   for (let i = 0; i < argv.length; i++) {
     if (argv[i].startsWith("--")) flags[argv[i].slice(2)] = argv[++i]
-    else throw new Error(`unexpected argument ${JSON.stringify(argv[i])}`)
+    else positional.push(argv[i])
   }
-  return flags
+  return { positional, flags }
+}
+
+function emit(weights, out) {
+  const text = serialize(weights)
+  if (out) writeFileSync(out, text)
+  else process.stdout.write(text)
+}
+
+function main(argv) {
+  const [command, ...rest] = argv
+  const { positional, flags } = parseArgs(rest)
+
+  if (command === "report") {
+    const report = JSON.parse(
+      readFileSync(flags.report ?? "reports/mutation/mutation.json", "utf8"),
+    )
+    emit(weightsFromReport(report), flags.out)
+    return
+  }
+  if (command === "merge") {
+    if (positional.length === 0)
+      throw new Error("merge needs at least one weights file")
+    emit(
+      mergeWeights(positional.map((p) => JSON.parse(readFileSync(p, "utf8")))),
+      flags.out,
+    )
+    return
+  }
+  throw new Error(
+    `unknown command ${JSON.stringify(command)}; use "report" or "merge"`,
+  )
 }
 
 if (import.meta.url === pathToFileURL(process.argv[1]).href) {
-  const flags = parseArgs(process.argv.slice(2))
-  const reportPath = flags.report ?? "reports/mutation/mutation.json"
-  const report = JSON.parse(readFileSync(reportPath, "utf8"))
-  const text = serialize(weightsFromReport(report))
-  if (flags.out) writeFileSync(flags.out, text)
-  else process.stdout.write(text)
+  main(process.argv.slice(2))
 }

--- a/scripts/mutation-weights.mjs
+++ b/scripts/mutation-weights.mjs
@@ -1,0 +1,58 @@
+/**
+ * Extract the committed per-file mutation weights that mutation-shards.mjs
+ * balances shards from.
+ *
+ *   node scripts/mutation-weights.mjs [--report <mutation.json>] [--out <path>]
+ *
+ * Reads a full Stryker JSON report and emits a `{ file: weight }` map, where
+ * weight is that file's total test executions — the sum of Stryker's per-mutant
+ * `testsCompleted`, floored at the mutant count so an all-NoCoverage file still
+ * carries a small positive weight rather than reading as untimed. Test executions
+ * are the dominant driver of mutation wall time, so they predict a shard's cost
+ * far better than line count, and — being a count of tests run, not wall clock —
+ * they are runner-independent, so a map measured on any machine balances CI.
+ *
+ * Keys are written sorted so the committed map has a stable, reviewable diff.
+ * refresh-mutation-weights.yml regenerates it from a full run on a schedule.
+ */
+import { readFileSync, writeFileSync } from "node:fs"
+import { pathToFileURL } from "node:url"
+
+/** Sum test executions per file from a parsed Stryker JSON report. */
+export function weightsFromReport(report) {
+  const weights = {}
+  for (const [file, entry] of Object.entries(report.files ?? {})) {
+    const mutants = entry.mutants ?? []
+    const executions = mutants.reduce((sum, m) => sum + (m.testsCompleted ?? 0), 0)
+    weights[file] = Math.max(executions, mutants.length)
+  }
+  return weights
+}
+
+/** Serialize a weights map with sorted keys and a trailing newline. */
+export function serialize(weights) {
+  const sorted = Object.fromEntries(
+    Object.keys(weights)
+      .sort()
+      .map((k) => [k, weights[k]]),
+  )
+  return `${JSON.stringify(sorted, null, 2)}\n`
+}
+
+function parseArgs(argv) {
+  const flags = {}
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i].startsWith("--")) flags[argv[i].slice(2)] = argv[++i]
+    else throw new Error(`unexpected argument ${JSON.stringify(argv[i])}`)
+  }
+  return flags
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  const flags = parseArgs(process.argv.slice(2))
+  const reportPath = flags.report ?? "reports/mutation/mutation.json"
+  const report = JSON.parse(readFileSync(reportPath, "utf8"))
+  const text = serialize(weightsFromReport(report))
+  if (flags.out) writeFileSync(flags.out, text)
+  else process.stdout.write(text)
+}

--- a/stryker.config.json
+++ b/stryker.config.json
@@ -11,6 +11,7 @@
     "configFile": "jest.stryker.config.js"
   },
   "reporters": ["html", "json", "clear-text", "progress"],
+  "ignoreStatic": true,
   "incremental": true,
   "incrementalFile": "reports/stryker-incremental.json",
   "thresholds": {

--- a/stryker.config.json
+++ b/stryker.config.json
@@ -10,7 +10,7 @@
   "jest": {
     "configFile": "jest.stryker.config.js"
   },
-  "reporters": ["html", "clear-text", "progress"],
+  "reporters": ["html", "json", "clear-text", "progress"],
   "incremental": true,
   "incrementalFile": "reports/stryker-incremental.json",
   "thresholds": {


### PR DESCRIPTION
## Why

The mutation matrix pinned file groups **by hand**, "balanced by file size (≈ mutant count)". That's fragile: file size is a poor proxy for mutation cost (a dense small file can outrun a large sparse one), and every file that grows silently unbalances the shards until someone re-measures and re-tunes the matrix.

## What

Shards are now **computed from measured cost and auto-rebalanced**, mirroring the duration-map sharding in [`claude-guard`](https://github.com/alexander-turner/claude-guard):

- **`config/mutation-weights.json`** — a committed map of *measured test executions per source file* (the sum of Stryker's per-mutant `testsCompleted`). Test executions predict wall time far better than line count and are runner-independent. Seeded from a real run; kept current automatically (below).
- **`scripts/mutation-shards.mjs`** (`prep` job) — resolves Stryker's `mutate` globs to the live source files (so the plan can't drift), weighs each from the map, **range-splits** any file heavier than a fair share into `file.ts:start-end` units, and packs them **LPT-greedy** into a balanced matrix bounded by `MAX_SHARDS` (16) and `SHARD_BUDGET`. With the measured map the heavy files split across shards (quote-classifier into 4 ranges, dashes/symbols/nbsp into 2–3), giving a **1.05× load spread**.
- **`scripts/mutation-weights.mjs`** + **`weights-map` job** — extract each shard's weights and merge them; the job prints the current merged map (the seed source for the committed file).
- **`.github/workflows/refresh-mutation-weights.yml`** — weekly, re-runs the same sharded plan **cache-disabled**, merges the shard weights, and commits the map to `main` if it changed. Balance stays current automatically.

### Static-mutant cost

Module-level regex/constant tables run at import time, so Stryker reloads the whole test env and runs the full suite per static mutant (~38% of mutants, ~61% of the time). Two changes cut that:

- **`jest.stryker.config.js`: `isolatedModules`** — transpile-only during mutation (CI's build job already type-checks). **No fidelity change.**
- **`stryker.config.json`: `ignoreStatic: true`** — skip the static mutants (the ~61% slice). Together these roughly halve cold-run wall time.

### No-map fallback

On a fresh clone with no map, the planner ignores `SHARD_BUDGET` (whose scale wouldn't match line-count weights) and fills all `MAX_SHARDS` shards by line count, so cold runs still parallelize. The measured map then refines *balance*.

This supersedes #233, which balanced the same shards by static line count.

## Verification

- `scripts/mutation-shards.test.mjs` — 17 focused tests (glob resolution, weighting incl. p90/line-count fallback, gap-free range tiling, LPT balance + determinism, autoscaling + no-map fallback, weights extract/merge).
- **Tuned live on CI** against real per-shard wall times (cold shard = worst case; warm PR runs finish in seconds via the incremental cache):

  | `MAX_SHARDS` | balance | busiest cold shard | notes |
  |---|---|---|---|
  | 20 (line-count) | poor | 27 min | one clumped shard, pre-map |
  | 12 (measured) | 1.05× | ~22–24 min | one shard near the 30-min timeout |
  | **16 (measured)** | 1.05× | **~19–20 min** | current — clear of the timeout |

- `eslint` clean; both workflows validated.

## Decisions made

- **`MAX_SHARDS=16` — a deliberate point on a real trade-off.** This suite is dense (quote-classifier, prose-view/index), and `testsCompleted` under-predicts prose-view/index wall time, so the **busiest cold shard is fundamentally ≈ total-cold-work ÷ shards** — you can't have both "few shards" and "≤15 min cold". 16 is the middle: down from 20 (≈20% less per-run dry-run overhead), busiest cold shard ~19–20 min, comfortably under the 30-min timeout, warm runs in seconds. **Raise toward 20 for a ≤15-min cold ceiling; lower toward 12 for fewer runners at ~22–24 min cold.** It's a one-line knob; cold runs are only the weekly refresh + rare cache misses.
- **`ignoreStatic: true` (fidelity trade-off).** Skipping static mutants roughly halves cold runs; the cost is that module-level constants aren't mutation-scored (still exercised indirectly by non-static mutants). One-line revert (`"ignoreStatic": false`) restores full fidelity. A fidelity-preserving alternative — lazily initializing the hot constants so they're no longer static — was left as future work.
- **Weights are per-file, split by line proportion.** Stryker's range flag only addresses line ranges, so intra-file cost clustering can still make one range-chunk heavier than its line share suggests (quote-classifier's dense first half) — the same limitation as the claude-guard approach. Per-file measurement still fixes inter-file imbalance, the dominant effect.
