### PR TITLE
fix(ci): push release-docs + tag with the ruleset-bypass org token

### DIFF
--- a/.github/workflows/auto-version.yml
+++ b/.github/workflows/auto-version.yml
@@ -20,6 +20,13 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
+          # version-bump.sh pushes the release-docs commit + vX.Y.Z tag to main,
+          # which is protected by a required-status-checks ruleset the `[skip ci]`
+          # commit can't satisfy. GITHUB_TOKEN is not a bypass actor (its push is
+          # rejected with GH013, stranding the tag); TEMPLATE_SYNC_TOKEN_ORG is
+          # the org PAT registered as a ruleset bypass actor. Falls back to
+          # GITHUB_TOKEN only when unset (a fork).
+          token: ${{ secrets.TEMPLATE_SYNC_TOKEN_ORG || secrets.GITHUB_TOKEN }}
 
       - name: Setup
         uses: ./.github/actions/setup


### PR DESCRIPTION
## Problem
`auto-version` publishes to npm, then fails to push the release-docs commit and `vX.Y.Z` tag to `main` (e.g. "Skipping tag v5.2.6") because the checkout used the default `GITHUB_TOKEN`, which is not a bypass actor for `main`'s required-status-checks ruleset. Every recent run failed.

## Fix
Check out (and push) with `TEMPLATE_SYNC_TOKEN_ORG` — the org PAT registered as a ruleset bypass actor — falling back to `GITHUB_TOKEN` when unset (forks).

## Note
Requires `TEMPLATE_SYNC_TOKEN_ORG` present and authorized as a bypass actor on this repo's `main` ruleset. If set-but-unauthorized it will 403 (already the failing state), so no regression.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BnLd5qeoW88Ybe5u8JcYZt)_