### PR TITLE
fix(nbsp): don't glue the first space of a multi-space run

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -18,7 +18,7 @@ export {
   withProseView,
 } from "./prose-view.js"
 export { classifyApostrophes, niceQuotes, PUNCTUATION_STYLES, type PunctuationStyle, type QuoteOptions } from "./quotes.js"
-export { type SymbolOptions, symbolTransform } from "./symbols.js"
+export { collapseSpaces, type SymbolOptions, symbolTransform } from "./symbols.js"
 export type { TransformOptions } from "./transform-options.js"
 
 import { niceQuotes } from "./quotes.js"

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,7 +18,7 @@ export {
   withProseView,
 } from "./prose-view.js"
 export { classifyApostrophes, niceQuotes, PUNCTUATION_STYLES, type PunctuationStyle, type QuoteOptions } from "./quotes.js"
-export { collapseSpaces, type SymbolOptions, symbolTransform } from "./symbols.js"
+export { type SymbolOptions, symbolTransform } from "./symbols.js"
 export type { TransformOptions } from "./transform-options.js"
 
 import { niceQuotes } from "./quotes.js"

--- a/src/nbsp.ts
+++ b/src/nbsp.ts
@@ -1,4 +1,4 @@
-import { cachedRegExp, LATIN_LETTER_RE, LATIN_LETTERS, NBSP_CHARS, SPACE_CHARS, UNICODE_SYMBOLS } from "./constants.js"
+import { cachedRegExp, LATIN_LETTER_RE, LATIN_LETTERS, NBSP_CHARS, SPACE_CHAR_RE, SPACE_CHARS, UNICODE_SYMBOLS } from "./constants.js"
 import { boundaryCountAt, exceedsSingleBoundary, interiorBoundariesWithin, makeProsePass, overInput, type ProseView, replaceAllInView } from "./prose-view.js"
 
 const {
@@ -133,6 +133,16 @@ function isContractionFragment(text: string, offset: number): boolean {
 }
 
 /**
+ * True when the space at `index` opens a run of two or more spaces. Gluing such
+ * a space strands the NBSP next to a space that still renders, widening the gap
+ * instead of binding the two words.
+ */
+function opensSpaceRun(text: string, index: number): boolean {
+  // `slice` yields "" past the end of the text, which no space char matches.
+  return SPACE_CHAR_RE.test(text.slice(index + 1, index + 2))
+}
+
+/**
  * True when the word starting at `start` is already glued onward by an NBSP
  * (a unit, initial, or honorific chain). Binding a short word to it would
  * grow the non-breaking run past two words.
@@ -146,9 +156,10 @@ function nextWordGluesForward(text: string, start: number): boolean {
   return false
 }
 
-// Skips contraction fragments and any glue that would bind 3+ words into a
-// single line-break atom: preceded by NBSP, back-to-back with the previous
-// match, or followed by a word that is itself glued onward.
+// Skips contraction fragments, spaces opening a multi-space run, and any glue
+// that would bind 3+ words into a single line-break atom: preceded by NBSP,
+// back-to-back with the previous match, or followed by a word that is itself
+// glued onward.
 export const nbspAfterShortWords = makeProsePass(nbspAfterShortWordsOverView)
 
 function nbspAfterShortWordsOverView(view: ProseView): void {
@@ -170,6 +181,7 @@ function nbspAfterShortWordsOverView(view: ProseView): void {
         if (view.hasBoundary(offset)) return null
         if (offset > 0 && NBSP_CHARS.includes(clean[offset - 1])) return null
         if (isContractionFragment(clean, offset)) return null
+        if (opensSpaceRun(clean, offset + match[0].length - 1)) return null
         if (nextWordGluesForward(clean, offset + match[0].length)) return null
         previousMatchEnd = offset + match[0].length
         // Edit only the space so any boundary keeps its side of the NBSP.

--- a/src/tests/index.test.ts
+++ b/src/tests/index.test.ts
@@ -1,4 +1,4 @@
-import { DASH_STYLES, PUNCTUATION_STYLES, type TransformOptions, transformView, transform as transformWithoutChecks } from "../index.js"
+import { collapseSpaces, DASH_STYLES, PUNCTUATION_STYLES, type TransformOptions, transformView, transform as transformWithoutChecks } from "../index.js"
 import { resolveTransformOptions, TRANSFORM_OPTION_KEYS } from "../transform-options.js"
 import { ellipsis } from "../symbols.js"
 import { UNICODE_SYMBOLS } from "../constants.js"
@@ -158,6 +158,20 @@ describe("transform", () => {
       ["hello\t\tworld", "hello\t\tworld", "multiple tabs"],
     ])("preserves %s when disabled", (input, expected) => {
       expect(transform(input, { collapseSpaces: false, nbsp: false })).toBe(expected)
+    })
+
+    it("collapses a run before the short word glues across it", () => {
+      expect(transform("evaluated by  two senior people")).toBe(
+        `evaluated by${NBSP}two senior${NBSP}people`,
+      )
+    })
+
+    // Exported so consumers composing their own pass list (e.g. a rehype
+    // pipeline) can run it ahead of the nbsp passes, as the pipeline does.
+    it("is exported as a standalone pass", () => {
+      expect(collapseSpaces("evaluated by  two senior people")).toBe(
+        "evaluated by two senior people",
+      )
     })
   })
 

--- a/src/tests/index.test.ts
+++ b/src/tests/index.test.ts
@@ -1,4 +1,4 @@
-import { collapseSpaces, DASH_STYLES, PUNCTUATION_STYLES, type TransformOptions, transformView, transform as transformWithoutChecks } from "../index.js"
+import { DASH_STYLES, PUNCTUATION_STYLES, type TransformOptions, transformView, transform as transformWithoutChecks } from "../index.js"
 import { resolveTransformOptions, TRANSFORM_OPTION_KEYS } from "../transform-options.js"
 import { ellipsis } from "../symbols.js"
 import { UNICODE_SYMBOLS } from "../constants.js"
@@ -163,14 +163,6 @@ describe("transform", () => {
     it("collapses a run before the short word glues across it", () => {
       expect(transform("evaluated by  two senior people")).toBe(
         `evaluated by${NBSP}two senior${NBSP}people`,
-      )
-    })
-
-    // Exported so consumers composing their own pass list (e.g. a rehype
-    // pipeline) can run it ahead of the nbsp passes, as the pipeline does.
-    it("is exported as a standalone pass", () => {
-      expect(collapseSpaces("evaluated by  two senior people")).toBe(
-        "evaluated by two senior people",
       )
     })
   })

--- a/src/tests/nbsp.test.ts
+++ b/src/tests/nbsp.test.ts
@@ -66,6 +66,12 @@ describe("nbspAfterShortWords", () => {
     // A quoting apostrophe (no letter before it) still admits the glue.
     ["give ’em a break", `give ’em${NBSP}a break`],
     ["the cat", "the cat"],
+    // A space run stays untouched: an NBSP there would render as a wider gap
+    // rather than binding the words.
+    ["evaluated by  two senior people", "evaluated by  two senior people"],
+    ["a  cat", "a  cat"],
+    ["a \tcat", "a \tcat"],
+    [`a ${NBSP}cat`, `a ${NBSP}cat`],
     // Accented Latin short words
     ["à chat", `à${NBSP}chat`],
     ["où aller", `où${NBSP}aller`],


### PR DESCRIPTION
## Summary

- `nbspAfterShortWords` glued a 1–2 letter word to the space that follows it without checking whether more spaces followed. On `"evaluated by  two"` it produced `by<NBSP> two`.
- An NBSP is not collapsible whitespace, so the NBSP + space pair renders as a *visibly wider* gap in HTML — the opposite of the tightening the rule intends. This was reported as a stray double space on a rendered page.
- The pipeline normally prevents this: `collapseSpaces` runs immediately before the nbsp passes, so `"by  two"` becomes `"by two"` and the rule glues it into `by<NBSP>two`. The bug only surfaced for a consumer applying `nbspTransform` standalone. That consumer now calls `transformView` instead ([turntrout.com#1672](https://github.com/alexander-turner/TurnTrout.com/pull/1672)), which is the real fix; this PR makes the pass safe on its own terms.

## Changes

- `src/nbsp.ts`: added `opensSpaceRun`, and skip the glue in `nbspAfterShortWordsOverView` when the matched space is followed by another space character. This is also the correct behavior under `--no-collapse-spaces`, which explicitly asks for runs to be preserved — stranding an NBSP inside a preserved run is still wrong.
- The other nbsp passes need no guard: `nbspBeforeLastWord` already requires a word character immediately before the space it converts, and the honorific / abbreviation / section-symbol / copyright / initials / unit rules all require their context to follow the single space they match.
- Tests: `nbspAfterShortWords` cases for the reported string plus `"a  cat"`, `"a \tcat"`, and `a ` + NBSP + `cat`; and a pipeline-level case pinning `transform("evaluated by  two senior people")` → `evaluated by<NBSP>two senior<NBSP>people` (collapse, then glue).

## Testing

- `npm test` — 2544 tests pass, 100% statement/branch/function/line coverage maintained.
- `npx eslint src` — clean.
- Stryker over `src/nbsp.ts` locally — passes configured thresholds.

## Lessons Learned

- **What**: When a package exports both a full pipeline and its individual passes, prefer that consumers call the pipeline. Pass ordering is often load-bearing, and a hand-composed list silently drops the normalization a pass depends on.
- **Where**: any package that exports both a `transform()`/`transformView()` and its component passes.
- **Why**: this defect was unreachable through the library's own entry point and 2500+ tests, and only appeared on a consumer's rendered site — because that consumer rebuilt the pass list by hand and left out `collapseSpaces`.
