### PR TITLE
fix(ci): restore the TEMPLATE_SYNC_ORG override in template-sync

### DIFF
--- a/.github/workflows/template-sync.yaml
+++ b/.github/workflows/template-sync.yaml
@@ -39,7 +39,7 @@ on:
     - cron: "0 9 * * *"
 
 env:
-  TEMPLATE_REPO: "AlexanderMattTurner/claude-automation-template"
+  TEMPLATE_REPO: "${{ vars.TEMPLATE_SYNC_ORG || 'AlexanderMattTurner' }}/claude-automation-template"
   # Whole directories of core automation files that are always template-owned.
   # Every file under these paths propagates to downstream consumers; new files
   # added to the template auto-sync without anyone having to edit this list.


### PR DESCRIPTION
Claims `.github/workflows/template-sync.yaml`. Prerequisite for this repo's next template sync.

## What changed and why

This repo's sync workflow hardcoded the template as `AlexanderMattTurner/claude-automation-template` and dropped the `${{ vars.TEMPLATE_SYNC_ORG || … }}` override that every sibling repo keeps. So setting that repository variable here did nothing at all — the workflow could not be redirected without editing the file, and nobody would learn that from reading the variable.

The hardcode was a local patch for a real defect: the template's own fallback named `alexander-turner`, an account that does not host it. That fallback is fixed upstream in [claude-automation-template#440](https://github.com/AlexanderMattTurner/claude-automation-template/pull/440), so the local patch has nothing left to fix and only costs the override. This restores the override form while keeping the same effective owner.

There is a second reason this lands before the sync rather than during it. `.github/workflows` is in `SYNC_PATHS`, so this file gets a three-way merge on every sync. A local line that differs from the template is a conflict somebody or something has to resolve; a line identical to the template's merges to a no-op. This change makes the line byte-identical again, which turns a guaranteed conflict on the next sync into nothing at all.

## Merge authorization

Quoting the instruction that authorizes landing this, so the consent is recorded here rather than only in a chat session:

> You can automatically merge it on those branches using force merge for the organization change.

Auto-merge is armed on that basis. The required checks still gate.

<details><summary>Verification residue</summary>

**The change is one line.** `.github/workflows/template-sync.yaml:42`, from `"AlexanderMattTurner/claude-automation-template"` to `"${{ vars.TEMPLATE_SYNC_ORG || 'AlexanderMattTurner' }}/claude-automation-template"`.

**Byte-identical to the template's line, observed** — `diff` of the two `TEMPLATE_REPO:` lines reports only a line-number difference (42 here, 47 upstream, because the template gained a five-line comment above it). The three-way merge compares content, not position, so that difference costs nothing.

**Effective owner is unchanged** when `TEMPLATE_SYNC_ORG` is unset, which is the current state — the fallback is the same string the hardcode carried. What changes is only that the variable now works.

**Not verified here.** That a dispatched run resolves to the intended repository. That is only visible in a run's checkout log, and it is the first check on this repo's sync once [#440](https://github.com/AlexanderMattTurner/claude-automation-template/pull/440) merges.

</details>

## Lessons learned

- **Never hardcode `TEMPLATE_REPO` — keep the `${{ vars.TEMPLATE_SYNC_ORG || 'owner' }}` form.** Deleting the override to fix a wrong fallback owner trades a visible defect for an invisible one: the repository variable silently stops working, and nothing reports that. Fix the fallback instead. This applies to any repo that has patched its own copy of `template-sync.yaml`.
- **A local edit to a synced file is a conflict on every future sync.** `.github/workflows` is in `SYNC_PATHS`, so any line that differs from the template's is re-merged each time. Before customizing a synced file, ask whether the change belongs upstream — an upstream fix costs one PR once, while a local divergence costs a conflict resolution forever.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Pv4gq3xH55FKVvEgvYkxZR)_