### PR TITLE
fix(ci): read the Claude key from GH_ACTION_ANTHROPIC_API_KEY

### DIFF
--- a/.github/workflows/auto-version.yml
+++ b/.github/workflows/auto-version.yml
@@ -39,4 +39,4 @@ jobs:
       - name: Auto Version Bump and Publish
         run: bash scripts/version-bump.sh
         env:
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          ANTHROPIC_API_KEY: ${{ secrets.GH_ACTION_ANTHROPIC_API_KEY }}


### PR DESCRIPTION
`auto-version` passed `ANTHROPIC_API_KEY` from `secrets.ANTHROPIC_API_KEY`, but the valid key is stored under `GH_ACTION_ANTHROPIC_API_KEY`. The Claude call here only drafts changelog prose (degrades to a plain commit list on failure, so it wasn't blocking), but the drafted changelog silently fell back. Source the key from the correct secret.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BnLd5qeoW88Ybe5u8JcYZt)_