### PR TITLE
feat(constants): add OPENING_PUNCTUATION and CLOSING_BRACKETS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - feat(index): export TERMINAL_PUNCTUATION from package root
+- feat(constants): add OPENING_PUNCTUATION and CLOSING_BRACKETS
 
 ## [5.3.0] - 2026-07-28
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -73,6 +73,27 @@ export const UNICODE_SYMBOLS = {
   ARABIC_SEMICOLON: "\u061B", // ؛
   // Greek punctuation
   GREEK_QUESTION_MARK: "\u037E", // ; (visually identical to ASCII semicolon)
+  // Spanish inverted openers
+  INVERTED_EXCLAMATION: "\u00A1", // ¡
+  INVERTED_QUESTION: "\u00BF", // ¿
+  // CJK fullwidth brackets
+  FULLWIDTH_LEFT_PAREN: "\uFF08", // （
+  FULLWIDTH_RIGHT_PAREN: "\uFF09", // ）
+  FULLWIDTH_LEFT_BRACKET: "\uFF3B", // ［
+  FULLWIDTH_RIGHT_BRACKET: "\uFF3D", // ］
+  FULLWIDTH_LEFT_BRACE: "\uFF5B", // ｛
+  FULLWIDTH_RIGHT_BRACE: "\uFF5D", // ｝
+  // CJK ideographic brackets
+  LEFT_ANGLE_BRACKET: "\u3008", // 〈
+  RIGHT_ANGLE_BRACKET: "\u3009", // 〉
+  LEFT_DOUBLE_ANGLE_BRACKET: "\u300A", // 《
+  RIGHT_DOUBLE_ANGLE_BRACKET: "\u300B", // 》
+  LEFT_CORNER_BRACKET: "\u300C", // 「
+  RIGHT_CORNER_BRACKET: "\u300D", // 」
+  LEFT_WHITE_CORNER_BRACKET: "\u300E", // 『
+  RIGHT_WHITE_CORNER_BRACKET: "\u300F", // 』
+  LEFT_LENTICULAR_BRACKET: "\u3010", // 【
+  RIGHT_LENTICULAR_BRACKET: "\u3011", // 】
 } as const
 
 /** All terminal punctuation chars for regex character classes (ASCII through CJK/Arabic/Greek). */
@@ -89,6 +110,55 @@ export const TERMINAL_PUNCTUATION = [
   UNICODE_SYMBOLS.ARABIC_QUESTION_MARK, UNICODE_SYMBOLS.ARABIC_SEMICOLON,
   UNICODE_SYMBOLS.GREEK_QUESTION_MARK,
 ] as const
+
+/**
+ * Bracket pairs, opening first, ASCII through the fullwidth and CJK forms.
+ * {@link OPENING_PUNCTUATION} and {@link CLOSING_BRACKETS} are both projections
+ * of this list, so a bracket can never be listed on one side only.
+ */
+const BRACKET_PAIRS: readonly (readonly [string, string])[] = [
+  ["(", ")"],
+  ["[", "]"],
+  ["{", "}"],
+  [UNICODE_SYMBOLS.FULLWIDTH_LEFT_PAREN, UNICODE_SYMBOLS.FULLWIDTH_RIGHT_PAREN],
+  [UNICODE_SYMBOLS.FULLWIDTH_LEFT_BRACKET, UNICODE_SYMBOLS.FULLWIDTH_RIGHT_BRACKET],
+  [UNICODE_SYMBOLS.FULLWIDTH_LEFT_BRACE, UNICODE_SYMBOLS.FULLWIDTH_RIGHT_BRACE],
+  [UNICODE_SYMBOLS.LEFT_ANGLE_BRACKET, UNICODE_SYMBOLS.RIGHT_ANGLE_BRACKET],
+  [UNICODE_SYMBOLS.LEFT_DOUBLE_ANGLE_BRACKET, UNICODE_SYMBOLS.RIGHT_DOUBLE_ANGLE_BRACKET],
+  [UNICODE_SYMBOLS.LEFT_CORNER_BRACKET, UNICODE_SYMBOLS.RIGHT_CORNER_BRACKET],
+  [UNICODE_SYMBOLS.LEFT_WHITE_CORNER_BRACKET, UNICODE_SYMBOLS.RIGHT_WHITE_CORNER_BRACKET],
+  [UNICODE_SYMBOLS.LEFT_LENTICULAR_BRACKET, UNICODE_SYMBOLS.RIGHT_LENTICULAR_BRACKET],
+]
+
+/**
+ * Punctuation that opens a construct and so binds rightward, to the text after
+ * it rather than the text before: brackets, the Spanish inverted marks, and the
+ * opening quote forms (including the low-9 openers German and Polish use).
+ * Guillemets follow the French convention where `«` opens; German inverts them.
+ *
+ * The counterpart to {@link TERMINAL_PUNCTUATION}, and like it, spans ASCII
+ * through CJK. Straight `"` and `'` are absent: their shape is ambiguous until
+ * classified, which is what {@link niceQuotes} and {@link classifyApostrophes}
+ * settle, so a consumer that wants to treat one as an opener owns that call.
+ */
+export const OPENING_PUNCTUATION: readonly string[] = [
+  ...BRACKET_PAIRS.map(([opening]) => opening),
+  UNICODE_SYMBOLS.INVERTED_EXCLAMATION,
+  UNICODE_SYMBOLS.INVERTED_QUESTION,
+  UNICODE_SYMBOLS.LEFT_DOUBLE_QUOTE,
+  UNICODE_SYMBOLS.LEFT_SINGLE_QUOTE,
+  UNICODE_SYMBOLS.LEFT_GUILLEMET,
+  UNICODE_SYMBOLS.DOUBLE_LOW_9_QUOTE,
+  UNICODE_SYMBOLS.SINGLE_LOW_9_QUOTE,
+]
+
+/**
+ * Closing brackets, which may not begin a line. Scoped to brackets because the
+ * other marks barred from a line start are {@link TERMINAL_PUNCTUATION} and the
+ * closing quote forms in {@link UNICODE_SYMBOLS}; the three together are what a
+ * consumer keeps from stranding at a soft wrap.
+ */
+export const CLOSING_BRACKETS: readonly string[] = BRACKET_PAIRS.map(([, closing]) => closing)
 
 /**
  * Character class pattern for Latin letters including European accented characters.

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,9 @@
-export { TERMINAL_PUNCTUATION, UNICODE_SYMBOLS } from "./constants.js"
+export {
+  CLOSING_BRACKETS,
+  OPENING_PUNCTUATION,
+  TERMINAL_PUNCTUATION,
+  UNICODE_SYMBOLS,
+} from "./constants.js"
 export {
   DASH_STYLES,
   type DashOptions,

--- a/src/tests/index.test.ts
+++ b/src/tests/index.test.ts
@@ -1,7 +1,7 @@
-import { DASH_STYLES, PUNCTUATION_STYLES, TERMINAL_PUNCTUATION as ROOT_TERMINAL_PUNCTUATION, type TransformOptions, transformView, transform as transformWithoutChecks } from "../index.js"
+import { DASH_STYLES, PUNCTUATION_STYLES, CLOSING_BRACKETS as ROOT_CLOSING_BRACKETS, OPENING_PUNCTUATION as ROOT_OPENING_PUNCTUATION, TERMINAL_PUNCTUATION as ROOT_TERMINAL_PUNCTUATION, type TransformOptions, transformView, transform as transformWithoutChecks } from "../index.js"
 import { resolveTransformOptions, TRANSFORM_OPTION_KEYS } from "../transform-options.js"
 import { ellipsis } from "../symbols.js"
-import { TERMINAL_PUNCTUATION, UNICODE_SYMBOLS } from "../constants.js"
+import { CLOSING_BRACKETS, OPENING_PUNCTUATION, TERMINAL_PUNCTUATION, UNICODE_SYMBOLS } from "../constants.js"
 import { buildMixedContent, SEP as DEFAULT_SEPARATOR, viewTransform } from "./test-helpers.js"
 
 const {
@@ -847,6 +847,67 @@ describe("transform", () => {
 
 })
 
-it("re-exports TERMINAL_PUNCTUATION from the package root", () => {
-  expect(ROOT_TERMINAL_PUNCTUATION).toBe(TERMINAL_PUNCTUATION)
+describe("punctuation constants", () => {
+  it.each([
+    ["TERMINAL_PUNCTUATION", ROOT_TERMINAL_PUNCTUATION, TERMINAL_PUNCTUATION],
+    ["OPENING_PUNCTUATION", ROOT_OPENING_PUNCTUATION, OPENING_PUNCTUATION],
+    ["CLOSING_BRACKETS", ROOT_CLOSING_BRACKETS, CLOSING_BRACKETS],
+  ])("re-exports %s from the package root", (_name, fromRoot, fromModule) => {
+    expect(fromRoot).toBe(fromModule)
+  })
+
+  const SETS = [
+    ["TERMINAL_PUNCTUATION", TERMINAL_PUNCTUATION],
+    ["OPENING_PUNCTUATION", OPENING_PUNCTUATION],
+    ["CLOSING_BRACKETS", CLOSING_BRACKETS],
+  ] as const
+
+  // Each set is documented for use inside a regex character class and as a set
+  // of single characters, so a multi-code-point entry would silently widen the
+  // class to its constituent code points.
+  it.each(SETS)("%s holds distinct single code points", (_name, chars) => {
+    expect(new Set(chars).size).toBe(chars.length)
+    expect(chars.filter((char) => [...char].length !== 1)).toEqual([])
+  })
+
+  // A character that both opens and closes (or opens and terminates) would make
+  // any consumer's line-breaking decision ambiguous.
+  it.each([
+    ["OPENING_PUNCTUATION", "CLOSING_BRACKETS", OPENING_PUNCTUATION, CLOSING_BRACKETS],
+    ["OPENING_PUNCTUATION", "TERMINAL_PUNCTUATION", OPENING_PUNCTUATION, TERMINAL_PUNCTUATION],
+    ["CLOSING_BRACKETS", "TERMINAL_PUNCTUATION", CLOSING_BRACKETS, TERMINAL_PUNCTUATION],
+  ])("%s and %s are disjoint", (_left, _right, left, right) => {
+    const rightSet = new Set<string>(right)
+    expect(left.filter((char) => rightSet.has(char))).toEqual([])
+  })
+
+  it.each([
+    ["(", ")"],
+    ["[", "]"],
+    ["{", "}"],
+    [UNICODE_SYMBOLS.FULLWIDTH_LEFT_PAREN, UNICODE_SYMBOLS.FULLWIDTH_RIGHT_PAREN],
+    [UNICODE_SYMBOLS.LEFT_CORNER_BRACKET, UNICODE_SYMBOLS.RIGHT_CORNER_BRACKET],
+    [UNICODE_SYMBOLS.LEFT_LENTICULAR_BRACKET, UNICODE_SYMBOLS.RIGHT_LENTICULAR_BRACKET],
+  ])("pairs %s with %s at the same index", (opening, closing) => {
+    expect(OPENING_PUNCTUATION.indexOf(opening)).toBe(CLOSING_BRACKETS.indexOf(closing))
+  })
+
+  // The quote and inverted-mark openers have no bracket counterpart, so they sit
+  // past the paired prefix that CLOSING_BRACKETS mirrors.
+  it("carries opener-only marks after the bracket prefix", () => {
+    const openerOnly = [
+      UNICODE_SYMBOLS.INVERTED_EXCLAMATION,
+      UNICODE_SYMBOLS.INVERTED_QUESTION,
+      UNICODE_SYMBOLS.LEFT_DOUBLE_QUOTE,
+      UNICODE_SYMBOLS.LEFT_SINGLE_QUOTE,
+      UNICODE_SYMBOLS.LEFT_GUILLEMET,
+      UNICODE_SYMBOLS.DOUBLE_LOW_9_QUOTE,
+      UNICODE_SYMBOLS.SINGLE_LOW_9_QUOTE,
+    ]
+    expect(OPENING_PUNCTUATION.slice(CLOSING_BRACKETS.length)).toEqual(openerOnly)
+  })
+
+  it.each(['"', "'"])("excludes the shape-ambiguous straight quote %s", (quote) => {
+    expect(OPENING_PUNCTUATION).not.toContain(quote)
+  })
 })


### PR DESCRIPTION
Stacked on #275 — both touch `src/index.ts`'s first line. Review that one first; the base retargets to `main` automatically when it merges.

## The gap

`TERMINAL_PUNCTUATION` covers the marks that may not *begin* a line. There was no counterpart for the marks that *open* a construct, and none for closing brackets. A consumer making line-breaking or kerning decisions had to hand-list both — the library's existing opening sets (`SINGLE_OPEN_BEFORE_SET`, `DOUBLE_OPEN_BEFORE_SET` in `quote-classifier.ts`) are context-specific to quote classification and not part of the contract.

## What's added

**`OPENING_PUNCTUATION`** (18) — punctuation that binds rightward: brackets, the Spanish inverted marks, and the opening quote forms.

```
( [ { （ ［ ｛ 〈 《 「 『 【 ¡ ¿ “ ‘ « „ ‚
```

**`CLOSING_BRACKETS`** (11) — brackets that may not begin a line.

```
) ] } ） ］ ｝ 〉 》 」 』 】
```

Plus the `UNICODE_SYMBOLS` entries they need: `INVERTED_EXCLAMATION`, `INVERTED_QUESTION`, and the fullwidth/CJK bracket forms. Purely additive.

## Design decisions

- **Both sets are projections of one `BRACKET_PAIRS` list**, so a bracket can't be listed on one side only. The pairing is structural rather than test-enforced.
- **CJK coverage mirrors `TERMINAL_PUNCTUATION`.** An opening set that stopped at ASCII would silently under-serve the CJK text its sibling already handles.
- **Straight `"` and `'` are excluded.** Their shape is ambiguous until classified — that's `niceQuotes`' and `classifyApostrophes`' job. Same reasoning as #275's scope.
- **`CLOSING_BRACKETS` is brackets only, not a full mirror.** The other marks barred from a line start are already `TERMINAL_PUNCTUATION` plus the closing quotes in `UNICODE_SYMBOLS`; naming each set for exactly what it holds beats forced symmetry.
- **Guillemets follow the French convention** (`«` opens). Noted in the doc comment since German inverts them.

## Named consumer

turntrout.com hand-maintains both halves: `inlineCodeSpacing.ts`'s `NO_GAP_PREDECESSORS` (opening delimiters that hug the following inline code) and `inlineAtomGlue.ts`'s `) ] }` tail. Verified at runtime that `OPENING_PUNCTUATION` covers the former's punctuation and `CLOSING_BRACKETS` the latter. Its operator members (`/ - =`) and straight quotes stay local — those aren't punctuation openers.

## Test plan

- [x] `pnpm run build` (tsc) — clean
- [x] `pnpm run lint` (eslint, incl. `redos`/`regexp` gates) — clean
- [x] `pnpm test` — 22 suites / 2562 tests, 100% coverage held
- [x] Runtime check of both sets' contents, and that they cover the turntrout consumers

New tests assert the invariants rather than restating the literals: root reachability, distinct single code points, pairwise disjointness across all three sets, index-aligned bracket pairs from ASCII through CJK, and the documented straight-quote exclusion.


---
_Generated by [Claude Code](https://claude.ai/code/session_01E5BK25vYvUMRPqfM9VKHSV)_