### PR TITLE
fix: word-edge guard for NBSP glue, repair mutate-changed script, README corrections

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,12 +155,12 @@ transform(text, {
 
 Markdown sinks (`remarkPunctilio`, `transformMarkdown`, the Prettier plugin, and the CLI for Markdown files) default `nbsp` to `false` instead, because invisible U+00A0 characters in Markdown source files break `grep` and Ctrl+F. Pass `nbsp: true` (or the `--nbsp` CLI flag) to opt in.
 
-The `rehype` plugin accepts additional options. Elements matching any `skipTags` tag name or carrying any `skipClasses` class are left untransformed (values shown are the defaults for `skipTags`):
+The `rehype` plugin accepts additional options. Elements matching any `skipTags` tag name or carrying any `skipClasses` class are left untransformed. The `skipTags` value below is the default; `skipClasses` defaults to `[]`, and the value shown is a common opt-in (add `no-formatting` yourself to skip elements marked with it):
 
 ```typescript
 rehypePunctilio({
-  skipTags: ["code", "pre", "script", "style", "kbd", "var", "samp", "template", "math", "svg"],
-  skipClasses: ["no-formatting"],
+  skipTags: ["code", "pre", "script", "style", "kbd", "var", "samp", "template", "math", "svg"], // default
+  skipClasses: ["no-formatting"], // default: [] — shown here as a common opt-in
   transformAllElements: false, // see below
 });
 ```
@@ -210,7 +210,7 @@ prettier --write 'docs/**/*.md'
 # "Hello" -- world.    →    “Hello” – world.
 ```
 
-Code spans, fenced code blocks, and inline HTML are left untouched. The plugin currently transforms Markdown (`*.md`, `*.mdx` via the markdown parser); for HTML files, use the [CLI](#cli) or the [`rehype` plugin](#works-with-html-doms-via-boundary-aware-views) below.
+Code spans, fenced code blocks, and inline HTML are left untouched. The plugin extends Prettier’s `markdown` parser, so it transforms the files Prettier routes there (`*.md`, `*.markdown`); for HTML files, use the [CLI](#cli) or the [`rehype` plugin](#works-with-html-doms-via-boundary-aware-views) below.
 
 ### CLI
 

--- a/scripts/mutate-changed.mjs
+++ b/scripts/mutate-changed.mjs
@@ -13,8 +13,12 @@
  *   node scripts/mutate-changed.mjs main --concurrency 2
  *   node scripts/mutate-changed.mjs --concurrency 2
  *
- * Mutation runs with `--incremental false` so a scoped run never overwrites the
- * shared incremental cache that the full `pnpm mutation` run relies on.
+ * Mutation writes its incremental state to a scoped, gitignored file so a
+ * scoped run never overwrites the shared incremental cache the full
+ * `pnpm mutation` run relies on. Stryker's CLI has no flag to disable
+ * incremental mode (only `--incremental` to enable it, which the config already
+ * does), so redirecting `--incrementalFile` is how the scoped run stays
+ * isolated.
  *
  * CI keeps using `pnpm run mutation` with its own per-shard `--mutate`; this
  * script is a developer convenience and is intentionally separate.
@@ -71,7 +75,12 @@ for (const file of changed) console.log(`  ${file}`)
 
 const result = spawnSync(
   "npx",
-  ["stryker", "run", "--mutate", changed.join(","), "--incremental", "false", ...strykerArgs],
+  [
+    "stryker", "run",
+    "--mutate", changed.join(","),
+    "--incrementalFile", "reports/stryker-incremental.changed.json",
+    ...strykerArgs,
+  ],
   { stdio: "inherit", env: { ...process.env, STRYKER_RUN: "1" } },
 )
 process.exit(result.status ?? 1)

--- a/src/nbsp.ts
+++ b/src/nbsp.ts
@@ -1,4 +1,4 @@
-import { cachedRegExp, LATIN_LETTER_RE, LATIN_LETTERS, NBSP_CHARS, SPACE_CHAR_RE, SPACE_CHARS, UNICODE_SYMBOLS } from "./constants.js"
+import { cachedRegExp, LATIN_LETTER_RE, LATIN_LETTERS, LATIN_OR_DIGIT_RE, NBSP_CHARS, SPACE_CHAR_RE, SPACE_CHARS, UNICODE_SYMBOLS } from "./constants.js"
 import { boundaryCountAt, exceedsSingleBoundary, interiorBoundariesWithin, makeProsePass, overInput, type ProseView, replaceAllInView } from "./prose-view.js"
 
 const {
@@ -342,6 +342,7 @@ function nbspBeforeContext(
   contextPattern: string,
   flags: string,
   thingGroup: string,
+  requireWordStart = false,
 ): void {
   const pattern = cachedRegExp(
     `(?<${thingGroup}>${thingPattern})${SPACE}(?=${contextPattern})`,
@@ -354,6 +355,21 @@ function nbspBeforeContext(
     while ((match = pattern.exec(clean)) !== null) {
       const start = match.index
       const end = start + match[0].length
+      // Word-start guard for the letter-based rules (initials, honorifics,
+      // reference abbreviations): the literal must begin at a word edge, or it
+      // is a word-final substring — "A." inside "NASA.", "p." inside "help." —
+      // and gluing it strands a spurious NBSP across a sentence boundary. A node
+      // boundary at `start` is itself a word edge (the literal is node-initial
+      // there), so only a word char directly before it in the same node blocks.
+      if (
+        requireWordStart &&
+        start > 0 &&
+        !view.hasBoundary(start) &&
+        LATIN_OR_DIGIT_RE.test(clean[start - 1])
+      ) {
+        pattern.lastIndex = start + 1
+        continue
+      }
       // Slot between the `thing` literal and the space (offset = end - 1);
       // lookahead slot at the match end. Each tolerates one boundary; the
       // literal itself must be boundary-free.
@@ -374,7 +390,7 @@ function nbspBeforeContext(
 }
 
 function nbspAfterReferenceAbbreviationsOverView(view: ProseView): void {
-  nbspBeforeContext(view, ABBREVIATION_PATTERN, "\\d", "g", "abbrev")
+  nbspBeforeContext(view, ABBREVIATION_PATTERN, "\\d", "g", "abbrev", true)
 }
 
 function nbspAfterSectionSymbolsOverView(view: ProseView): void {
@@ -382,7 +398,7 @@ function nbspAfterSectionSymbolsOverView(view: ProseView): void {
 }
 
 function nbspAfterHonorificsOverView(view: ProseView): void {
-  nbspBeforeContext(view, HONORIFIC_PATTERN, UNICODE_UPPERCASE, "gu", "honorific")
+  nbspBeforeContext(view, HONORIFIC_PATTERN, UNICODE_UPPERCASE, "gu", "honorific", true)
 }
 
 function nbspAfterCopyrightSymbolsOverView(view: ProseView): void {
@@ -390,7 +406,7 @@ function nbspAfterCopyrightSymbolsOverView(view: ProseView): void {
 }
 
 function nbspBetweenInitialsOverView(view: ProseView): void {
-  nbspBeforeContext(view, `${UNICODE_UPPERCASE}\\.`, UNICODE_UPPERCASE, "gu", "initial")
+  nbspBeforeContext(view, `${UNICODE_UPPERCASE}\\.`, UNICODE_UPPERCASE, "gu", "initial", true)
 }
 
 export const nbspAfterReferenceAbbreviations = makeProsePass(nbspAfterReferenceAbbreviationsOverView)

--- a/src/nbsp.ts
+++ b/src/nbsp.ts
@@ -1,4 +1,4 @@
-import { cachedRegExp, LATIN_LETTER_RE, LATIN_LETTERS, LATIN_OR_DIGIT_RE, NBSP_CHARS, SPACE_CHAR_RE, SPACE_CHARS, UNICODE_SYMBOLS } from "./constants.js"
+import { cachedRegExp, LATIN_LETTER_RE, LATIN_LETTERS, NBSP_CHARS, SPACE_CHAR_RE, SPACE_CHARS, UNICODE_SYMBOLS } from "./constants.js"
 import { boundaryCountAt, exceedsSingleBoundary, interiorBoundariesWithin, makeProsePass, overInput, type ProseView, replaceAllInView } from "./prose-view.js"
 
 const {
@@ -15,6 +15,12 @@ const {
 const SPACE = `[${SPACE_CHARS}]`
 
 const UNICODE_UPPERCASE = "\\p{Lu}"
+
+// A word-forming character (any Unicode letter or number). Used for the
+// abbreviation-family word-start guard, which must span the same alphabets the
+// initial/honorific rules glue on (they key off `\p{Lu}`), so a non-Latin
+// acronym like "СССР." is guarded exactly as "NASA." is.
+const WORD_CHAR_RE = /[\p{L}\p{N}]/u
 
 /** Only specific abbreviations are matched to avoid false positives. */
 export const UNITS: readonly string[] = [
@@ -365,7 +371,7 @@ function nbspBeforeContext(
         requireWordStart &&
         start > 0 &&
         !view.hasBoundary(start) &&
-        LATIN_OR_DIGIT_RE.test(clean[start - 1])
+        WORD_CHAR_RE.test(clean[start - 1])
       ) {
         pattern.lastIndex = start + 1
         continue

--- a/src/tests/nbsp.test.ts
+++ b/src/tests/nbsp.test.ts
@@ -154,6 +154,12 @@ describe("nbspAfterReferenceAbbreviations", () => {
   it.each([
     ...REFERENCE_ABBREVIATIONS.map((abbr, i) => [`${abbr}. ${i + 1}`, `${abbr}.${NBSP}${i + 1}`]),
     ["Fig. caption", "Fig. caption"],
+    // A word ending in an abbreviation ("p"/"pp") is not that abbreviation:
+    // the literal must start at a word edge, or it glues mid-sentence.
+    ["help. 5", "help. 5"],
+    ["top. 5", "top. 5"],
+    ["app. 5", "app. 5"],
+    ["group. 5", "group. 5"],
   ] as [string, string][])('"%s" → "%s"', (input, expected) => {
     expect(nbspAfterReferenceAbbreviations(input)).toBe(expected)
   })
@@ -240,6 +246,10 @@ describe("nbspBetweenInitials", () => {
     ["J. Smith", `J.${NBSP}Smith`],
     ["É. Piaf", `É.${NBSP}Piaf`],
     ["A. test", "A. test"],
+    // A capital ending an acronym is not an initial: "NASA." must not glue its
+    // final "A." to the next sentence's opening word.
+    ["from NASA. Or maybe", "from NASA. Or maybe"],
+    ["the USA. Its people", "the USA. Its people"],
   ])('"%s" → "%s"', (input, expected) => {
     expect(nbspBetweenInitials(input)).toBe(expected)
   })

--- a/src/tests/nbsp.test.ts
+++ b/src/tests/nbsp.test.ts
@@ -247,9 +247,12 @@ describe("nbspBetweenInitials", () => {
     ["É. Piaf", `É.${NBSP}Piaf`],
     ["A. test", "A. test"],
     // A capital ending an acronym is not an initial: "NASA." must not glue its
-    // final "A." to the next sentence's opening word.
+    // final "A." to the next sentence's opening word. The guard spans the same
+    // alphabets the rule matches (`\p{Lu}`), so non-Latin acronyms are covered.
     ["from NASA. Or maybe", "from NASA. Or maybe"],
     ["the USA. Its people", "the USA. Its people"],
+    ["СССР. Это", "СССР. Это"],
+    ["Π. Δ. Καλός", `Π.${NBSP}Δ.${NBSP}Καλός`],
   ])('"%s" → "%s"', (input, expected) => {
     expect(nbspBetweenInitials(input)).toBe(expected)
   })


### PR DESCRIPTION
## Summary

An adversarial audit of the whole repo (every `src/` module, docs, deps, CI, and dev scripts) turned up three clearly-scoped, verified fixes worth landing now. Several other findings were verified but deliberately **not** changed because they are intentional, tested design decisions or too risky to touch unattended — those are documented at the bottom so nothing is lost.

The suite stays at **100% branch/line/function/statement coverage** (2570 tests, +8 new), lint clean, `test:scripts` green, fixed cases idempotent through the full pipeline, and `mutate-changed` reports **87%** mutation score on the changed `nbsp.ts` (above the repo's 80 "high" threshold).

## 1. Bug fix: spurious NBSP inside words / across sentence boundaries

The `nbspAfterHonorifics`, `nbspAfterReferenceAbbreviations`, and `nbspBetweenInitials` rules matched their literal **anywhere** in the concatenated text, including as a word-final substring ( ` ` = injected non-breaking space):

| Input | Before | After |
| :--- | :--- | :--- |
| `from NASA. Or maybe` | `NASA. Or` (glued across a sentence!) | `NASA. Or` |
| `help. 5` | `help. 5` (`"p."` matched inside `help`) | `help. 5` |
| `top. 5`, `app. 5`, `group. 5` | glued | unchanged |
| `СССР. Это` (Cyrillic) | glued | unchanged |

This injects an invisible `U+00A0` mid-sentence and suppresses a legitimate line break — corrupting the plain-text bytes for downstream consumers.

### Fix

Gate the three letter-based rules on a **word-start check evaluated inside the scan loop**, where node boundaries are visible (a regex lookbehind can't be — the view's `text` is the flattened node concatenation). The matched literal must begin at the start of the text, after a non-word character, or at a node boundary (where it is node-initial — e.g. `Ca⟨boundary⟩p. 1` still glues). The guard matches any Unicode letter/number (`\p{L}`/`\p{N}`) so it spans the same alphabets the initial/honorific rules key off (`\p{Lu}`). Section/copyright symbols aren't word-forming, so they keep no guard.

All legitimate cases are preserved: `J. R. Tolkien`, `Dr. Smith`, `p. 5`, `Fig. 1`, `É. Piaf`, `No. 5`, Greek `Π. Δ. Καλός`, and the boundary-split re-anchor case. New parametrized regression tests cover the false positives and the good cases.

## 2. Bug fix: `mutate-changed.mjs` never ran

`node scripts/mutate-changed.mjs` died with `Invalid config file "false"` on every invocation: it passed `--incremental false`, but Stryker 9's CLI has no way to disable incremental mode (`--incremental` is a bare boolean; the trailing `false` was parsed as a positional config-file path). Redirect `--incrementalFile` to a scoped, gitignored path instead — preserving the original intent (don't clobber the shared incremental cache) while actually running.

## 3. Docs

- **Prettier plugin scope:** the plugin only overrides Prettier's `markdown` parser, so it never sees `.mdx` (Prettier routes those to the separate `mdx` parser). Dropped the false `*.mdx` claim; it handles the files Prettier maps to the markdown parser (`*.md`, `*.markdown`), matching the CLI's extension set.
- **`skipClasses` default:** the rehype options block was framed as defaults, but `skipClasses` defaults to `[]`, not `["no-formatting"]`. Clarified that `no-formatting` is an opt-in you pass yourself.

## Audit findings intentionally left out (with rationale)

- **CLI: one bad file aborts a batch / errors propagate.** Real, but **deliberate**: there is a test named *"propagates unexpected errors instead of swallowing them"* asserting ENOENT rejects, and CLAUDE.md's philosophy is *"prefer throwing errors that fail loudly."* Swallowing per-file errors would override a tested design decision.
- **Quote classifier: `'She said, "hello"'` → the inner closing `"` stays straight and the leading `'` flips to an apostrophe.** Verified HIGH-severity bug on a nested `"'` sequence. Left untouched: the fix is entangled with the documented *"leading apostrophe vs. opening quote"* ambiguity (README known-limitations) and the delicate singles↔doubles fixpoint ordering. Deserves a dedicated, carefully-reviewed change rather than an unattended edit to the library's most sensitive component.
- **`dashStyle` blocks all `NNN-NNNN` ranges** (`500-1000` stays a hyphen) — an intentional phone-number heuristic; disambiguating needs semantics (matches the stated known-limitations philosophy).
- **`degrees` converts bare `digit+C/F`** (`grade 5C` → `5 °C`) — already documented as aggressive and opt-in (`default: false`).
- **French guillemets via `niceQuotes` alone can double-space** — masked by `collapseSpaces` in the full `transform()` pipeline; low impact.
- **Deps / migration guide / CONTRIBUTING / SECURITY:** audited clean — all runtime deps used, none unused/risky, migration guide matches source, `recheck` confirms no ReDoS.

## Test plan

- `npm test` → 2570 passed, 100% coverage
- `npm run lint` → clean
- `npm run test:scripts` → pass
- `node scripts/mutate-changed.mjs main` → runs; 87% mutation score on `nbsp.ts`
- Manual idempotency spot-checks on the fixed nbsp cases through `transform()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LW93KreJkmy37hbDFACjJj