### PR TITLE
fix: correctness fixes from an adversarial audit (quotes, legal symbols, option resolution)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Unreleased
 
+### Fixed
+
+- A closing double quote isolated in its own node (a node boundary on each side, e.g. `"Hi<sup>"</sup>`) no longer becomes a second opening quote; it now closes the open quotation as it does in the single-node path.
+- Legal markers glued directly after a slash (`foo/(tm)`, `example.com/(c) 2024`) are recognized as path/URL context and left untouched, matching the existing `example.com/path(c)` behavior.
+- An explicit `null` passed as `punctuationStyle`/`dashStyle` from untyped callers now resolves to the default instead of surviving into the resolved options.
+
+### Removed
+
+- Dropped the unused `ISSUES_URL` constant.
+
 ## [5.2.0] - 2026-07-11
 
 ### Fixed

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -157,9 +157,6 @@ export const MAX_BOUNDARY_SEPARATORS = 3
 /** Max AST recursion depth; guards against stack overflow from deep nesting. */
 export const MAX_RECURSION_DEPTH = 1000
 
-/** Single source of truth for issue tracker URL in error messages. */
-export const ISSUES_URL = "https://github.com/AlexanderMattTurner/punctilio/issues"
-
 export const MAX_REGEX_CACHE_SIZE = 1000
 const regexCache = new QuickLRU<string, RegExp>({ maxSize: MAX_REGEX_CACHE_SIZE })
 

--- a/src/quote-classifier.ts
+++ b/src/quote-classifier.ts
@@ -705,30 +705,49 @@ function foldsToNotEqual(items: Item[], index: number): boolean {
  * mirror of {@link classifyClosingDoubles}'s opener-side absorption).
  */
 function classifyOpeningDoubles(items: Item[], style: ActiveQuoteStyle): void {
+  // `doubleOpenerPrefixOk` treats a bare node boundary as opener context, so a
+  // straight double quote isolated in its own node (a boundary on each side)
+  // reads as an opener even when it is really closing an open quotation — e.g.
+  // the `"` in `"Hi<sup>"</sup>` would become a second opener, leaving
+  // unbalanced output. Track the running opener depth, exactly as
+  // `classifyQuotedPunctuationOpeners` does, and suppress opening only when the
+  // opener context is supplied *solely* by a preceding boundary while a
+  // quotation is already open. A real opener character (space, comma, newline,
+  // `(`) still opens at any depth, so nested doubles (`'She said, "hello"'`) and
+  // multi-paragraph dialogue (each paragraph re-opens) are unaffected.
+  let openDepth = 0
   for (let i = 0; i < items.length; i++) {
     const item = items[i]
-    if (item.boundary || item.ch !== '"') continue
-    if (!doubleOpenerPrefixOk(items, i)) continue
-    // Arm 1: a boundary then space/period/comma (the boundary-start quirk).
-    const next = items[i + 1]
-    let opens = false
-    if (next?.boundary === true) {
-      const afterBoundary = items[i + 2]
-      opens = afterBoundary !== undefined && !afterBoundary.boundary
-        && (afterBoundary.ch === " " || afterBoundary.ch === "." || afterBoundary.ch === ",")
-    }
-    // Arm 2: up to one boundary, then "..." or a non-ending character.
-    if (!opens) {
-      const j = nextIndex(items, i, 1)
-      if (j < items.length && !items[j].boundary) {
-        const ch = items[j].ch
-        const absorbedIntoCloser = style === "french" && ch === " " && isCharItem(items, j + 1, RIGHT_DOUBLE_QUOTE)
-        opens = isEllipsisDots(items, j) || foldsToNotEqual(items, j)
-          || (!SPACE_RE.test(ch) && !DOUBLE_OPEN_ENDING_SET.has(ch))
-          || absorbedIntoCloser
+    if (item.boundary) continue
+    const openerContextIsBareBoundary = i > 0 && items[i - 1].boundary
+    if (
+      item.ch === '"' &&
+      !(openerContextIsBareBoundary && openDepth > 0) &&
+      doubleOpenerPrefixOk(items, i)
+    ) {
+      // Arm 1: a boundary then space/period/comma (the boundary-start quirk).
+      const next = items[i + 1]
+      let opens = false
+      if (next?.boundary === true) {
+        const afterBoundary = items[i + 2]
+        opens = afterBoundary !== undefined && !afterBoundary.boundary
+          && (afterBoundary.ch === " " || afterBoundary.ch === "." || afterBoundary.ch === ",")
       }
+      // Arm 2: up to one boundary, then "..." or a non-ending character.
+      if (!opens) {
+        const j = nextIndex(items, i, 1)
+        if (j < items.length && !items[j].boundary) {
+          const ch = items[j].ch
+          const absorbedIntoCloser = style === "french" && ch === " " && isCharItem(items, j + 1, RIGHT_DOUBLE_QUOTE)
+          opens = isEllipsisDots(items, j) || foldsToNotEqual(items, j)
+            || (!SPACE_RE.test(ch) && !DOUBLE_OPEN_ENDING_SET.has(ch))
+            || absorbedIntoCloser
+        }
+      }
+      if (opens) item.ch = LEFT_DOUBLE_QUOTE
     }
-    if (opens) item.ch = LEFT_DOUBLE_QUOTE
+    if (item.ch === LEFT_DOUBLE_QUOTE) openDepth++
+    else if ((item.ch === RIGHT_DOUBLE_QUOTE || item.ch === '"') && openDepth > 0) openDepth--
   }
 }
 

--- a/src/quote-classifier.ts
+++ b/src/quote-classifier.ts
@@ -697,6 +697,24 @@ function foldsToNotEqual(items: Item[], index: number): boolean {
 }
 
 /**
+ * True iff a straight double quote at `index` sits in opener position *only*
+ * because a node boundary precedes it: the nearest real character across the
+ * boundary run is itself a non-opener (not a space, an opener glyph, or the
+ * start of text). That boundary is an editing seam, not real opener context —
+ * so the single-node spelling of the same text would not read the quote as an
+ * opener. {@link classifyOpeningDoubles} uses this to leave such a quote for the
+ * closing pass when a quotation is already open, instead of re-opening a closer.
+ */
+function openerContextIsSolelyBoundary(items: Item[], index: number): boolean {
+  if (index === 0 || !items[index - 1].boundary) return false
+  let j = index - 1
+  while (j >= 0 && items[j].boundary) j--
+  if (j < 0) return false // start of text is real opener context
+  const ch = items[j].ch
+  return !(SPACE_RE.test(ch) || DOUBLE_OPEN_BEFORE_SET.has(ch))
+}
+
+/**
  * Opening double quote by following context.
  *
  * French: a plain space directly before a pre-labeled closer merges into the
@@ -711,18 +729,19 @@ function classifyOpeningDoubles(items: Item[], style: ActiveQuoteStyle): void {
   // the `"` in `"Hi<sup>"</sup>` would become a second opener, leaving
   // unbalanced output. Track the running opener depth, exactly as
   // `classifyQuotedPunctuationOpeners` does, and suppress opening only when the
-  // opener context is supplied *solely* by a preceding boundary while a
-  // quotation is already open. A real opener character (space, comma, newline,
-  // `(`) still opens at any depth, so nested doubles (`'She said, "hello"'`) and
-  // multi-paragraph dialogue (each paragraph re-opens) are unaffected.
+  // opener context is supplied *solely* by a preceding boundary (see
+  // {@link openerContextIsSolelyBoundary}) while a quotation is already open. A
+  // real opener character across the boundary (a space, `(`, or start of text)
+  // still opens at any depth, so nested doubles (`'She said, "hello"'`) and
+  // multi-paragraph dialogue (each paragraph re-opens) match the single-node
+  // reading whether the separator is a newline or an inline-element boundary.
   let openDepth = 0
   for (let i = 0; i < items.length; i++) {
     const item = items[i]
     if (item.boundary) continue
-    const openerContextIsBareBoundary = i > 0 && items[i - 1].boundary
     if (
       item.ch === '"' &&
-      !(openerContextIsBareBoundary && openDepth > 0) &&
+      !(openerContextIsSolelyBoundary(items, i) && openDepth > 0) &&
       doubleOpenerPrefixOk(items, i)
     ) {
       // Arm 1: a boundary then space/period/comma (the boundary-start quirk).

--- a/src/symbols.ts
+++ b/src/symbols.ts
@@ -496,9 +496,12 @@ const FRACTION_GLYPH_RE = new RegExp(
 const isPathContext = (before: string): boolean => {
   const parts = before.split(/\s+/)
   const trailing = parts[parts.length - 1]
-  if (FRACTION_GLYPH_RE.test(trailing)) return true
-  const slashIdx = trailing.indexOf("/")
-  return slashIdx >= 0 && slashIdx < trailing.length - 1
+  // A slash anywhere in the token that leads up to the legal marker signals a
+  // path/URL. The marker itself is excluded from `before`, so a slash sitting
+  // right before it (`foo/(tm)`, `example.com/(c)`) leaves the slash as the
+  // token's final character — still a path, so match on any slash, not only an
+  // interior one.
+  return FRACTION_GLYPH_RE.test(trailing) || trailing.includes("/")
 }
 
 function contextAwareLegalReplace(

--- a/src/tests/index.test.ts
+++ b/src/tests/index.test.ts
@@ -1,5 +1,5 @@
 import { DASH_STYLES, PUNCTUATION_STYLES, type TransformOptions, transformView, transform as transformWithoutChecks } from "../index.js"
-import { TRANSFORM_OPTION_KEYS } from "../transform-options.js"
+import { resolveTransformOptions, TRANSFORM_OPTION_KEYS } from "../transform-options.js"
 import { ellipsis } from "../symbols.js"
 import { UNICODE_SYMBOLS } from "../constants.js"
 import { buildMixedContent, SEP as DEFAULT_SEPARATOR, viewTransform } from "./test-helpers.js"
@@ -725,6 +725,17 @@ describe("transform", () => {
       expect(() => transform("hello", { punctuationStyle: style as never })).toThrow(
         /Invalid punctuationStyle/
       )
+    })
+
+    it("coalesces an explicit null style to the default (Required return contract)", () => {
+      // JS callers outside the type system can pass null; it must not survive
+      // into the resolved options, which are typed Required<TransformOptions>.
+      const resolved = resolveTransformOptions({
+        punctuationStyle: null as never,
+        dashStyle: null as never,
+      })
+      expect(resolved.punctuationStyle).toBe("american")
+      expect(resolved.dashStyle).toBe("american")
     })
 
     it("includes valid values in punctuationStyle error message", () => {

--- a/src/tests/quote-classifier.test.ts
+++ b/src/tests/quote-classifier.test.ts
@@ -183,6 +183,10 @@ describe("boundary-sensitive edges (ports of v4 sentinel behavior)", () => {
     [`"Hi${SEP}"${SEP} there`, `${LEFT_DOUBLE_QUOTE}Hi${SEP}${RIGHT_DOUBLE_QUOTE}${SEP} there`],
     // ...but at depth zero the same isolated position is still a valid opener.
     [`a ${SEP}"${SEP}quote"`, `a ${SEP}${LEFT_DOUBLE_QUOTE}${SEP}quote${RIGHT_DOUBLE_QUOTE}`],
+    // A continued opener separated from its space by an inline-element boundary
+    // (`"Para one <em>"Para two</em>`) still opens: real opener context sits
+    // across the boundary, so it matches the single-node reading, not a closer.
+    [`"Para one ${SEP}"Para two"`, `${LEFT_DOUBLE_QUOTE}Para one ${SEP}${LEFT_DOUBLE_QUOTE}Para two${RIGHT_DOUBLE_QUOTE}`],
     // A fresh pair after the first closes opens again from a boundary-isolated node.
     [`"a" and ${SEP}"${SEP}b"`, `${LEFT_DOUBLE_QUOTE}a${RIGHT_DOUBLE_QUOTE} and ${SEP}${LEFT_DOUBLE_QUOTE}${SEP}b${RIGHT_DOUBLE_QUOTE}`],
   ])("niceQuotes(%j) === %j", (input, expected) => {

--- a/src/tests/quote-classifier.test.ts
+++ b/src/tests/quote-classifier.test.ts
@@ -176,6 +176,15 @@ describe("boundary-sensitive edges (ports of v4 sentinel behavior)", () => {
     // closer ahead keeps the elision pass away, and the opener rule requires
     // a non-space follower.
     [`x ' b${RIGHT_SINGLE_QUOTE} c`, `x ' b${RIGHT_SINGLE_QUOTE} c`],
+    // A closing double quote isolated in its own node (a boundary on each side,
+    // e.g. `"Hi<sup>"</sup>there`) closes the open quotation. The bare-boundary
+    // opener prefix must not turn it into a second opener while a quote is open.
+    [`"Hi${SEP}"${SEP}there`, `${LEFT_DOUBLE_QUOTE}Hi${SEP}${RIGHT_DOUBLE_QUOTE}${SEP}there`],
+    [`"Hi${SEP}"${SEP} there`, `${LEFT_DOUBLE_QUOTE}Hi${SEP}${RIGHT_DOUBLE_QUOTE}${SEP} there`],
+    // ...but at depth zero the same isolated position is still a valid opener.
+    [`a ${SEP}"${SEP}quote"`, `a ${SEP}${LEFT_DOUBLE_QUOTE}${SEP}quote${RIGHT_DOUBLE_QUOTE}`],
+    // A fresh pair after the first closes opens again from a boundary-isolated node.
+    [`"a" and ${SEP}"${SEP}b"`, `${LEFT_DOUBLE_QUOTE}a${RIGHT_DOUBLE_QUOTE} and ${SEP}${LEFT_DOUBLE_QUOTE}${SEP}b${RIGHT_DOUBLE_QUOTE}`],
   ])("niceQuotes(%j) === %j", (input, expected) => {
     expect(viewTransform(niceQuotes, input, SEP)).toBe(expected)
   })

--- a/src/tests/symbols.test.ts
+++ b/src/tests/symbols.test.ts
@@ -249,6 +249,11 @@ describe("legalSymbols", () => {
     ["example.com/path(tm)", "example.com/path(tm)"],
     ["example.com/path(r)", "example.com/path(r)"],
     ["/usr/local/bin(r)", "/usr/local/bin(r)"],
+    // The marker sitting directly after a slash is still a path: the slash is
+    // the trailing token's final character, with no character after it.
+    ["foo/(tm)", "foo/(tm)"],
+    ["docs/(r)", "docs/(r)"],
+    ["example.com/(c) 2024", "example.com/(c) 2024"],
   ])('preserves legal symbols in path context "%s"', (input, expected) => {
     expect(legalSymbols(input)).toBe(expected)
   })

--- a/src/transform-options.ts
+++ b/src/transform-options.ts
@@ -139,5 +139,9 @@ export function resolveTransformOptions(options: TransformOptions): ResolvedTran
     )
   }
 
-  return { ...defaultOpts, ...filterUndefined(options) }
+  // `filterUndefined` drops only `undefined`, so an explicit `null` (from JS
+  // callers outside the type system) would otherwise survive the spread and
+  // break the `Required` return contract. Re-apply the validated, null-coalesced
+  // style values last so the result always holds a real enum member.
+  return { ...defaultOpts, ...filterUndefined(options), punctuationStyle, dashStyle }
 }


### PR DESCRIPTION
## Summary

An adversarial, "as if my enemy wrote it" audit of the whole library. The codebase is genuinely robust — 2511 existing tests, 100% branch-coverage gate, property-based fuzzing, and mutation testing all hold — so most of the audit cleared. Three real defects survived scrutiny, plus one bit of dead code. Each is fixed here with a pinned regression test; the suite grows to **2519 tests**, coverage stays at 100%, lint is clean, and the competitor benchmark holds at 158/160.

Each finding was reproduced against the built library before fixing and re-checked after.

## Fixes

### 1. Closing double quote isolated in its own node was re-opened (`quote-classifier.ts`)
A straight `"` alone in its own text node — a node boundary on each side, e.g. `"Hi<sup>"</sup>there` — was classified as a *second opening* quote. `doubleOpenerPrefixOk` reads a bare boundary as opener context, and `classifyOpeningDoubles` had no depth guard, so the closer flipped to an opener and produced visibly unbalanced output.

```
transformView over ["\"Hi", "\"", "there"]
  before: “Hi“there   (two openers, no closer)
  after:  “Hi”there
```

The fix tracks the running opener depth exactly as `classifyQuotedPunctuationOpeners` already does, and suppresses opening **only** when the opener context comes *solely* from a preceding boundary while a quotation is already open. A real opener character (space, comma, newline, `(`) still opens at any depth — so **nested doubles** (`'She said, "hello"'`) and **multi-paragraph dialogue** (each paragraph re-opens) are unaffected. Verified across american/british, german, and french styles.

### 2. Legal marker glued after a slash mis-fired in path context (`symbols.ts`)
`isPathContext` required a character *after* the slash within the trailing token, but the `(c)`/`(r)`/`(tm)` marker itself is excluded from the `before` window — so a path/URL ending right at the slash slipped through:

```
foo/(tm)            → foo/™     (now preserved: foo/(tm))
docs/(r)            → docs/®    (now preserved: docs/(r))
example.com/(c) 2024 → © …     (now preserved)
```

Now any slash in the trailing token counts as path context, mirroring the already-covered `example.com/path(c)` case.

### 3. Explicit `null` style survived option resolution (`transform-options.ts`)
`filterUndefined` strips only `undefined`, so a `null` passed as `punctuationStyle`/`dashStyle` by an untyped (JS) caller passed validation via `?? "american"` yet landed in the resolved object, violating the `Required<TransformOptions>` return contract. The validated, null-coalesced values are now re-applied last.

### 4. Removed dead `ISSUES_URL` constant (`constants.ts`)
Exported and documented as the single source of truth for the issue-tracker URL in error messages, but referenced nowhere.

## Identified but deferred

One further medium-severity finding is **not** addressed here because a correct fix touches the core prose-collection recursion and carries real regression risk — it deserves its own focused change:

- **rehype: loose/root text is silently never transformed.** Text directly under the `Root`, or directly inside a non-transformable container (`<body>`, `<form>`, `<fieldset>`), is dropped by the element-only visitor and the non-transformable recursion branch. Notably `transformHtml('"hello" -- world')` (a bare-text fragment — a headline use case) returns unchanged, and even `transformAllElements: true` can't reach root-level bare text since there's no element for the visitor to enter. `remark` has no analogous gap. Happy to follow up with a targeted PR if desired.

## Testing
- `pnpm test` — 2519 passed, 100% branches/functions/lines/statements
- `pnpm lint`, `pnpm build --noEmit`, `pnpm typecheck:scripts`, `pnpm test:scripts` — all clean
- `node benchmark.mjs --min-passes 158` — punctilio 158/160

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JVPsghYZeQV3txPpxzVSAp

---
_Generated by [Claude Code](https://claude.ai/code/session_01JVPsghYZeQV3txPpxzVSAp)_