### PR TITLE
feat(index): export TERMINAL_PUNCTUATION from package root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- feat(index): export TERMINAL_PUNCTUATION from package root
+
 ## [5.3.0] - 2026-07-28
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - feat(index): export TERMINAL_PUNCTUATION from package root
+- feat(constants): add OPENING_PUNCTUATION and CLOSING_BRACKETS
 
 ## [5.3.0] - 2026-07-28
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -73,6 +73,27 @@ export const UNICODE_SYMBOLS = {
   ARABIC_SEMICOLON: "\u061B", // ؛
   // Greek punctuation
   GREEK_QUESTION_MARK: "\u037E", // ; (visually identical to ASCII semicolon)
+  // Spanish inverted openers
+  INVERTED_EXCLAMATION: "\u00A1", // ¡
+  INVERTED_QUESTION: "\u00BF", // ¿
+  // CJK fullwidth brackets
+  FULLWIDTH_LEFT_PAREN: "\uFF08", // （
+  FULLWIDTH_RIGHT_PAREN: "\uFF09", // ）
+  FULLWIDTH_LEFT_BRACKET: "\uFF3B", // ［
+  FULLWIDTH_RIGHT_BRACKET: "\uFF3D", // ］
+  FULLWIDTH_LEFT_BRACE: "\uFF5B", // ｛
+  FULLWIDTH_RIGHT_BRACE: "\uFF5D", // ｝
+  // CJK ideographic brackets
+  LEFT_ANGLE_BRACKET: "\u3008", // 〈
+  RIGHT_ANGLE_BRACKET: "\u3009", // 〉
+  LEFT_DOUBLE_ANGLE_BRACKET: "\u300A", // 《
+  RIGHT_DOUBLE_ANGLE_BRACKET: "\u300B", // 》
+  LEFT_CORNER_BRACKET: "\u300C", // 「
+  RIGHT_CORNER_BRACKET: "\u300D", // 」
+  LEFT_WHITE_CORNER_BRACKET: "\u300E", // 『
+  RIGHT_WHITE_CORNER_BRACKET: "\u300F", // 』
+  LEFT_LENTICULAR_BRACKET: "\u3010", // 【
+  RIGHT_LENTICULAR_BRACKET: "\u3011", // 】
 } as const
 
 /** All terminal punctuation chars for regex character classes (ASCII through CJK/Arabic/Greek). */
@@ -89,6 +110,55 @@ export const TERMINAL_PUNCTUATION = [
   UNICODE_SYMBOLS.ARABIC_QUESTION_MARK, UNICODE_SYMBOLS.ARABIC_SEMICOLON,
   UNICODE_SYMBOLS.GREEK_QUESTION_MARK,
 ] as const
+
+/**
+ * Bracket pairs, opening first, ASCII through the fullwidth and CJK forms.
+ * {@link OPENING_PUNCTUATION} and {@link CLOSING_BRACKETS} are both projections
+ * of this list, so a bracket can never be listed on one side only.
+ */
+const BRACKET_PAIRS: readonly (readonly [string, string])[] = [
+  ["(", ")"],
+  ["[", "]"],
+  ["{", "}"],
+  [UNICODE_SYMBOLS.FULLWIDTH_LEFT_PAREN, UNICODE_SYMBOLS.FULLWIDTH_RIGHT_PAREN],
+  [UNICODE_SYMBOLS.FULLWIDTH_LEFT_BRACKET, UNICODE_SYMBOLS.FULLWIDTH_RIGHT_BRACKET],
+  [UNICODE_SYMBOLS.FULLWIDTH_LEFT_BRACE, UNICODE_SYMBOLS.FULLWIDTH_RIGHT_BRACE],
+  [UNICODE_SYMBOLS.LEFT_ANGLE_BRACKET, UNICODE_SYMBOLS.RIGHT_ANGLE_BRACKET],
+  [UNICODE_SYMBOLS.LEFT_DOUBLE_ANGLE_BRACKET, UNICODE_SYMBOLS.RIGHT_DOUBLE_ANGLE_BRACKET],
+  [UNICODE_SYMBOLS.LEFT_CORNER_BRACKET, UNICODE_SYMBOLS.RIGHT_CORNER_BRACKET],
+  [UNICODE_SYMBOLS.LEFT_WHITE_CORNER_BRACKET, UNICODE_SYMBOLS.RIGHT_WHITE_CORNER_BRACKET],
+  [UNICODE_SYMBOLS.LEFT_LENTICULAR_BRACKET, UNICODE_SYMBOLS.RIGHT_LENTICULAR_BRACKET],
+]
+
+/**
+ * Punctuation that opens a construct and so binds rightward, to the text after
+ * it rather than the text before: brackets, the Spanish inverted marks, and the
+ * opening quote forms (including the low-9 openers German and Polish use).
+ * Guillemets follow the French convention where `«` opens; German inverts them.
+ *
+ * The counterpart to {@link TERMINAL_PUNCTUATION}, and like it, spans ASCII
+ * through CJK. Straight `"` and `'` are absent: their shape is ambiguous until
+ * classified, which is what {@link niceQuotes} and {@link classifyApostrophes}
+ * settle, so a consumer that wants to treat one as an opener owns that call.
+ */
+export const OPENING_PUNCTUATION: readonly string[] = [
+  ...BRACKET_PAIRS.map(([opening]) => opening),
+  UNICODE_SYMBOLS.INVERTED_EXCLAMATION,
+  UNICODE_SYMBOLS.INVERTED_QUESTION,
+  UNICODE_SYMBOLS.LEFT_DOUBLE_QUOTE,
+  UNICODE_SYMBOLS.LEFT_SINGLE_QUOTE,
+  UNICODE_SYMBOLS.LEFT_GUILLEMET,
+  UNICODE_SYMBOLS.DOUBLE_LOW_9_QUOTE,
+  UNICODE_SYMBOLS.SINGLE_LOW_9_QUOTE,
+]
+
+/**
+ * Closing brackets, which may not begin a line. Scoped to brackets because the
+ * other marks barred from a line start are {@link TERMINAL_PUNCTUATION} and the
+ * closing quote forms in {@link UNICODE_SYMBOLS}; the three together are what a
+ * consumer keeps from stranding at a soft wrap.
+ */
+export const CLOSING_BRACKETS: readonly string[] = BRACKET_PAIRS.map(([, closing]) => closing)
 
 /**
  * Character class pattern for Latin letters including European accented characters.

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,9 @@
-export { TERMINAL_PUNCTUATION, UNICODE_SYMBOLS } from "./constants.js"
+export {
+  CLOSING_BRACKETS,
+  OPENING_PUNCTUATION,
+  TERMINAL_PUNCTUATION,
+  UNICODE_SYMBOLS,
+} from "./constants.js"
 export {
   DASH_STYLES,
   type DashOptions,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-export { UNICODE_SYMBOLS } from "./constants.js"
+export { TERMINAL_PUNCTUATION, UNICODE_SYMBOLS } from "./constants.js"
 export {
   DASH_STYLES,
   type DashOptions,

--- a/src/tests/index.test.ts
+++ b/src/tests/index.test.ts
@@ -1,7 +1,7 @@
-import { DASH_STYLES, PUNCTUATION_STYLES, TERMINAL_PUNCTUATION as ROOT_TERMINAL_PUNCTUATION, type TransformOptions, transformView, transform as transformWithoutChecks } from "../index.js"
+import { DASH_STYLES, PUNCTUATION_STYLES, CLOSING_BRACKETS as ROOT_CLOSING_BRACKETS, OPENING_PUNCTUATION as ROOT_OPENING_PUNCTUATION, TERMINAL_PUNCTUATION as ROOT_TERMINAL_PUNCTUATION, type TransformOptions, transformView, transform as transformWithoutChecks } from "../index.js"
 import { resolveTransformOptions, TRANSFORM_OPTION_KEYS } from "../transform-options.js"
 import { ellipsis } from "../symbols.js"
-import { TERMINAL_PUNCTUATION, UNICODE_SYMBOLS } from "../constants.js"
+import { CLOSING_BRACKETS, OPENING_PUNCTUATION, TERMINAL_PUNCTUATION, UNICODE_SYMBOLS } from "../constants.js"
 import { buildMixedContent, SEP as DEFAULT_SEPARATOR, viewTransform } from "./test-helpers.js"
 
 const {
@@ -847,6 +847,67 @@ describe("transform", () => {
 
 })
 
-it("re-exports TERMINAL_PUNCTUATION from the package root", () => {
-  expect(ROOT_TERMINAL_PUNCTUATION).toBe(TERMINAL_PUNCTUATION)
+describe("punctuation constants", () => {
+  it.each([
+    ["TERMINAL_PUNCTUATION", ROOT_TERMINAL_PUNCTUATION, TERMINAL_PUNCTUATION],
+    ["OPENING_PUNCTUATION", ROOT_OPENING_PUNCTUATION, OPENING_PUNCTUATION],
+    ["CLOSING_BRACKETS", ROOT_CLOSING_BRACKETS, CLOSING_BRACKETS],
+  ])("re-exports %s from the package root", (_name, fromRoot, fromModule) => {
+    expect(fromRoot).toBe(fromModule)
+  })
+
+  const SETS = [
+    ["TERMINAL_PUNCTUATION", TERMINAL_PUNCTUATION],
+    ["OPENING_PUNCTUATION", OPENING_PUNCTUATION],
+    ["CLOSING_BRACKETS", CLOSING_BRACKETS],
+  ] as const
+
+  // Each set is documented for use inside a regex character class and as a set
+  // of single characters, so a multi-code-point entry would silently widen the
+  // class to its constituent code points.
+  it.each(SETS)("%s holds distinct single code points", (_name, chars) => {
+    expect(new Set(chars).size).toBe(chars.length)
+    expect(chars.filter((char) => [...char].length !== 1)).toEqual([])
+  })
+
+  // A character that both opens and closes (or opens and terminates) would make
+  // any consumer's line-breaking decision ambiguous.
+  it.each([
+    ["OPENING_PUNCTUATION", "CLOSING_BRACKETS", OPENING_PUNCTUATION, CLOSING_BRACKETS],
+    ["OPENING_PUNCTUATION", "TERMINAL_PUNCTUATION", OPENING_PUNCTUATION, TERMINAL_PUNCTUATION],
+    ["CLOSING_BRACKETS", "TERMINAL_PUNCTUATION", CLOSING_BRACKETS, TERMINAL_PUNCTUATION],
+  ])("%s and %s are disjoint", (_left, _right, left, right) => {
+    const rightSet = new Set<string>(right)
+    expect(left.filter((char) => rightSet.has(char))).toEqual([])
+  })
+
+  it.each([
+    ["(", ")"],
+    ["[", "]"],
+    ["{", "}"],
+    [UNICODE_SYMBOLS.FULLWIDTH_LEFT_PAREN, UNICODE_SYMBOLS.FULLWIDTH_RIGHT_PAREN],
+    [UNICODE_SYMBOLS.LEFT_CORNER_BRACKET, UNICODE_SYMBOLS.RIGHT_CORNER_BRACKET],
+    [UNICODE_SYMBOLS.LEFT_LENTICULAR_BRACKET, UNICODE_SYMBOLS.RIGHT_LENTICULAR_BRACKET],
+  ])("pairs %s with %s at the same index", (opening, closing) => {
+    expect(OPENING_PUNCTUATION.indexOf(opening)).toBe(CLOSING_BRACKETS.indexOf(closing))
+  })
+
+  // The quote and inverted-mark openers have no bracket counterpart, so they sit
+  // past the paired prefix that CLOSING_BRACKETS mirrors.
+  it("carries opener-only marks after the bracket prefix", () => {
+    const openerOnly = [
+      UNICODE_SYMBOLS.INVERTED_EXCLAMATION,
+      UNICODE_SYMBOLS.INVERTED_QUESTION,
+      UNICODE_SYMBOLS.LEFT_DOUBLE_QUOTE,
+      UNICODE_SYMBOLS.LEFT_SINGLE_QUOTE,
+      UNICODE_SYMBOLS.LEFT_GUILLEMET,
+      UNICODE_SYMBOLS.DOUBLE_LOW_9_QUOTE,
+      UNICODE_SYMBOLS.SINGLE_LOW_9_QUOTE,
+    ]
+    expect(OPENING_PUNCTUATION.slice(CLOSING_BRACKETS.length)).toEqual(openerOnly)
+  })
+
+  it.each(['"', "'"])("excludes the shape-ambiguous straight quote %s", (quote) => {
+    expect(OPENING_PUNCTUATION).not.toContain(quote)
+  })
 })

--- a/src/tests/index.test.ts
+++ b/src/tests/index.test.ts
@@ -1,7 +1,7 @@
-import { DASH_STYLES, PUNCTUATION_STYLES, type TransformOptions, transformView, transform as transformWithoutChecks } from "../index.js"
+import { DASH_STYLES, PUNCTUATION_STYLES, TERMINAL_PUNCTUATION as ROOT_TERMINAL_PUNCTUATION, type TransformOptions, transformView, transform as transformWithoutChecks } from "../index.js"
 import { resolveTransformOptions, TRANSFORM_OPTION_KEYS } from "../transform-options.js"
 import { ellipsis } from "../symbols.js"
-import { UNICODE_SYMBOLS } from "../constants.js"
+import { TERMINAL_PUNCTUATION, UNICODE_SYMBOLS } from "../constants.js"
 import { buildMixedContent, SEP as DEFAULT_SEPARATOR, viewTransform } from "./test-helpers.js"
 
 const {
@@ -845,4 +845,8 @@ describe("transform", () => {
     })
   })
 
+})
+
+it("re-exports TERMINAL_PUNCTUATION from the package root", () => {
+  expect(ROOT_TERMINAL_PUNCTUATION).toBe(TERMINAL_PUNCTUATION)
 })


### PR DESCRIPTION
## Summary

- `TERMINAL_PUNCTUATION` (the 23-char terminal-punctuation set: ASCII `! ? . , ; :`, `ELLIPSIS`, the interrobang family, and fullwidth/CJK/Arabic/Greek forms) was only reachable via a deep import past the package's `exports` map (`dist/constants.js`), since `src/index.ts` re-exported `UNICODE_SYMBOLS` but not `TERMINAL_PUNCTUATION`.
- Re-export `TERMINAL_PUNCTUATION` alongside `UNICODE_SYMBOLS` from `src/index.ts` so consumers can `import { TERMINAL_PUNCTUATION } from "punctilio"` without depending on a path outside the package's public contract.
- Added a test asserting the root export is the same reference as `constants.ts`'s, so root reachability is guarded going forward (nothing previously asserted this).
- Added a changelog bullet under `## Unreleased` per `CONTRIBUTING.md`.

## Motivation

turntrout.com's `inlineAtomGlue.ts` maintains a hand-written set of "closing punctuation that must not begin a line" that duplicates `TERMINAL_PUNCTUATION` verbatim, specifically because this constant wasn't reachable from any public entry point (documented in alexander-turner/TurnTrout.com#1680). This change lets that consumer (and others) import the canonical set instead of carrying its own copy.

## Test plan

- [x] `pnpm run build` (tsc) — clean
- [x] `pnpm run lint` (eslint) — clean
- [x] `pnpm test` — 22 suites / 2545 tests pass, 100% coverage maintained
- [x] Runtime check: `(await import("./dist/index.js")).TERMINAL_PUNCTUATION` is a 23-element array starting `["!","?",".",",",";",":","…"]`


---
_Generated by [Claude Code](https://claude.ai/code/session_01E5BK25vYvUMRPqfM9VKHSV)_